### PR TITLE
[FIX] update business day check for Turkish calendar to include Friday

### DIFF
--- a/delivery_fedex/models/delivery_carrier.py
+++ b/delivery_fedex/models/delivery_carrier.py
@@ -1177,7 +1177,7 @@ class DeliveryCarrier(models.Model):
             raise UserError(
                 _(
                     "No available pickups found on a business day. "
-                    "All available dates fall on weekends or Friday same-day."
+                    "All available dates fall on weekends."
                 )
             )
 

--- a/delivery_integration_base/models/delivery_carrier.py
+++ b/delivery_integration_base/models/delivery_carrier.py
@@ -436,11 +436,11 @@ class DeliveryCarrier(models.Model):
         return zpl_files
 
     def _is_tr_business_day(self, dt):
-        """Check if a date is a Turkish business day (not weekend or Friday).
-        Used for same-day pickup eligibility (Mon-Thu only).
+        """Check if a date is a Turkish business day (not weekend).
+        Used for same-day pickup eligibility (Mon-Fri).
         """
         d = dt.date() if isinstance(dt, datetime) else dt
-        return d.weekday() < 4
+        return d.weekday() < 5
 
     def _get_next_tr_business_day(self, dt):
         """Advance a datetime to the next business day (Mon-Fri) if needed.


### PR DESCRIPTION
Friday added to weekdays for pickup date

DHL cutoff is 14:00 with 30min margin (13:30 effective).
If request comes before 13:30, Friday is now accepted as same-day pickup.
After cutoff on Friday, pickup date moves to Monday.

FedEx has no cutoff check - if API returns Friday as available, it is now accepted for both SAME_DAY and FUTURE_DAY pickups.