### PR TITLE
[REF] altinkaya_sales: update portal report_ref to new Proforma xml_id

### DIFF
--- a/altinkaya_sales/controllers/portal.py
+++ b/altinkaya_sales/controllers/portal.py
@@ -18,8 +18,6 @@ from odoo.addons.portal.controllers.portal import CustomerPortal
 class AltinkayaSalesPortal(CustomerPortal):
     def _show_report(self, model, report_type, report_ref, download=False):
         if report_ref == "sale.action_report_saleorder":
-            report_ref = (
-                "altinkaya_py3o_reports.report_altinkaya_sale_order_quotation_py3o"
-            )
+            report_ref = "altinkaya_py3o_reports.report_altinkaya_sale_proforma_py3o"
 
         return super()._show_report(model, report_type, report_ref, download)


### PR DESCRIPTION
## Summary
Companion change to altinkaya-opensource/odoo#640 (renames `report_altinkaya_sale_order_quotation_py3o` → `report_altinkaya_sale_proforma_py3o`).

`_show_report` in the portal controller intercepts the core Odoo `sale.action_report_saleorder` and swaps the report_ref to Altinkaya's custom py3o report. The xml_id string must track the rename; without it, `env.ref` would fail and the customer-portal PDF endpoint would 500.

## Test plan
- [ ] Merge odoo#640 first (or together)
- [ ] Log in as a portal user with a sale order
- [ ] Visit `/my/orders/<id>?report_type=pdf` — should return the renamed Proforma PDF
- [ ] Old id `altinkaya_py3o_reports.report_altinkaya_sale_order_quotation_py3o` no longer referenced anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)