### PR TITLE
[JPL] moved percentage calculation to SQL, added group permission

### DIFF
--- a/altinkaya_reports/models/account_move_line.py
+++ b/altinkaya_reports/models/account_move_line.py
@@ -33,11 +33,6 @@ class AccountMoveLine(models.Model):
         store=True,
         help="Expected unit price according to pricelist, in USD.",
     )
-    manual_discount_percentage = fields.Float(
-        compute="_compute_pricelist_comparison",
-        store=True,
-        help="Difference between actual price and pricelist price in percentage.",
-    )
 
     @api.depends(
         "move_id.invoice_date",
@@ -86,12 +81,9 @@ class AccountMoveLine(models.Model):
         "move_id.partner_id",
         "move_id.invoice_date",
         "move_id.move_type",
-        "move_id.currency_id",
         "product_id",
         "product_uom_id",
         "quantity",
-        "price_unit",
-        "discount",
         "display_type",
     )
     def _compute_pricelist_comparison(self):
@@ -99,7 +91,6 @@ class AccountMoveLine(models.Model):
 
         for line in self:
             line.origin_price_usd = 0.0
-            line.manual_discount_percentage = 0.0
 
             # Only out.invoice and product lines
             if (
@@ -132,21 +123,3 @@ class AccountMoveLine(models.Model):
                 origin_price_usd = pricelist_price
 
             line.origin_price_usd = origin_price_usd
-
-            # Calculate the actual price
-            actual_price = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
-
-            # Convert actual price to USD
-            invoice_currency = line.move_id.currency_id
-            if invoice_currency and invoice_currency != currency_usd:
-                actual_price_usd = invoice_currency._convert(
-                    actual_price, currency_usd, company, date, round=False
-                )
-            else:
-                actual_price_usd = actual_price
-
-            # Calculate manual discount percentage
-            if origin_price_usd:
-                line.manual_discount_percentage = (
-                    (origin_price_usd - actual_price_usd) / origin_price_usd * 100.0
-                )

--- a/altinkaya_reports/report/account_invoice_report.py
+++ b/altinkaya_reports/report/account_invoice_report.py
@@ -100,7 +100,11 @@ class AccountInvoiceReport(models.Model):
         "res.partner.industry", string="Industry", readonly=True
     )
     # Fields from account.move.line
-    origin_price_usd = fields.Float(string="Pricelist Price USD", readonly=True)
+    origin_price_usd = fields.Float(
+        string="Pricelist Price USD",
+        readonly=True,
+        groups="account.group_account_manager",
+    )
     manual_discount_percentage = fields.Float(readonly=True, group_operator="avg")
 
     def _select(self):
@@ -147,8 +151,16 @@ class AccountInvoiceReport(models.Model):
                line.insert_installation_price as insert_installation_price,
                inv_count_sub.invoice_count,
                partner.industry_id as industry_id,
-               line.origin_price_usd as origin_price_usd,
-               line.manual_discount_percentage as manual_discount_percentage
+               line.origin_price_usd * line.quantity as origin_price_usd,
+               CASE
+                   WHEN line.origin_price_usd > 0 THEN
+                       (line.origin_price_usd
+                        - line.price_unit
+                        * (1 - COALESCE(line.discount, 0) / 100.0)
+                        * move.usd_rate)
+                       / line.origin_price_usd * 100.0
+                   ELSE 0
+               END as manual_discount_percentage
 
             """
         )


### PR DESCRIPTION
Before updating you module, make sure to create the columns for the computed field. In PostgreSQL, execute:

ALTER TABLE public.account_move_line
ADD COLUMN IF NOT EXISTS origin_price_usd DOUBLE PRECISION DEFAULT 0; 

After that, update the module.

To test the compute, you can use this:

 env['account.move.line'].search([("move_id.pricelist_id", "!=", False), ("product_id", "!=", False), ("move_id.move_type", "=", "out_invoice"), ("move_id.state", "=", "posted"), ("date", ">=", "2026-01-01"), ("display_type", "=", "product")])._compute_pricelist_comparison()

Do not forget to commit it after:

env.cr.commit()