### PR TITLE
[FIX] fixed merge picking not putting the package count and weight values

### DIFF
--- a/delivery_package_barcode/wizard/delivery_package_barcode_wiz.py
+++ b/delivery_package_barcode/wizard/delivery_package_barcode_wiz.py
@@ -71,7 +71,7 @@ class DeliveryPackageBarcodeWiz(models.TransientModel):
                 }
             )
             res = wizard_obj.action_merge()
-            picking = self.env["stock.picking"].browse(res.get("picking_id"))
+            picking = self.env["stock.picking"].browse(res.get("res_id"))
 
         else:
             picking = self.picking_ids


### PR DESCRIPTION
action_merge was sending the id as res_id(in merge_picking_orders), but button_save was trying to get it as picking_id which doesn't exist.