### PR TITLE
[FIX] Fix wrong field name in bank statement lines - #368

### DIFF
--- a/altinkaya_account/__manifest__.py
+++ b/altinkaya_account/__manifest__.py
@@ -28,5 +28,6 @@
         "views/account_invoice_report_view.xml",
         "views/account_payment_term_view.xml",
         "views/res_currency_rate_view.xml",
+        "views/account_bank_statement_line_view.xml",
     ],
 }

--- a/altinkaya_account/views/account_bank_statement_line_view.xml
+++ b/altinkaya_account/views/account_bank_statement_line_view.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="account_bank_statement_line_tree" model="ir.ui.view">
+            <field name="name">account.bank.statement.line.tree</field>
+            <field name="model">account.bank.statement.line</field>
+            <field name="arch" type="xml">
+                <tree string="Statement lines" create="false" default_order="date desc, statement_id desc, sequence desc, id desc">
+                    <field name="sequence" readonly="1" invisible="1"/>
+                    <field name="statement_id"/>
+                    <field name="journal_id" invisible="1"/>
+                    <field name="date"/>
+                    <field name="name"/>
+                    <field name="ref"/>
+                    <field name="partner_id"/>
+                    <field name="amount"/>
+                    <field name="currency_id" invisible="1"/>
+                    <field name="state" invisible="1"></field>
+                </tree>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
IMPORTANT: Delete following views from database:
- account.bank.statement.line.tree2

Related Issue: https://github.com/altinkaya-opensource/odoo/issues/368