### PR TITLE
[#TKL] added minimum order quantity field for products

### DIFF
--- a/product_qty_increment_step/__manifest__.py
+++ b/product_qty_increment_step/__manifest__.py
@@ -9,12 +9,13 @@
     "license": "AGPL-3",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "category": "Extensions",
-    "depends": ["website_sale", "altinkaya_ecommerce"],
+    "depends": ["website_sale", "sale_product_configurator", "altinkaya_ecommerce"],
     "data": [
         "views/product_template_view.xml",
         "views/product_product_view.xml",
         "templates/cart_lines.xml",
         "templates/product_quantity.xml",
+        "templates/product_configurator_quantity.xml",
     ],
     "assets": {
         "web.assets_frontend": [

--- a/product_qty_increment_step/__manifest__.py
+++ b/product_qty_increment_step/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["website_sale", "altinkaya_ecommerce"],
     "data": [
         "views/product_template_view.xml",
+        "views/product_product_view.xml",
         "templates/cart_lines.xml",
         "templates/product_quantity.xml",
     ],

--- a/product_qty_increment_step/i18n/ar_AA.po
+++ b/product_qty_increment_step/i18n/ar_AA.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "الحد الأدنى لكمية الطلب"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"الحد الأدنى لكمية الطلب لهذا المنتج في المتجر الإلكتروني. عيّن 0 لتعطيل "
+"هذه الميزة."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "المنتج"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"المنتج \"%(product)s\" لديه حد أدنى لكمية الطلب %(min_qty)s.\n"
+"الكمية %(quantity)s التي أدخلتها أقل من الحد الأدنى."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/bg.po
+++ b/product_qty_increment_step/i18n/bg.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Мин. количество за поръчка"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Минимално количество за поръчка на този продукт в онлайн магазина. Задайте "
+"0, за да деактивирате тази функция."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Продукт"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Продуктът \"%(product)s\" има минимално количество за поръчка %(min_qty)s.\n"
+"Вашето количество %(quantity)s е под минимума."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/de.po
+++ b/product_qty_increment_step/i18n/de.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Mindestbestellmenge"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Mindestbestellmenge für dieses Produkt im Webshop. Setzen Sie 0, um diese "
+"Funktion zu deaktivieren."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Produkt"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Produkt \"%(product)s\" hat eine Mindestbestellmenge von %(min_qty)s.\n"
+"Ihre Menge %(quantity)s liegt unter dem Minimum."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/el_GR.po
+++ b/product_qty_increment_step/i18n/el_GR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Ελάχ. ποσότητα παραγγελίας"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Ελάχιστη ποσότητα παραγγελίας για αυτό το προϊόν στο ηλεκτρονικό "
+"κατάστημα. Ορίστε 0 για να απενεργοποιήσετε αυτή τη λειτουργία."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Προϊόν"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Το προϊόν \"%(product)s\" έχει ελάχιστη ποσότητα παραγγελίας %(min_qty)s.\n"
+"Η ποσότητα %(quantity)s που εισαγάγατε είναι κάτω από το ελάχιστο."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/en_US.po
+++ b/product_qty_increment_step/i18n/en_US.po
@@ -6,14 +6,30 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Min Order Qty"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
 
 #. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
@@ -25,13 +41,21 @@ msgstr ""
 #: code:addons/product_qty_increment_step/models/sale_order_line.py:0
 #, python-format
 msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
 "Product \"%(product)s\" must be ordered in multiples of %(step)s.\n"
 "Your quantity %(quantity)s is not valid.\n"
 "Valid quantities: %(step)s, %(double)s, %(triple)s, etc."
 msgstr ""
-"Product \"%(product)s\" must be ordered in multiples of %(step)s.\n"
-"Your quantity %(quantity)s is not valid.\n"
-"Valid quantities: %(step)s, %(double)s, %(triple)s, etc."
 
 #. module: product_qty_increment_step
 #: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__qty_increment_step

--- a/product_qty_increment_step/i18n/es.po
+++ b/product_qty_increment_step/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Cantidad mín. de pedido"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Cantidad mínima de pedido para este producto en la tienda en línea. "
+"Establezca 0 para desactivar esta función."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Producto"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"El producto \"%(product)s\" tiene una cantidad mínima de pedido de %(min_qty)s.\n"
+"La cantidad %(quantity)s ingresada está por debajo del mínimo."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/fr.po
+++ b/product_qty_increment_step/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Qté min. de commande"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Quantité minimum de commande pour ce produit dans la boutique en ligne. "
+"Définissez 0 pour désactiver cette fonctionnalité."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Produit"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Le produit \"%(product)s\" a une quantité minimum de commande de %(min_qty)s.\n"
+"Votre quantité %(quantity)s est inférieure au minimum."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/hu.po
+++ b/product_qty_increment_step/i18n/hu.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Min rendelési mennyiség"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"A termék minimális rendelési mennyisége a webáruházban. A funkció "
+"letiltásához állítsa be a 0 értéket."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Termék"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"A \"%(product)s\" termék minimális rendelési mennyisége %(min_qty)s.\n"
+"A megadott %(quantity)s mennyiség a minimum alatt van."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/it.po
+++ b/product_qty_increment_step/i18n/it.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Qtà min. ordine"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Quantità minima di ordine per questo prodotto nel negozio online. Impostare "
+"0 per disabilitare questa funzione."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Prodotto"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Il prodotto \"%(product)s\" ha una quantità minima di ordine di %(min_qty)s.\n"
+"La quantità %(quantity)s inserita è inferiore al minimo."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/ja_JP.po
+++ b/product_qty_increment_step/i18n/ja_JP.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "最小注文数量"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"ウェブショップでのこの製品の最小注文数量。この機能を無効にするには0を設定し"
+"ます。"
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "製品"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"製品「%(product)s」の最小注文数量は %(min_qty)s です。\n"
+"入力された数量 %(quantity)s は最小値を下回っています。"
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/nl.po
+++ b/product_qty_increment_step/i18n/nl.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Min bestelhoeveelheid"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Minimale bestelhoeveelheid voor dit product in de webshop. Stel 0 in om "
+"deze functie uit te schakelen."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr ""
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Product \"%(product)s\" heeft een minimale bestelhoeveelheid van %(min_qty)s.\n"
+"Uw hoeveelheid %(quantity)s is lager dan het minimum."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/pl.po
+++ b/product_qty_increment_step/i18n/pl.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Min ilość zamówienia"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Minimalna ilość zamówienia dla tego produktu w sklepie internetowym. Ustaw "
+"0, aby wyłączyć tę funkcję."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Produkt"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Produkt \"%(product)s\" ma minimalną ilość zamówienia %(min_qty)s.\n"
+"Wprowadzona ilość %(quantity)s jest poniżej minimum."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/product_qty_increment_step.pot
+++ b/product_qty_increment_step/i18n/product_qty_increment_step.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,8 +16,31 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr ""
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
+msgstr ""
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
 msgstr ""
 
 #. module: product_qty_increment_step

--- a/product_qty_increment_step/i18n/pt.po
+++ b/product_qty_increment_step/i18n/pt.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Qtd mín. de encomenda"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Quantidade mínima de encomenda para este produto na loja online. Defina 0 "
+"para desativar esta funcionalidade."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Produtos"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"O produto \"%(product)s\" tem uma quantidade mínima de encomenda de %(min_qty)s.\n"
+"A quantidade %(quantity)s introduzida está abaixo do mínimo."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/ru.po
+++ b/product_qty_increment_step/i18n/ru.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Мин. кол-во заказа"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Минимальное количество заказа для этого товара в интернет-магазине. "
+"Установите 0, чтобы отключить эту функцию."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Продукт"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"Товар \"%(product)s\" имеет минимальное количество заказа %(min_qty)s.\n"
+"Ваше количество %(quantity)s ниже минимума."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/tr.po
+++ b/product_qty_increment_step/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "Min Sipariş Miktarı"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"Bu ürün için web mağazasındaki minimum sipariş miktarı. Bu özelliği devre "
+"dışı bırakmak için 0 olarak ayarlayın."
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "Ürün"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"\"%(product)s\" ürününün minimum sipariş miktarı %(min_qty)s'dir.\n"
+"Girdiğiniz %(quantity)s miktarı minimumun altındadır."
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/i18n/zh_HK.po
+++ b/product_qty_increment_step/i18n/zh_HK.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-30 11:01+0000\n"
-"PO-Revision-Date: 2025-10-30 11:01+0000\n"
+"POT-Creation-Date: 2026-02-23 13:32+0000\n"
+"PO-Revision-Date: 2026-02-23 13:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,35 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: product_qty_increment_step
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,field_description:product_qty_increment_step.field_product_template__min_order_qty
+msgid "Min Order Qty"
+msgstr "最低訂購數量"
+
+#. module: product_qty_increment_step
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_product__min_order_qty
+#: model:ir.model.fields,help:product_qty_increment_step.field_product_template__min_order_qty
+msgid ""
+"Minimum order quantity for this product in the webshop. Set 0 to disable "
+"this feature."
+msgstr ""
+"此產品在網上商店的最低訂購數量。設置 0 則禁用此功能。"
+
+#. module: product_qty_increment_step
 #: model:ir.model,name:product_qty_increment_step.model_product_template
 msgid "Product"
 msgstr "产品"
+
+#. module: product_qty_increment_step
+#. odoo-python
+#: code:addons/product_qty_increment_step/models/sale_order_line.py:0
+#, python-format
+msgid ""
+"Product \"%(product)s\" has a minimum order quantity of %(min_qty)s.\n"
+"Your quantity %(quantity)s is below the minimum."
+msgstr ""
+"產品「%(product)s」的最低訂購數量為 %(min_qty)s。\n"
+"您輸入的數量 %(quantity)s 低於最低要求。"
 
 #. module: product_qty_increment_step
 #. odoo-python

--- a/product_qty_increment_step/models/__init__.py
+++ b/product_qty_increment_step/models/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2022 Yiğit Budak (https://github.com/yibudak)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from . import product_product
 from . import product_template
 from . import sale_order_line

--- a/product_qty_increment_step/models/product_product.py
+++ b/product_qty_increment_step/models/product_product.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Yiğit Budak (https://github.com/yibudak)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from odoo import fields, models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    min_order_qty = fields.Integer(
+        default=0,
+        help="Minimum order quantity for this product in the webshop."
+        " Set 0 to disable this feature.",
+    )

--- a/product_qty_increment_step/models/product_template.py
+++ b/product_qty_increment_step/models/product_template.py
@@ -11,3 +11,24 @@ class ProductTemplate(models.Model):
         help="Set a step for product quantity increment in the product page."
         " Set 0 to disable this feature.",
     )
+
+    def _get_combination_info(
+        self,
+        combination=False,
+        product_id=False,
+        add_qty=1,
+        pricelist=False,
+        parent_combination=False,
+        only_template=False,
+    ):
+        combination_info = super()._get_combination_info(
+            combination=combination,
+            product_id=product_id,
+            add_qty=add_qty,
+            pricelist=pricelist,
+            parent_combination=parent_combination,
+            only_template=only_template,
+        )
+        product = self.env["product.product"].browse(combination_info["product_id"])
+        combination_info["min_order_qty"] = product.min_order_qty if product else 0
+        return combination_info

--- a/product_qty_increment_step/models/product_template.py
+++ b/product_qty_increment_step/models/product_template.py
@@ -11,8 +11,3 @@ class ProductTemplate(models.Model):
         help="Set a step for product quantity increment in the product page."
         " Set 0 to disable this feature.",
     )
-    min_order_qty = fields.Integer(
-        default=0,
-        help="Minimum order quantity for this product in the webshop."
-        " Set 0 to disable this feature.",
-    )

--- a/product_qty_increment_step/models/product_template.py
+++ b/product_qty_increment_step/models/product_template.py
@@ -11,3 +11,8 @@ class ProductTemplate(models.Model):
         help="Set a step for product quantity increment in the product page."
         " Set 0 to disable this feature.",
     )
+    min_order_qty = fields.Integer(
+        default=0,
+        help="Minimum order quantity for this product in the webshop."
+        " Set 0 to disable this feature.",
+    )

--- a/product_qty_increment_step/models/sale_order_line.py
+++ b/product_qty_increment_step/models/sale_order_line.py
@@ -26,6 +26,22 @@ class SaleOrderLine(models.Model):
             if not line.product_id:
                 continue
 
+            # Check minimum order quantity
+            min_qty = line.product_id.product_tmpl_id.min_order_qty
+            if min_qty and min_qty > 0 and line.product_uom_qty < min_qty:
+                raise ValidationError(
+                    _(
+                        'Product "%(product)s" has a minimum order'
+                        " quantity of %(min_qty)s.\n"
+                        "Your quantity %(quantity)s is below the minimum."
+                    )
+                    % {
+                        "product": line.product_id.display_name,
+                        "min_qty": int(min_qty),
+                        "quantity": int(line.product_uom_qty),
+                    }
+                )
+
             # Get the increment step from the product template
             step = line.product_id.product_tmpl_id.qty_increment_step
 

--- a/product_qty_increment_step/models/sale_order_line.py
+++ b/product_qty_increment_step/models/sale_order_line.py
@@ -27,7 +27,7 @@ class SaleOrderLine(models.Model):
                 continue
 
             # Check minimum order quantity
-            min_qty = line.product_id.product_tmpl_id.min_order_qty
+            min_qty = line.product_id.min_order_qty
             if min_qty and min_qty > 0 and line.product_uom_qty < min_qty:
                 raise ValidationError(
                     _(

--- a/product_qty_increment_step/static/src/js/qty_increment_step.js
+++ b/product_qty_increment_step/static/src/js/qty_increment_step.js
@@ -79,14 +79,21 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
             if (!$span.length) {
                 return;
             }
+            // Only reset qty when the variant (product_id) actually changed
+            var variantChanged = combination.product_id !== $span.data("last-product-id");
+            $span.data("last-product-id", combination.product_id);
             $span.data("min-order-qty", minOrderQty);
             $span.attr("data-min-order-qty", minOrderQty);
             var $input = $span.closest('.input-group').find("input[name='add_qty']");
             if ($input.length) {
                 var step = $span.data("increment-step") || 1;
                 var minQty = minOrderQty > 0 ? Math.max(minOrderQty, step) : step;
-                // Always reset to new minimum on variant change
-                $input.val(minQty);
+                var currentQty = parseInt($input.val(), 10) || 0;
+                if (variantChanged) {
+                    $input.val(minQty);
+                } else if (currentQty < minQty) {
+                    $input.val(minQty);
+                }
             }
         },
 

--- a/product_qty_increment_step/static/src/js/qty_increment_step.js
+++ b/product_qty_increment_step/static/src/js/qty_increment_step.js
@@ -15,13 +15,16 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
     VariantMixin.onClickAddCartJSON = function (ev) {
         ev.preventDefault();
         var $link = $(ev.currentTarget);
-        var $incrementSize = $link.closest('.input-group').find("span[data-increment-step]").data("increment-step");
+        var $span = $link.closest('.input-group').find("span[data-increment-step]");
+        var $incrementSize = $span.data("increment-step");
+        var minOrderQty = $span.data("min-order-qty") || 0;
         var $input = $link.closest('.input-group').find("input");
 
         var max = parseFloat($input.data("max") || Infinity);
         var previousQty = parseFloat($input.val() || 0, 10);
         var quantity = ($link.has(".fa-minus").length ? -$incrementSize : $incrementSize) + previousQty;
-        var newQty = quantity > $incrementSize ? (quantity < max ? quantity : max) : $incrementSize;
+        var minQty = minOrderQty > 0 ? Math.max(minOrderQty, $incrementSize) : $incrementSize;
+        var newQty = quantity > minQty ? (quantity < max ? quantity : max) : minQty;
 
         if (newQty !== previousQty) {
             $input.val(newQty).trigger('change');
@@ -52,7 +55,10 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
             // Example: If the increment step is 50, the quantity will be 50, 100, 150, etc.
             // If the quantity is 75, it will be rounded to 100.
             const $input = $(ev.currentTarget);
-            const $incrementSize = $input.closest('.input-group').find("span[data-increment-step]").data("increment-step");
+            const $span = $input.closest('.input-group').find("span[data-increment-step]");
+            const $incrementSize = $span.data("increment-step");
+            const minOrderQty = $span.data("min-order-qty") || 0;
+            const minQty = minOrderQty > 0 ? Math.max(minOrderQty, $incrementSize) : $incrementSize;
             let qty = parseInt($input.val(), 10); // Parse input value to integer
 
             // If the quantity is zero, return false (this means the user has deleted the input value)
@@ -60,20 +66,24 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
                 return false;
             }
 
-            qty = isNaN(qty) ? $incrementSize : qty;
+            qty = isNaN(qty) ? minQty : qty;
 
-            // Ensure the minimum quantity is equal to the increment size, and it's not zero or negative
-            if (qty <= $incrementSize) {
-                qty = $incrementSize;
+            // Ensure the minimum quantity respects both min_order_qty and increment size
+            if (qty <= minQty) {
+                qty = minQty;
             }
 
             const remainder = qty % $incrementSize;
             if (remainder > 0) {
                 // Round to the nearest increment step value based on whether the value is increasing or decreasing
-                const prevQty = parseInt($input.data("prevQty"), 10) || $incrementSize;
+                const prevQty = parseInt($input.data("prevQty"), 10) || minQty;
                 if (qty < prevQty) {
                     // Decreasing, round down to the nearest increment step value
                     qty -= remainder;
+                    // Ensure we don't go below minimum after rounding down
+                    if (qty < minQty) {
+                        qty += $incrementSize;
+                    }
                 } else {
                     // Increasing, round up to the nearest increment step value
                     qty += $incrementSize - remainder;

--- a/product_qty_increment_step/static/src/js/qty_increment_step.js
+++ b/product_qty_increment_step/static/src/js/qty_increment_step.js
@@ -7,8 +7,51 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
     var publicWidget = require('web.public.widget');
     var VariantMixin = require('sale.VariantMixin');
     var ajax = require('web.ajax');
+    var { OptionalProductsModal } = require('@sale_product_configurator/js/product_configurator_modal');
     // Ensure WebsiteSale is loaded before we .include() it
     require('website_sale.website_sale');
+
+    /**
+     * Format the quantity input to align with increment step and min order qty.
+     * Shared between WebsiteSale and OptionalProductsModal.
+     */
+    function formatQtyWithStep(ev) {
+        var $input = $(ev.currentTarget || ev.target);
+        var $span = $input.closest('.input-group').find("span[data-increment-step]");
+        var incrementSize = $span.data("increment-step");
+        if (!incrementSize) {
+            return;
+        }
+        var minOrderQty = $span.data("min-order-qty") || 0;
+        var minQty = minOrderQty > 0 ? Math.max(minOrderQty, incrementSize) : incrementSize;
+        var qty = parseInt($input.val(), 10);
+
+        if (qty === 0) {
+            return;
+        }
+
+        qty = isNaN(qty) ? minQty : qty;
+
+        if (qty <= minQty) {
+            qty = minQty;
+        }
+
+        var remainder = qty % incrementSize;
+        if (remainder > 0) {
+            var prevQty = parseInt($input.data("prevQty"), 10) || minQty;
+            if (qty < prevQty) {
+                qty -= remainder;
+                if (qty < minQty) {
+                    qty += incrementSize;
+                }
+            } else {
+                qty += incrementSize - remainder;
+            }
+        }
+
+        $input.data("prevQty", qty);
+        $input.val(qty);
+    }
 
     /*
      * Override onClickAddCartJSON on VariantMixin so that any widget
@@ -19,14 +62,27 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
         ev.preventDefault();
         var $link = $(ev.currentTarget);
         var $span = $link.closest('.input-group').find("span[data-increment-step]");
-        var $incrementSize = $span.data("increment-step");
+        var incrementSize = $span.data("increment-step");
         var minOrderQty = $span.data("min-order-qty") || 0;
         var $input = $link.closest('.input-group').find("input");
 
+        if (!incrementSize) {
+            // Fallback to default +/- 1 behavior
+            var min = parseFloat($input.data("min") || 0);
+            var max = parseFloat($input.data("max") || Infinity);
+            var prev = parseFloat($input.val() || 0, 10);
+            var quantity = ($link.has(".fa-minus").length ? -1 : 1) + prev;
+            var newVal = quantity > min ? (quantity < max ? quantity : max) : min;
+            if (newVal !== prev) {
+                $input.val(newVal).trigger('change');
+            }
+            return false;
+        }
+
         var max = parseFloat($input.data("max") || Infinity);
         var previousQty = parseFloat($input.val() || 0, 10);
-        var quantity = ($link.has(".fa-minus").length ? -$incrementSize : $incrementSize) + previousQty;
-        var minQty = minOrderQty > 0 ? Math.max(minOrderQty, $incrementSize) : $incrementSize;
+        var quantity = ($link.has(".fa-minus").length ? -incrementSize : incrementSize) + previousQty;
+        var minQty = minOrderQty > 0 ? Math.max(minOrderQty, incrementSize) : incrementSize;
         var newQty = quantity > minQty ? (quantity < max ? quantity : max) : minQty;
 
         if (newQty !== previousQty) {
@@ -35,6 +91,9 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
         return false;
     };
 
+    // -------------------------------------------------------
+    // WebsiteSale (product detail page + cart)
+    // -------------------------------------------------------
     publicWidget.registry.WebsiteSale.include({
         onClickAddCartJSON: VariantMixin.onClickAddCartJSON,
 
@@ -103,53 +162,68 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
          */
         _onChangeAddQuantity: function (ev) {
             this._super.apply(this, arguments);
-            this._formatQtyWithStep(ev);
+            formatQtyWithStep(ev);
         },
 
-        /**
-         * Format the quantity with the increment step value.
-         */
-        _formatQtyWithStep: function (ev) {
-            var $input = $(ev.currentTarget);
-            var $span = $input.closest('.input-group').find("span[data-increment-step]");
-            var $incrementSize = $span.data("increment-step");
-            var minOrderQty = $span.data("min-order-qty") || 0;
-            var minQty = minOrderQty > 0 ? Math.max(minOrderQty, $incrementSize) : $incrementSize;
-            var qty = parseInt($input.val(), 10);
-
-            if (qty === 0) {
-                return false;
-            }
-
-            qty = isNaN(qty) ? minQty : qty;
-
-            if (qty <= minQty) {
-                qty = minQty;
-            }
-
-            var remainder = qty % $incrementSize;
-            if (remainder > 0) {
-                var prevQty = parseInt($input.data("prevQty"), 10) || minQty;
-                if (qty < prevQty) {
-                    qty -= remainder;
-                    if (qty < minQty) {
-                        qty += $incrementSize;
-                    }
-                } else {
-                    qty += $incrementSize - remainder;
-                }
-            }
-
-            $input.data("prevQty", qty);
-            $input.val(qty);
-        },
+        _formatQtyWithStep: formatQtyWithStep,
 
         /**
          * @override
          * Also format quantity with step on cart quantity change.
          */
         _onChangeCartQuantity: function (ev) {
-            this._formatQtyWithStep(ev);
+            formatQtyWithStep(ev);
+            this._super.apply(this, arguments);
+        },
+    });
+
+    // -------------------------------------------------------
+    // OptionalProductsModal (advanced configurator popup)
+    // -------------------------------------------------------
+    OptionalProductsModal.include({
+        onClickAddCartJSON: VariantMixin.onClickAddCartJSON,
+
+        /**
+         * @override
+         * Update min_order_qty data attributes when combination changes
+         * in the configurator modal.
+         */
+        _onChangeCombination: function (ev, $parent, combination) {
+            this._super.apply(this, arguments);
+            var minOrderQty = combination.min_order_qty || 0;
+            var $span = $parent.find('.input-group span[data-increment-step]');
+            if (!$span.length) {
+                return;
+            }
+            var variantChanged = combination.product_id !== $span.data("last-product-id");
+            $span.data("last-product-id", combination.product_id);
+            $span.data("min-order-qty", minOrderQty);
+            $span.attr("data-min-order-qty", minOrderQty);
+            var $input = $span.closest('.input-group').find("input[name='add_qty']");
+            if ($input.length) {
+                var step = $span.data("increment-step") || 1;
+                var minQty = minOrderQty > 0 ? Math.max(minOrderQty, step) : step;
+                var currentQty = parseInt($input.val(), 10) || 0;
+                if (variantChanged) {
+                    $input.val(minQty);
+                    if ($parent.hasClass('main_product')) {
+                        this.rootProduct.quantity = minQty;
+                    }
+                } else if (currentQty < minQty) {
+                    $input.val(minQty);
+                    if ($parent.hasClass('main_product')) {
+                        this.rootProduct.quantity = minQty;
+                    }
+                }
+            }
+        },
+
+        /**
+         * @override
+         * Format quantity with step before processing the change.
+         */
+        _onChangeQuantity: function (ev) {
+            formatQtyWithStep(ev);
             this._super.apply(this, arguments);
         },
     });

--- a/product_qty_increment_step/static/src/js/qty_increment_step.js
+++ b/product_qty_increment_step/static/src/js/qty_increment_step.js
@@ -6,11 +6,14 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
 
     var publicWidget = require('web.public.widget');
     var VariantMixin = require('sale.VariantMixin');
-    var WebsiteSale = require('website_sale.website_sale');
+    var ajax = require('web.ajax');
+    // Ensure WebsiteSale is loaded before we .include() it
+    require('website_sale.website_sale');
 
     /*
-        * We need to override this method to prevent the default behavior of
-        * the website_sale module.
+     * Override onClickAddCartJSON on VariantMixin so that any widget
+     * using it (including theme_prime's CartSidebar) gets step-aware
+     * +/- button behavior.
      */
     VariantMixin.onClickAddCartJSON = function (ev) {
         ev.preventDefault();
@@ -32,67 +35,116 @@ odoo.define('product_qty_increment_step.qty_step', function (require) {
         return false;
     };
 
-    publicWidget.registry.QtyIncrementStep = publicWidget.Widget.extend(VariantMixin, WebsiteSale, {
-        selector: '.oe_website_sale',
-        events: {
-            'change form .js_product:first input[name="add_qty"]': '_formatQtyWithStep',
-            'change table input.js_quantity.form-control.quantity': '_formatQtyWithStep',
+    publicWidget.registry.WebsiteSale.include({
+        onClickAddCartJSON: VariantMixin.onClickAddCartJSON,
+
+        /**
+         * @override
+         * After variant changes, fetch min_order_qty for the selected
+         * variant and update the qty input accordingly.
+         * We use our own RPC because the base _onChangeCombination callback
+         * is unreachable via include due to _throttledGetCombinationInfo's
+         * _.memoize + .bind closure capturing function references.
+         */
+        onChangeVariant: function (ev) {
+            var self = this;
+            this._super.apply(this, arguments);
+
+            var $parent = $(ev.target).closest('.js_product');
+            if (!$parent.length) {
+                return;
+            }
+
+            var combination = this.getSelectedVariantValues($parent);
+            var productTemplateId = parseInt($parent.find('.product_template_id').val());
+
+            ajax.jsonRpc(this._getUri('/sale/get_combination_info'), 'call', {
+                'product_template_id': productTemplateId,
+                'product_id': this._getProductId($parent),
+                'combination': combination,
+                'add_qty': parseInt($parent.find('input[name="add_qty"]').val()),
+                'pricelist_id': this.pricelistId || false,
+            }).then(function (data) {
+                self._updateMinOrderQty($parent, data);
+            });
         },
 
         /**
-         * @constructor
+         * Update min_order_qty data attribute and enforce minimum quantity
+         * on the qty input based on combination info response.
          */
-        init: function ($parent) {
+        _updateMinOrderQty: function ($parent, combination) {
+            var minOrderQty = combination.min_order_qty || 0;
+            var $span = $parent.find('.input-group span[data-increment-step]');
+            if (!$span.length) {
+                return;
+            }
+            $span.data("min-order-qty", minOrderQty);
+            $span.attr("data-min-order-qty", minOrderQty);
+            var $input = $span.closest('.input-group').find("input[name='add_qty']");
+            if ($input.length) {
+                var step = $span.data("increment-step") || 1;
+                var minQty = minOrderQty > 0 ? Math.max(minOrderQty, step) : step;
+                // Always reset to new minimum on variant change
+                $input.val(minQty);
+            }
+        },
+
+        /**
+         * @override
+         * After the default add quantity change handler, format with step.
+         */
+        _onChangeAddQuantity: function (ev) {
             this._super.apply(this, arguments);
+            this._formatQtyWithStep(ev);
         },
 
-        start() {
-            return this._super(...arguments);
-        },
-
+        /**
+         * Format the quantity with the increment step value.
+         */
         _formatQtyWithStep: function (ev) {
-            // Format the quantity with the increment step value.
-            // Example: If the increment step is 50, the quantity will be 50, 100, 150, etc.
-            // If the quantity is 75, it will be rounded to 100.
-            const $input = $(ev.currentTarget);
-            const $span = $input.closest('.input-group').find("span[data-increment-step]");
-            const $incrementSize = $span.data("increment-step");
-            const minOrderQty = $span.data("min-order-qty") || 0;
-            const minQty = minOrderQty > 0 ? Math.max(minOrderQty, $incrementSize) : $incrementSize;
-            let qty = parseInt($input.val(), 10); // Parse input value to integer
+            var $input = $(ev.currentTarget);
+            var $span = $input.closest('.input-group').find("span[data-increment-step]");
+            var $incrementSize = $span.data("increment-step");
+            var minOrderQty = $span.data("min-order-qty") || 0;
+            var minQty = minOrderQty > 0 ? Math.max(minOrderQty, $incrementSize) : $incrementSize;
+            var qty = parseInt($input.val(), 10);
 
-            // If the quantity is zero, return false (this means the user has deleted the input value)
-            if(qty === 0) {
+            if (qty === 0) {
                 return false;
             }
 
             qty = isNaN(qty) ? minQty : qty;
 
-            // Ensure the minimum quantity respects both min_order_qty and increment size
             if (qty <= minQty) {
                 qty = minQty;
             }
 
-            const remainder = qty % $incrementSize;
+            var remainder = qty % $incrementSize;
             if (remainder > 0) {
-                // Round to the nearest increment step value based on whether the value is increasing or decreasing
-                const prevQty = parseInt($input.data("prevQty"), 10) || minQty;
+                var prevQty = parseInt($input.data("prevQty"), 10) || minQty;
                 if (qty < prevQty) {
-                    // Decreasing, round down to the nearest increment step value
                     qty -= remainder;
-                    // Ensure we don't go below minimum after rounding down
                     if (qty < minQty) {
                         qty += $incrementSize;
                     }
                 } else {
-                    // Increasing, round up to the nearest increment step value
                     qty += $incrementSize - remainder;
                 }
             }
 
-            $input.data("prevQty", qty); // Store the previous quantity value
-            $input.val(qty); // Update input value to formatted quantity
-        }
+            $input.data("prevQty", qty);
+            $input.val(qty);
+        },
+
+        /**
+         * @override
+         * Also format quantity with step on cart quantity change.
+         */
+        _onChangeCartQuantity: function (ev) {
+            this._formatQtyWithStep(ev);
+            this._super.apply(this, arguments);
+        },
     });
 
 });

--- a/product_qty_increment_step/templates/cart_lines.xml
+++ b/product_qty_increment_step/templates/cart_lines.xml
@@ -9,7 +9,7 @@
             <span
                 class="d-none"
                 t-attf-data-increment-step="#{line.product_id.product_tmpl_id.qty_increment_step}"
-                t-attf-data-min-order-qty="#{line.product_id.product_tmpl_id.min_order_qty or 0}"
+                t-attf-data-min-order-qty="#{line.product_id.min_order_qty or 0}"
             />
         </xpath>
     </template>

--- a/product_qty_increment_step/templates/cart_lines.xml
+++ b/product_qty_increment_step/templates/cart_lines.xml
@@ -9,6 +9,7 @@
             <span
                 class="d-none"
                 t-attf-data-increment-step="#{line.product_id.product_tmpl_id.qty_increment_step}"
+                t-attf-data-min-order-qty="#{line.product_id.product_tmpl_id.min_order_qty or 0}"
             />
         </xpath>
     </template>

--- a/product_qty_increment_step/templates/product_configurator_quantity.xml
+++ b/product_qty_increment_step/templates/product_configurator_quantity.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <template
+        id="product_quantity_config_step"
+        inherit_id="sale_product_configurator.product_quantity_config"
+        name="Configurator Qty Increment Step"
+    >
+        <xpath expr="//input[@name='add_qty']" position="before">
+            <t
+                t-set="cfg_step"
+                t-value="product_variant.qty_increment_step if product_variant else 1"
+            />
+            <t
+                t-set="cfg_min_qty"
+                t-value="product_variant.min_order_qty if product_variant else 0"
+            />
+            <span
+                t-attf-data-increment-step="#{cfg_step or 1}"
+                t-attf-data-min-order-qty="#{cfg_min_qty or 0}"
+                class="d-none"
+            />
+        </xpath>
+
+        <xpath expr="//input[@name='add_qty']" position="attributes">
+            <attribute
+                name="t-att-value"
+            >max(cfg_min_qty or 0, cfg_step or 1)</attribute>
+        </xpath>
+    </template>
+</odoo>

--- a/product_qty_increment_step/templates/product_quantity.xml
+++ b/product_qty_increment_step/templates/product_quantity.xml
@@ -7,7 +7,10 @@
     >
         <xpath expr="//input[@name='add_qty']" position="before">
             <t t-set="step" t-value="product.qty_increment_step or add_qty or 1" />
-            <t t-set="min_qty" t-value="product.min_order_qty or 0" />
+            <t
+                t-set="min_qty"
+                t-value="product.product_variant_id.min_order_qty or 0"
+            />
             <span
                 t-attf-data-increment-step="#{product.qty_increment_step}"
                 t-attf-data-min-order-qty="#{min_qty}"

--- a/product_qty_increment_step/templates/product_quantity.xml
+++ b/product_qty_increment_step/templates/product_quantity.xml
@@ -7,14 +7,16 @@
     >
         <xpath expr="//input[@name='add_qty']" position="before">
             <t t-set="step" t-value="product.qty_increment_step or add_qty or 1" />
+            <t t-set="min_qty" t-value="product.min_order_qty or 0" />
             <span
                 t-attf-data-increment-step="#{product.qty_increment_step}"
+                t-attf-data-min-order-qty="#{min_qty}"
                 t-attf-class="d-none"
             />
         </xpath>
 
         <xpath expr="//input[@name='add_qty']" position="attributes">
-            <attribute name="t-att-value">step</attribute>
+            <attribute name="t-att-value">max(min_qty, step)</attribute>
         </xpath>
     </template>
 </odoo>

--- a/product_qty_increment_step/views/product_product_view.xml
+++ b/product_qty_increment_step/views/product_product_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<data>
+    <record
+        id="product_qty_increment_step_product_product_form_view"
+        model="ir.ui.view"
+    >
+        <field name="name">Product Min Order Qty View</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_standard_price']" position="inside">
+                <field name="min_order_qty" />
+            </xpath>
+        </field>
+    </record>
+</data>

--- a/product_qty_increment_step/views/product_template_view.xml
+++ b/product_qty_increment_step/views/product_template_view.xml
@@ -10,6 +10,7 @@
         <field name="arch" type="xml">
             <xpath expr="//page[@name='altinkaya_ecommerce']/group" position="inside">
                 <field name="qty_increment_step" />
+                <field name="min_order_qty" />
             </xpath>
         </field>
     </record>

--- a/product_qty_increment_step/views/product_template_view.xml
+++ b/product_qty_increment_step/views/product_template_view.xml
@@ -10,7 +10,6 @@
         <field name="arch" type="xml">
             <xpath expr="//page[@name='altinkaya_ecommerce']/group" position="inside">
                 <field name="qty_increment_step" />
-                <field name="min_order_qty" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
It can be found after "Sale Price" in "General Information" tab.


This is a addition that needs updating the code in multiple locations in multiple repositories:
(v16web)
1) Pull from odoo-addons(16.0 branch) in odoo-addons directory to get the code and upgrade Product Qty Increment Step module, which will add the field in v16web and function in detail page of a product and cart page.

2)  Pull from odoo(16.0web branch) in private-addons directory to get the code and upgrade Theme Prime module, which will make minimum quantity work on sidebar cart.

3) Pull from connector-odoo2odoo(16.0 branch) in connector-odoo2odoo directory for the field to be added to connector.
(v16)
4) Pull from odoo(16.0 branch) in private-addons for the new field to be added to 16.0. 