### PR TITLE
[ADD] Expense classification fields, analysis report and screen

### DIFF
--- a/altinkaya_account/__manifest__.py
+++ b/altinkaya_account/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Altinkaya Account",
     "summary": "Accounting Extension for Altinkaya Enclosures",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "author": "Ismail Çağan Yılmaz, Altinkaya Enclosures",
     "license": "AGPL-3",
@@ -44,6 +44,8 @@
         "views/account_move_line_view.xml",
         "views/res_config_settings.xml",
         "views/credit_control_policy_view.xml",
+        "views/expense_classification_view.xml",
+        "views/account_account_view.xml",
         "wizards/change_partner_accounts.xml",
         "wizards/create_currency_difference_invoice.xml",
         "wizards/create_currency_valuation_move.xml",

--- a/altinkaya_account/i18n/altinkaya_account.pot
+++ b/altinkaya_account/i18n/altinkaya_account.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-08 07:23+0000\n"
-"PO-Revision-Date: 2026-05-08 07:23+0000\n"
+"POT-Creation-Date: 2026-05-25 13:42+0000\n"
+"PO-Revision-Date: 2026-05-25 13:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -28,6 +28,11 @@ msgstr ""
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__data_file
 msgid ".xlsx File"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_account_account
+msgid "Account"
 msgstr ""
 
 #. module: altinkaya_account
@@ -88,6 +93,13 @@ msgstr ""
 msgid ""
 "Action is completed but there is an error happened for these partners\n"
 " %(errs)s"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__active
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__active
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__active
+msgid "Active"
 msgstr ""
 
 #. module: altinkaya_account
@@ -249,6 +261,7 @@ msgid "Change Partner Accounts to USD"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__changeset_change_ids
@@ -269,6 +282,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__changeset_change_ids
@@ -280,6 +296,7 @@ msgid "Changeset Changes"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__changeset_ids
@@ -300,6 +317,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__changeset_ids
@@ -355,6 +375,7 @@ msgid "Could not read the .xlsx file: %s"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_changesets
@@ -375,6 +396,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_changesets
@@ -386,6 +410,7 @@ msgid "Count Changesets"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_pending_changeset_changes
@@ -406,6 +431,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_pending_changeset_changes
@@ -417,6 +445,7 @@ msgid "Count Pending Changeset Changes"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_pending_changesets
@@ -437,6 +466,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_pending_changesets
@@ -504,6 +536,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__create_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__create_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__create_uid
 msgid "Created by"
 msgstr ""
 
@@ -516,6 +551,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__create_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__create_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__create_date
 msgid "Created on"
 msgstr ""
 
@@ -649,6 +687,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__display_name
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__display_name
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -739,6 +780,53 @@ msgid "Execution Log"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_classification
+msgid "Expense Classification"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_item
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_item_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Item"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_item
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_item
+msgid "Expense Items"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_type
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_type_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Type"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_type
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_type
+msgid "Expense Types"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_unit
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_unit_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Unit"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_unit
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_unit
+msgid "Expense Units"
+msgstr ""
+
+#. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Fark"
 msgstr ""
@@ -806,6 +894,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__id
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__id
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__id
 msgid "ID"
 msgstr ""
 
@@ -920,6 +1011,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move____last_update
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log____last_update
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit____last_update
 msgid "Last Modified on"
 msgstr ""
 
@@ -932,6 +1026,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__write_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__write_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__write_uid
 msgid "Last Updated by"
 msgstr ""
 
@@ -944,6 +1041,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__write_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__write_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__write_date
 msgid "Last Updated on"
 msgstr ""
 
@@ -1570,6 +1670,7 @@ msgid ""
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__smart_search
@@ -1590,6 +1691,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__smart_search
@@ -1716,6 +1820,7 @@ msgid "The inverse rate of the currency"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_pending_changeset_changes
@@ -1736,6 +1841,9 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_pending_changeset_changes
@@ -1747,6 +1855,7 @@ msgid "The number of pending changes of this record"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_pending_changesets
@@ -1767,6 +1876,9 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_pending_changesets
@@ -1778,6 +1890,7 @@ msgid "The number of pending changesets of this record"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_changesets
@@ -1798,6 +1911,9 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_changesets
@@ -1851,6 +1967,13 @@ msgstr ""
 msgid ""
 "This journal will be used on the write-off entries created by the "
 "reconciliation."
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_item_name_uniq
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_type_name_uniq
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_unit_name_uniq
+msgid "This record already exists."
 msgstr ""
 
 #. module: altinkaya_account
@@ -1932,6 +2055,7 @@ msgid "Upload Fee Accrual"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__user_can_see_changeset
@@ -1952,6 +2076,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__user_can_see_changeset

--- a/altinkaya_account/i18n/en_US.po
+++ b/altinkaya_account/i18n/en_US.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-08 07:23+0000\n"
-"PO-Revision-Date: 2026-05-08 07:23+0000\n"
+"POT-Creation-Date: 2026-05-25 13:42+0000\n"
+"PO-Revision-Date: 2026-05-25 13:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -28,6 +28,11 @@ msgstr ""
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__data_file
 msgid ".xlsx File"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_account_account
+msgid "Account"
 msgstr ""
 
 #. module: altinkaya_account
@@ -88,6 +93,13 @@ msgstr ""
 msgid ""
 "Action is completed but there is an error happened for these partners\n"
 " %(errs)s"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__active
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__active
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__active
+msgid "Active"
 msgstr ""
 
 #. module: altinkaya_account
@@ -249,6 +261,7 @@ msgid "Change Partner Accounts to USD"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__changeset_change_ids
@@ -269,6 +282,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__changeset_change_ids
@@ -280,6 +296,7 @@ msgid "Changeset Changes"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__changeset_ids
@@ -300,6 +317,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__changeset_ids
@@ -355,6 +375,7 @@ msgid "Could not read the .xlsx file: %s"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_changesets
@@ -375,6 +396,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_changesets
@@ -386,6 +410,7 @@ msgid "Count Changesets"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_pending_changeset_changes
@@ -406,6 +431,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_pending_changeset_changes
@@ -417,6 +445,7 @@ msgid "Count Pending Changeset Changes"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_pending_changesets
@@ -437,6 +466,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_pending_changesets
@@ -504,6 +536,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__create_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__create_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__create_uid
 msgid "Created by"
 msgstr ""
 
@@ -516,6 +551,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__create_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__create_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__create_date
 msgid "Created on"
 msgstr ""
 
@@ -649,6 +687,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__display_name
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__display_name
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -739,6 +780,53 @@ msgid "Execution Log"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_classification
+msgid "Expense Classification"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_item
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_item_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Item"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_item
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_item
+msgid "Expense Items"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_type
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_type_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Type"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_type
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_type
+msgid "Expense Types"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_unit
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_unit_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Unit"
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_unit
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_unit
+msgid "Expense Units"
+msgstr ""
+
+#. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Fark"
 msgstr ""
@@ -806,6 +894,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__id
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__id
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__id
 msgid "ID"
 msgstr ""
 
@@ -920,6 +1011,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move____last_update
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log____last_update
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit____last_update
 msgid "Last Modified on"
 msgstr ""
 
@@ -932,6 +1026,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__write_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__write_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__write_uid
 msgid "Last Updated by"
 msgstr ""
 
@@ -944,6 +1041,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__write_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__write_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__write_date
 msgid "Last Updated on"
 msgstr ""
 
@@ -1570,6 +1670,7 @@ msgid ""
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__smart_search
@@ -1590,6 +1691,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__smart_search
@@ -1716,6 +1820,7 @@ msgid "The inverse rate of the currency"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_pending_changeset_changes
@@ -1736,6 +1841,9 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_pending_changeset_changes
@@ -1747,6 +1855,7 @@ msgid "The number of pending changes of this record"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_pending_changesets
@@ -1767,6 +1876,9 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_pending_changesets
@@ -1778,6 +1890,7 @@ msgid "The number of pending changesets of this record"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_changesets
@@ -1798,6 +1911,9 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_changesets
@@ -1851,6 +1967,13 @@ msgstr ""
 msgid ""
 "This journal will be used on the write-off entries created by the "
 "reconciliation."
+msgstr ""
+
+#. module: altinkaya_account
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_item_name_uniq
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_type_name_uniq
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_unit_name_uniq
+msgid "This record already exists."
 msgstr ""
 
 #. module: altinkaya_account
@@ -1932,6 +2055,7 @@ msgid "Upload Fee Accrual"
 msgstr ""
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__user_can_see_changeset
@@ -1952,6 +2076,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__user_can_see_changeset

--- a/altinkaya_account/i18n/tr.po
+++ b/altinkaya_account/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-08 07:23+0000\n"
-"PO-Revision-Date: 2026-05-08 07:23+0000\n"
+"POT-Creation-Date: 2026-05-25 13:42+0000\n"
+"PO-Revision-Date: 2026-05-25 13:42+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,17 +18,22 @@ msgstr ""
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "$₺€ Bakiye"
-msgstr "$₺€ Bakiye"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "$₺€ V.Gelen"
-msgstr "$₺€ V.Gelen"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__data_file
 msgid ".xlsx File"
 msgstr "Excel Dosyası"
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_account_account
+msgid "Account"
+msgstr "Hesap"
 
 #. module: altinkaya_account
 #: model:ir.model,name:altinkaya_account.model_account_account_reconcile
@@ -46,7 +51,9 @@ msgstr "Hesap Oto Uzlaştırma"
 msgid ""
 "Account for unrealized FX gains booked by the period-end currency valuation "
 "(646 - Kambiyo Karları)."
-msgstr "Dönem sonu kur değerlemesinde kayda alınan gerçekleşmemiş kambiyo karları için kullanılan hesap (646 - Kambiyo Karları)."
+msgstr ""
+"Dönem sonu kur değerlemesinde kayda alınan gerçekleşmemiş kambiyo karları "
+"için kullanılan hesap (646 - Kambiyo Karları)."
 
 #. module: altinkaya_account
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__currency_valuation_loss_account_id
@@ -54,7 +61,9 @@ msgstr "Dönem sonu kur değerlemesinde kayda alınan gerçekleşmemiş kambiyo 
 msgid ""
 "Account for unrealized FX losses booked by the period-end currency valuation"
 " (656 - Kambiyo Zararları)."
-msgstr "Dönem sonu kur değerlemesinde kayda alınan gerçekleşmemiş kambiyo zararları için kullanılan hesap (656 - Kambiyo Zararları)."
+msgstr ""
+"Dönem sonu kur değerlemesinde kayda alınan gerçekleşmemiş kambiyo zararları "
+"için kullanılan hesap (656 - Kambiyo Zararları)."
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_partner__accounting_contact
@@ -93,6 +102,13 @@ msgstr ""
 " %(errs)s"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__active
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__active
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__active
+msgid "Active"
+msgstr ""
+
+#. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__move_line_domain
 msgid "Additional Move Line Domain"
 msgstr "Ek Yevmiye Kalemi Domain'i"
@@ -102,7 +118,9 @@ msgstr "Ek Yevmiye Kalemi Domain'i"
 msgid ""
 "Additional domain to filter move lines for credit control checks. This "
 "domain is added to the default domain used to select move lines."
-msgstr "Kredi kontrol kontrolleri için yevmiye kalemlerini filtrelemekte kullanılan ek domain. Varsayılan domain'e eklenir."
+msgstr ""
+"Kredi kontrol kontrolleri için yevmiye kalemlerini filtrelemekte kullanılan "
+"ek domain. Varsayılan domain'e eklenir."
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.currency_reconcile_fix_wizard_form
@@ -185,7 +203,7 @@ msgstr "Faturalama Noktası"
 #: model:ir.ui.menu,name:altinkaya_account.menu_res_partner_balance_account
 #: model:ir.ui.menu,name:altinkaya_account.menu_res_partner_balance_sale
 msgid "Borç / Alacak Listesi"
-msgstr "Borç / Alacak Listesi"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__can_reconcile
@@ -248,7 +266,7 @@ msgstr "İş Ortağı Hesaplarını EUR'ya Değiştir"
 #. module: altinkaya_account
 #: model:ir.model,name:altinkaya_account.model_change_partner_accounts_eur
 msgid "Change Partner Accounts to EUR Wizard"
-msgstr "İş Ortağı Hesaplarını EUR'ya Değiştirme Sihirbazı"
+msgstr "Hesapları Değiştir EURO Sihirbazı"
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_change_accounts_try_view
@@ -261,6 +279,7 @@ msgid "Change Partner Accounts to USD"
 msgstr "İş Ortağı Hesaplarını USD'ye Değiştir"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__changeset_change_ids
@@ -281,6 +300,9 @@ msgstr "İş Ortağı Hesaplarını USD'ye Değiştir"
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__changeset_change_ids
@@ -292,6 +314,7 @@ msgid "Changeset Changes"
 msgstr "Değişiklikler"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__changeset_ids
@@ -312,6 +335,9 @@ msgstr "Değişiklikler"
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__changeset_ids
@@ -325,7 +351,7 @@ msgstr "Değişiklikler"
 #. module: altinkaya_account
 #: model:ir.model,name:altinkaya_account.model_change_partner_accounts_usd
 msgid "Changing partner accounts to USD Wizard"
-msgstr "İş Ortağı Hesaplarını USD'ye Değiştirme Sihirbazı"
+msgstr "Hesapları Değiştir USD Sihirbazı"
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.currency_reconcile_fix_wizard_form
@@ -367,6 +393,7 @@ msgid "Could not read the .xlsx file: %s"
 msgstr "Excel dosyası okunamadı: %s"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_changesets
@@ -387,6 +414,9 @@ msgstr "Excel dosyası okunamadı: %s"
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_changesets
@@ -398,6 +428,7 @@ msgid "Count Changesets"
 msgstr "Değişiklik Sayısı"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_pending_changeset_changes
@@ -418,6 +449,9 @@ msgstr "Değişiklik Sayısı"
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_pending_changeset_changes
@@ -429,6 +463,7 @@ msgid "Count Pending Changeset Changes"
 msgstr "Bekleyen Değişiklik Sayısı"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__count_pending_changesets
@@ -449,6 +484,9 @@ msgstr "Bekleyen Değişiklik Sayısı"
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__count_pending_changesets
@@ -516,6 +554,9 @@ msgstr "Yevmiye Oluştur"
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__create_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__create_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__create_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__create_uid
 msgid "Created by"
 msgstr "Oluşturan"
 
@@ -528,6 +569,9 @@ msgstr "Oluşturan"
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__create_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__create_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__create_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__create_date
 msgid "Created on"
 msgstr "Oluşturulma"
 
@@ -645,7 +689,7 @@ msgstr "Detaylar"
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_partner__devir_yapildi
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_users__devir_yapildi
 msgid "Devir Yapıldı"
-msgstr "Devir Yapıldı"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_move_line__unit_discounted
@@ -661,6 +705,9 @@ msgstr "İnd. Birim Fiyatı"
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__display_name
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__display_name
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__display_name
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__display_name
 msgid "Display Name"
 msgstr "Görünüm Adı"
 
@@ -688,12 +735,12 @@ msgstr "Vade Günleri"
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Döviz Bakiye"
-msgstr "Döviz Bakiye"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Döviz Vade Gelen"
-msgstr "Döviz Vade Gelen"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,help:altinkaya_account.field_account_bank_statement_line__z_tevkifatli_mi
@@ -702,7 +749,9 @@ msgstr "Döviz Vade Gelen"
 msgid ""
 "Eger fatura tevkifatli fatura ise bu alan secilmeli Sadece zirve programi "
 "transferinde kullanilmaktadir."
-msgstr "Fatura tevkifatlı ise bu alan seçilmelidir. Yalnızca Zirve programı transferinde kullanılır."
+msgstr ""
+"Fatura tevkifatlı ise bu alan seçilmelidir. Yalnızca Zirve programı "
+"transferinde kullanılır."
 
 #. module: altinkaya_account
 #. odoo-python
@@ -751,16 +800,63 @@ msgid "Execution Log"
 msgstr "Çalıştırma Logu"
 
 #. module: altinkaya_account
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_classification
+msgid "Expense Classification"
+msgstr "Gider Sınıflandırma"
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_item
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_item_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Item"
+msgstr "Gider Kalemi"
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_item
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_item
+msgid "Expense Items"
+msgstr "Gider Kalemleri"
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_type
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_type_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Type"
+msgstr "Harcama Türü"
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_type
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_type
+msgid "Expense Types"
+msgstr "Harcama Türleri"
+
+#. module: altinkaya_account
+#: model:ir.model,name:altinkaya_account.model_expense_unit
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__expense_unit_id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__name
+#: model_terms:ir.ui.view,arch_db:altinkaya_account.view_account_search_expense
+msgid "Expense Unit"
+msgstr "Birim"
+
+#. module: altinkaya_account
+#: model:ir.actions.act_window,name:altinkaya_account.action_expense_unit
+#: model:ir.ui.menu,name:altinkaya_account.menu_expense_unit
+msgid "Expense Units"
+msgstr "Birimler"
+
+#. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Fark"
-msgstr "Fark"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_bank_statement_line__x_serino
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_move__x_serino
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_payment__x_serino
 msgid "Fatura No"
-msgstr "Fatura No"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__filename
@@ -818,13 +914,18 @@ msgstr "Bu faturaya bağlı tam uzlaşmalar"
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__id
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__id
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__id
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__id
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__partner_id
 msgid "If set, only process this partner. Leave empty for all partners."
-msgstr "Belirtildiyse yalnızca bu iş ortağı işlenir. Tüm iş ortakları için boş bırakın."
+msgstr ""
+"Belirtildiyse yalnızca bu iş ortağı işlenir. Tüm iş ortakları için boş "
+"bırakın."
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.view_accrual_upload_wizard_form
@@ -904,24 +1005,26 @@ msgstr "Yevmiye Adı"
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__currency_valuation_journal_id
 #: model:ir.model.fields,help:altinkaya_account.field_res_config_settings__currency_valuation_journal_id
 msgid "Journal used to post period-end currency valuation entries (KRDGR)."
-msgstr "Dönem sonu kur değerleme kayıtlarını işlemek için kullanılan yevmiye (KRDGR)."
+msgstr ""
+"Dönem sonu kur değerleme kayıtlarını işlemek için kullanılan yevmiye "
+"(KRDGR)."
 
 #. module: altinkaya_account
 #. odoo-python
 #: code:addons/altinkaya_account/models/res_partner.py:0
 #, python-format
 msgid "KDV %s oranlı vergi tanımlanmamış!"
-msgstr "KDV %s oranlı vergi tanımlanmamış!"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.view_partner_form
 msgid "Kur Farkı"
-msgstr "Kur Farkı"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.view_partner_form
 msgid "Kur Farkı Faturası Oluştur"
-msgstr "Kur Farkı Faturası Oluştur"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard____last_update
@@ -932,6 +1035,9 @@ msgstr "Kur Farkı Faturası Oluştur"
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move____last_update
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log____last_update
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type____last_update
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit____last_update
 msgid "Last Modified on"
 msgstr "Son Güncelleme"
 
@@ -944,6 +1050,9 @@ msgstr "Son Güncelleme"
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__write_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__write_uid
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__write_uid
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__write_uid
 msgid "Last Updated by"
 msgstr "Son Güncelleyen"
 
@@ -956,6 +1065,9 @@ msgstr "Son Güncelleyen"
 #: model:ir.model.fields,field_description:altinkaya_account.field_create_currency_valuation_move__write_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__write_date
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__write_date
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__write_date
 msgid "Last Updated on"
 msgstr "Son Güncelleme"
 
@@ -967,12 +1079,12 @@ msgstr "Geçen Yıl"
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Limit"
-msgstr "Limit"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Limit Para B."
-msgstr "Limit Para B."
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__lines_to_reconcile_count
@@ -984,7 +1096,8 @@ msgstr "Yeniden Uzlaştırılacak Kalemler"
 #: code:addons/altinkaya_account/wizards/currency_reconcile_fix_wizard.py:0
 #, python-format
 msgid "Lines to re-reconcile (from %(date)s): %(count)d"
-msgstr "Yeniden uzlaştırılacak kalemler (%(date)s tarihinden itibaren): %(count)d"
+msgstr ""
+"Yeniden uzlaştırılacak kalemler (%(date)s tarihinden itibaren): %(count)d"
 
 #. module: altinkaya_account
 #. odoo-python
@@ -1001,7 +1114,7 @@ msgstr "Lot/Seri Numarası"
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.account_move_search_inherit
 msgid "Mali Koşul"
-msgstr "Mali Koşul"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__manual_model_id
@@ -1025,7 +1138,9 @@ msgstr "Sevk Satırlarını Eşleştir"
 #, python-format
 msgid ""
 "Missing TCMB forex-buying rate for currency id %(currency)s on %(date)s."
-msgstr "%(date)s tarihinde %(currency)s para birimi için TCMB döviz alış kuru bulunamadı."
+msgstr ""
+"%(date)s tarihinde %(currency)s para birimi için TCMB döviz alış kuru "
+"bulunamadı."
 
 #. module: altinkaya_account
 #. odoo-python
@@ -1066,7 +1181,8 @@ msgstr "Seçilen gün için döviz kuru bilgisi bulunamadı!"
 #: code:addons/altinkaya_account/models/res_partner.py:0
 #, python-format
 msgid "No foreign-currency open balances found for the selected partners."
-msgstr "Seçilen iş ortakları için yabancı para cinsinden açık bakiye bulunamadı."
+msgstr ""
+"Seçilen iş ortakları için yabancı para cinsinden açık bakiye bulunamadı."
 
 #. module: altinkaya_account
 #. odoo-python
@@ -1168,7 +1284,8 @@ msgstr "Bağlantısı Kaldırılacak Kısmi Uzlaşmalar"
 #: code:addons/altinkaya_account/wizards/currency_reconcile_fix_wizard.py:0
 #, python-format
 msgid "Partials to unlink (no full_reconcile_id): %(count)d"
-msgstr "Bağlantısı kaldırılacak kısmi uzlaşmalar (full_reconcile_id'siz): %(count)d"
+msgstr ""
+"Bağlantısı kaldırılacak kısmi uzlaşmalar (full_reconcile_id'siz): %(count)d"
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__partner_id
@@ -1412,7 +1529,9 @@ msgstr "Lütfen önce Aşama 3'ü tamamlayın."
 msgid ""
 "Please configure the Currency Valuation gain/loss accounts and journal under"
 " Accounting Settings."
-msgstr "Lütfen Muhasebe Ayarları'ndan Kur Değerleme kar/zarar hesaplarını ve yevmiyesini yapılandırın."
+msgstr ""
+"Lütfen Muhasebe Ayarları'ndan Kur Değerleme kar/zarar hesaplarını ve "
+"yevmiyesini yapılandırın."
 
 #. module: altinkaya_account
 #. odoo-python
@@ -1540,7 +1659,7 @@ msgstr "Sonuç"
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Risk"
-msgstr "Risk"
+msgstr ""
 
 #. module: altinkaya_account
 #. odoo-python
@@ -1549,7 +1668,9 @@ msgstr "Risk"
 msgid ""
 "Row %(idx)s has a different date (%(row_date)s) than previous rows "
 "(%(move_date)s). All rows must share the same date."
-msgstr "%(idx)s satırının tarihi (%(row_date)s) önceki satırların tarihinden (%(move_date)s) farklı. Tüm satırlar aynı tarihi paylaşmalıdır."
+msgstr ""
+"%(idx)s satırının tarihi (%(row_date)s) önceki satırların tarihinden "
+"(%(move_date)s) farklı. Tüm satırlar aynı tarihi paylaşmalıdır."
 
 #. module: altinkaya_account
 #. odoo-python
@@ -1562,12 +1683,12 @@ msgstr "%s satırında hem Borç hem Alacak mevcut. Lütfen düzeltme yapın."
 #: model:ir.model.fields,help:altinkaya_account.field_res_partner__purchase_default_account_id
 #: model:ir.model.fields,help:altinkaya_account.field_res_users__purchase_default_account_id
 msgid "Satın alma işlemlerinde varsayılan muhasebe hesabı."
-msgstr "Satın alma işlemlerinde varsayılan muhasebe hesabı."
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.view_partner_form
 msgid "Satınalma Masraf Hesabı"
-msgstr "Satınalma Masraf Hesabı"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_bank_statement_line__address_contact_id
@@ -1581,9 +1702,12 @@ msgstr "Teslimat Adresi"
 msgid ""
 "Shorter name used for display. The journal entries of this journal will also"
 " be named using this prefix by default."
-msgstr "Görüntüleme için kullanılan kısa ad. Bu yevmiyenin kayıtları varsayılan olarak bu önekle adlandırılır."
+msgstr ""
+"Görüntüleme için kullanılan kısa ad. Bu yevmiyenin kayıtları varsayılan "
+"olarak bu önekle adlandırılır."
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__smart_search
@@ -1604,6 +1728,9 @@ msgstr "Görüntüleme için kullanılan kısa ad. Bu yevmiyenin kayıtları var
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__smart_search
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__smart_search
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__smart_search
@@ -1646,17 +1773,17 @@ msgstr "Tedarikçiler"
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.base_res_partner_search_inherit
 msgid "Sıfır Değil"
-msgstr "Sıfır Değil"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "TL Bakiye"
-msgstr "TL Bakiye"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "TL Vade Gelen"
-msgstr "TL Vade Gelen"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_partner__balance
@@ -1693,7 +1820,7 @@ msgstr "Vergi Dairesi Adı"
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.account_move_total_balance
 msgid "Teslimat Adresi"
-msgstr "Teslimat Adresi"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_bank_statement_line__x_teslimat
@@ -1707,7 +1834,7 @@ msgstr "Teslimat Kısaltması"
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_move__z_tevkifatli_mi
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_payment__z_tevkifatli_mi
 msgid "Tevkifatlı"
-msgstr "Tevkifatlı"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__invoice_currency_id
@@ -1733,6 +1860,7 @@ msgid "The inverse rate of the currency"
 msgstr "Para birimi ters kur"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_pending_changeset_changes
@@ -1753,6 +1881,9 @@ msgstr "Para birimi ters kur"
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_pending_changeset_changes
@@ -1764,6 +1895,7 @@ msgid "The number of pending changes of this record"
 msgstr "Bu kayıt için bekleyen değişiklikler"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_pending_changesets
@@ -1784,6 +1916,9 @@ msgstr "Bu kayıt için bekleyen değişiklikler"
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_pending_changesets
@@ -1795,6 +1930,7 @@ msgid "The number of pending changesets of this record"
 msgstr "Bu kayıt için bekleyen değişiklik sayısı"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,help:altinkaya_account.field_account_account__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_account_reconcile__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_accrual_upload_wizard__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_account_auto_reconcile__count_changesets
@@ -1815,6 +1951,9 @@ msgstr "Bu kayıt için bekleyen değişiklik sayısı"
 #: model:ir.model.fields,help:altinkaya_account.field_credit_control_policy__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_log__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_currency_reconcile_fix_wizard__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_item__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_type__count_changesets
+#: model:ir.model.fields,help:altinkaya_account.field_expense_unit__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_payment_transaction__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_product_pricelist__count_changesets
 #: model:ir.model.fields,help:altinkaya_account.field_res_company__count_changesets
@@ -1851,7 +1990,9 @@ msgstr "Bu Yıl"
 msgid ""
 "This action will change every accounting records of partner. Ask your "
 "administrator before use it."
-msgstr "Bu işlem iş ortağının tüm muhasebe kayıtlarını değiştirir. Kullanmadan önce yöneticinize danışın."
+msgstr ""
+"Bu işlem iş ortağının tüm muhasebe kayıtlarını değiştirir. Kullanmadan önce "
+"yöneticinize danışın."
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_create_difference_inv
@@ -1868,7 +2009,15 @@ msgstr "Bu işlem seçilen iş ortakları için kur değerleme hareketi oluştur
 msgid ""
 "This journal will be used on the write-off entries created by the "
 "reconciliation."
-msgstr "Bu yevmiye, uzlaştırma sırasında oluşturulan silme kayıtlarında kullanılır."
+msgstr ""
+"Bu yevmiye, uzlaştırma sırasında oluşturulan silme kayıtlarında kullanılır."
+
+#. module: altinkaya_account
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_item_name_uniq
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_type_name_uniq
+#: model:ir.model.constraint,message:altinkaya_account.constraint_expense_unit_name_uniq
+msgid "This record already exists."
+msgstr "Bu kayıt zaten mevcut."
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.currency_reconcile_fix_wizard_form
@@ -1880,14 +2029,18 @@ msgstr "Bu işlem yetim KRFRK kayıtlarını siler. Devam edilsin mi?"
 msgid ""
 "This will execute ALL phases in sequence. This is a destructive operation. "
 "Are you sure?"
-msgstr "Bu işlem TÜM aşamaları sırayla çalıştırır. Yıkıcı bir işlemdir. Emin misiniz?"
+msgstr ""
+"Bu işlem TÜM aşamaları sırayla çalıştırır. Yıkıcı bir işlemdir. Emin "
+"misiniz?"
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.currency_reconcile_fix_wizard_form
 msgid ""
 "This will unlink all partial reconciliations without full_reconcile_id. "
 "Continue?"
-msgstr "Bu işlem full_reconcile_id'si olmayan tüm kısmi uzlaşmaların bağlantısını keser. Devam edilsin mi?"
+msgstr ""
+"Bu işlem full_reconcile_id'si olmayan tüm kısmi uzlaşmaların bağlantısını "
+"keser. Devam edilsin mi?"
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.currency_reconcile_fix_wizard_form
@@ -1935,7 +2088,7 @@ msgstr "Kur Değerleme Hareketi için Geçici Model"
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.base_res_partner_search_inherit
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.inherit_view_account_invoice_report_search
 msgid "Türkiye"
-msgstr "Türkiye"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.view_accrual_upload_wizard_form
@@ -1949,6 +2102,7 @@ msgid "Upload Fee Accrual"
 msgstr "Fiyat Tahakkuku Yükle"
 
 #. module: altinkaya_account
+#: model:ir.model.fields,field_description:altinkaya_account.field_account_account__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_account_reconcile__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_accrual_upload_wizard__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_account_auto_reconcile__user_can_see_changeset
@@ -1969,6 +2123,9 @@ msgstr "Fiyat Tahakkuku Yükle"
 #: model:ir.model.fields,field_description:altinkaya_account.field_credit_control_policy__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_log__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_currency_reconcile_fix_wizard__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_item__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_type__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_account.field_expense_unit__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_payment_transaction__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_product_pricelist__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_company__user_can_see_changeset
@@ -2001,40 +2158,40 @@ msgstr "Sihirbaz Tamamlandı"
 #. module: altinkaya_account
 #: model:ir.model,name:altinkaya_account.model_change_partner_accounts_try
 msgid "Wizard for changing partner accounts to TRY"
-msgstr "İş Ortağı Hesaplarını TL'ye Değiştirme Sihirbazı"
+msgstr "Hesapları Değiştir TRY Sihirbazı"
 
 #. module: altinkaya_account
 #: model:ir.actions.act_window,name:altinkaya_account.act_res_partner_2_account_move_line
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.view_partner_form
 msgid "Yevmiye Kalemleri"
-msgstr "Yevmiye Kalemleri"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.base_res_partner_search_inherit
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.inherit_view_account_invoice_report_search
 msgid "Yurtdışı"
-msgstr "Yurtdışı"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.account_move_search_inherit
 msgid "Yurtiçi Normal TL"
-msgstr "Yurtiçi Normal TL"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.account_move_search_inherit
 msgid "Yurtiçi Normal YP"
-msgstr "Yurtiçi Normal YP"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.account_move_search_inherit
 msgid "Yurtiçi Tevkifat"
-msgstr "Yurtiçi Tevkifat"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_partner__z_muhasebe_kodu
 #: model:ir.model.fields,field_description:altinkaya_account.field_res_users__z_muhasebe_kodu
 msgid "Zirve Muhasebe kodu"
-msgstr "Zirve Muhasebe kodu"
+msgstr ""
 
 #. module: altinkaya_account
 #: model:ir.model,name:altinkaya_account.model_credit_control_communication
@@ -2051,24 +2208,24 @@ msgstr "İhracat Fatura Notu"
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "Ödeme Şekli"
-msgstr "Ödeme Şekli"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_form_view_cari
 msgid "Özel Limitler"
-msgstr "Özel Limitler"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.account_move_search_inherit
 msgid "İhracat"
-msgstr "İhracat"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "₺ Bakiye"
-msgstr "₺ Bakiye"
+msgstr ""
 
 #. module: altinkaya_account
 #: model_terms:ir.ui.view,arch_db:altinkaya_account.res_partner_balance_tree
 msgid "₺ V.Gelen"
-msgstr "₺ V.Gelen"
+msgstr ""

--- a/altinkaya_account/models/__init__.py
+++ b/altinkaya_account/models/__init__.py
@@ -19,3 +19,5 @@ from . import account_auto_reconcile
 from . import payment_transaction
 from . import credit_control_policy
 from . import credit_control_communication
+from . import expense_classification
+from . import account_account

--- a/altinkaya_account/models/account_account.py
+++ b/altinkaya_account/models/account_account.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class AccountAccount(models.Model):
+    _inherit = "account.account"
+
+    expense_item_id = fields.Many2one("expense.item", index=True)
+    expense_unit_id = fields.Many2one("expense.unit", index=True)
+    expense_type_id = fields.Many2one("expense.type", index=True)

--- a/altinkaya_account/models/expense_classification.py
+++ b/altinkaya_account/models/expense_classification.py
@@ -1,0 +1,40 @@
+from odoo import fields, models
+
+
+class ExpenseItem(models.Model):
+    _name = "expense.item"
+    _description = "Expense Item"
+    _order = "name"
+
+    name = fields.Char(string="Expense Item", required=True)
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("name_uniq", "unique(name)", "This record already exists."),
+    ]
+
+
+class ExpenseUnit(models.Model):
+    _name = "expense.unit"
+    _description = "Expense Unit"
+    _order = "name"
+
+    name = fields.Char(string="Expense Unit", required=True)
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("name_uniq", "unique(name)", "This record already exists."),
+    ]
+
+
+class ExpenseType(models.Model):
+    _name = "expense.type"
+    _description = "Expense Type"
+    _order = "name"
+
+    name = fields.Char(string="Expense Type", required=True)
+    active = fields.Boolean(default=True)
+
+    _sql_constraints = [
+        ("name_uniq", "unique(name)", "This record already exists."),
+    ]

--- a/altinkaya_account/security/ir.model.access.csv
+++ b/altinkaya_account/security/ir.model.access.csv
@@ -7,3 +7,9 @@ access_currency_reconcile_fix_log,access.currency.reconcile.fix.log,model_curren
 access_change_partner_accounts_usd,access_change_partner_accounts_usd,model_change_partner_accounts_usd,account.group_account_manager,1,1,1,1
 access_change_partner_accounts_eur,access_change_partner_accounts_eur,model_change_partner_accounts_eur,account.group_account_manager,1,1,1,1
 access_change_partner_accounts_try,access_change_partner_accounts_try,model_change_partner_accounts_try,account.group_account_manager,1,1,1,1
+access_expense_item_user,expense.item.user,model_expense_item,account.group_account_user,1,0,0,0
+access_expense_item_manager,expense.item.manager,model_expense_item,account.group_account_manager,1,1,1,1
+access_expense_unit_user,expense.unit.user,model_expense_unit,account.group_account_user,1,0,0,0
+access_expense_unit_manager,expense.unit.manager,model_expense_unit,account.group_account_manager,1,1,1,1
+access_expense_type_user,expense.type.user,model_expense_type,account.group_account_user,1,0,0,0
+access_expense_type_manager,expense.type.manager,model_expense_type,account.group_account_manager,1,1,1,1

--- a/altinkaya_account/views/account_account_view.xml
+++ b/altinkaya_account/views/account_account_view.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_account_form_expense" model="ir.ui.view">
+        <field name="name">account.account.form.expense</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_form" />
+        <field name="arch" type="xml">
+            <field name="account_type" position="after">
+                <field name="expense_item_id" />
+                <field name="expense_unit_id" />
+                <field name="expense_type_id" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_account_list_expense" model="ir.ui.view">
+        <field name="name">account.account.list.expense</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_list" />
+        <field name="arch" type="xml">
+            <field name="account_type" position="after">
+                <field name="expense_item_id" optional="hide" />
+                <field name="expense_unit_id" optional="hide" />
+                <field name="expense_type_id" optional="hide" />
+            </field>
+        </field>
+    </record>
+
+    <record id="view_account_search_expense" model="ir.ui.view">
+        <field name="name">account.account.search.expense</field>
+        <field name="model">account.account</field>
+        <field name="inherit_id" ref="account.view_account_search" />
+        <field name="arch" type="xml">
+            <filter name="accounttype" position="after">
+                <filter
+                    string="Expense Item"
+                    name="group_expense_item"
+                    context="{'group_by': 'expense_item_id'}"
+                />
+                <filter
+                    string="Expense Unit"
+                    name="group_expense_unit"
+                    context="{'group_by': 'expense_unit_id'}"
+                />
+                <filter
+                    string="Expense Type"
+                    name="group_expense_type"
+                    context="{'group_by': 'expense_type_id'}"
+                />
+            </filter>
+        </field>
+    </record>
+</odoo>

--- a/altinkaya_account/views/account_invoice_report_view.xml
+++ b/altinkaya_account/views/account_invoice_report_view.xml
@@ -61,9 +61,7 @@
         <field name="priority" eval="100" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_categ_id']" position="replace" />
-            <field name="price_subtotal" position="replace">
-                <field name="price_total_usd" type="measure" />
-            </field>
+            <xpath expr="//field[@name='price_subtotal']" position="replace" />
         </field>
     </record>
 

--- a/altinkaya_account/views/expense_classification_view.xml
+++ b/altinkaya_account/views/expense_classification_view.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="expense_item_tree" model="ir.ui.view">
+        <field name="name">expense.item.tree</field>
+        <field name="model">expense.item</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom">
+                <field name="name" />
+                <field name="active" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="expense_item_form" model="ir.ui.view">
+        <field name="name">expense.item.form</field>
+        <field name="model">expense.item</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name" />
+                        <field name="active" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_expense_item" model="ir.actions.act_window">
+        <field name="name">Expense Items</field>
+        <field name="res_model">expense.item</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="expense_unit_tree" model="ir.ui.view">
+        <field name="name">expense.unit.tree</field>
+        <field name="model">expense.unit</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom">
+                <field name="name" />
+                <field name="active" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="expense_unit_form" model="ir.ui.view">
+        <field name="name">expense.unit.form</field>
+        <field name="model">expense.unit</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name" />
+                        <field name="active" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_expense_unit" model="ir.actions.act_window">
+        <field name="name">Expense Units</field>
+        <field name="res_model">expense.unit</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record id="expense_type_tree" model="ir.ui.view">
+        <field name="name">expense.type.tree</field>
+        <field name="model">expense.type</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom">
+                <field name="name" />
+                <field name="active" widget="boolean_toggle" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="expense_type_form" model="ir.ui.view">
+        <field name="name">expense.type.form</field>
+        <field name="model">expense.type</field>
+        <field name="arch" type="xml">
+            <form>
+                <sheet>
+                    <group>
+                        <field name="name" />
+                        <field name="active" />
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_expense_type" model="ir.actions.act_window">
+        <field name="name">Expense Types</field>
+        <field name="res_model">expense.type</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem
+        id="menu_expense_classification"
+        name="Expense Classification"
+        parent="account.menu_finance_configuration"
+        sequence="90"
+    />
+    <menuitem
+        id="menu_expense_item"
+        name="Expense Items"
+        parent="menu_expense_classification"
+        action="action_expense_item"
+        sequence="10"
+    />
+    <menuitem
+        id="menu_expense_unit"
+        name="Expense Units"
+        parent="menu_expense_classification"
+        action="action_expense_unit"
+        sequence="20"
+    />
+    <menuitem
+        id="menu_expense_type"
+        name="Expense Types"
+        parent="menu_expense_classification"
+        action="action_expense_type"
+        sequence="30"
+    />
+</odoo>

--- a/altinkaya_reports/__init__.py
+++ b/altinkaya_reports/__init__.py
@@ -2,3 +2,4 @@ from . import wizard
 from . import models
 from .report import account_invoice_report
 from .report import expense_analysis_report
+from .report import payment_analysis_report

--- a/altinkaya_reports/__init__.py
+++ b/altinkaya_reports/__init__.py
@@ -1,3 +1,4 @@
 from . import wizard
 from . import models
 from .report import account_invoice_report
+from .report import expense_analysis_report

--- a/altinkaya_reports/__manifest__.py
+++ b/altinkaya_reports/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Altinkaya Reports",
-    "version": "16.0.1.3.0",
+    "version": "16.0.1.4.0",
     "category": "General",
     "depends": [
         "base",

--- a/altinkaya_reports/__manifest__.py
+++ b/altinkaya_reports/__manifest__.py
@@ -40,6 +40,7 @@
         "views/res_users_views.xml",
         "views/partner_view.xml",
         "views/utm_views.xml",
+        "views/account_invoice_report_views.xml",
         "views/expense_analysis_report_views.xml",
         "views/payment_analysis_report_views.xml",
         "data/partner_data.xml",

--- a/altinkaya_reports/__manifest__.py
+++ b/altinkaya_reports/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Altinkaya Reports",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.2.0",
     "category": "General",
     "depends": [
         "base",
@@ -40,6 +40,7 @@
         "views/res_users_views.xml",
         "views/partner_view.xml",
         "views/utm_views.xml",
+        "views/expense_analysis_report_views.xml",
         "data/partner_data.xml",
         "security/ir.model.access.csv",
     ],

--- a/altinkaya_reports/__manifest__.py
+++ b/altinkaya_reports/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Altinkaya Reports",
-    "version": "16.0.1.2.0",
+    "version": "16.0.1.3.0",
     "category": "General",
     "depends": [
         "base",

--- a/altinkaya_reports/__manifest__.py
+++ b/altinkaya_reports/__manifest__.py
@@ -41,6 +41,7 @@
         "views/partner_view.xml",
         "views/utm_views.xml",
         "views/expense_analysis_report_views.xml",
+        "views/payment_analysis_report_views.xml",
         "data/partner_data.xml",
         "security/ir.model.access.csv",
     ],

--- a/altinkaya_reports/__manifest__.py
+++ b/altinkaya_reports/__manifest__.py
@@ -10,6 +10,7 @@
         "l10n_tr_invoice_amount_in_words",
         "base_report_to_printer",
         "account",
+        "altinkaya_account",
         "account_check",
         "mrp",
         "account_invoice_change_currency",

--- a/altinkaya_reports/i18n/altinkaya_reports.pot
+++ b/altinkaya_reports/i18n/altinkaya_reports.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 09:32+0000\n"
-"PO-Revision-Date: 2026-06-01 09:32+0000\n"
+"POT-Creation-Date: 2026-06-01 10:38+0000\n"
+"PO-Revision-Date: 2026-06-01 10:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -587,6 +587,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__account_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Account"
 msgstr ""
@@ -619,11 +620,13 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_tl
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__amount_tl
 msgid "Amount (TL)"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_usd
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__amount_usd
 msgid "Amount (USD)"
 msgstr ""
 
@@ -748,11 +751,22 @@ msgid "Cari:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__cash
+msgid "Cash"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__category
+msgid "Category"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__changeset_change_ids
@@ -765,10 +779,21 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__changeset_ids
 msgid "Changesets"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__channel
+msgid "Channel"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__cheque
+msgid "Cheque"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -798,6 +823,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__company_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__company_id
 msgid "Company"
 msgstr ""
 
@@ -822,6 +848,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_changesets
@@ -834,6 +861,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_pending_changeset_changes
@@ -846,6 +874,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_pending_changesets
@@ -870,12 +899,18 @@ msgid "Credit"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__customer_collection
+msgid "Customer Collection"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_delivery_carrier_report_data
 msgid "DESİ"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__date
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__date
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
@@ -944,6 +979,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__display_name
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__display_name
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -1040,6 +1076,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__id
 msgid "ID"
 msgstr ""
 
@@ -1093,6 +1130,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report____last_update
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard____last_update
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report____last_update
 msgid "Last Modified on"
 msgstr ""
 
@@ -1104,6 +1142,11 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__loan
+msgid "Loan"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1198,6 +1241,11 @@ msgid "P.12.F.03 Yazdıran:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__pos
+msgid "POS"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__paid
 msgid "Paid"
 msgstr ""
@@ -1205,6 +1253,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__partner_id
 msgid "Partner"
 msgstr ""
 
@@ -1266,6 +1315,16 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__partner_ids
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_utm_campaign_form_inherit_altinkaya
 msgid "Partners"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model,name:altinkaya_reports.model_payment_analysis_report
+msgid "Payment Analysis"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__personnel
+msgid "Personnel"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1405,6 +1464,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__smart_search
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__smart_search
@@ -1420,6 +1480,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__state_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__state
 msgid "State"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__supplier_payment
+msgid "Supplier Payment"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1455,6 +1520,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_delivery_carrier_report_data
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_picking_altinkaya
 msgid "Tarih:"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__tax
+msgid "Tax"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1497,6 +1567,7 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_pending_changeset_changes
@@ -1509,6 +1580,7 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_pending_changesets
@@ -1521,6 +1593,7 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_changesets
@@ -1584,6 +1657,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__user_can_see_changeset

--- a/altinkaya_reports/i18n/altinkaya_reports.pot
+++ b/altinkaya_reports/i18n/altinkaya_reports.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-02 06:13+0000\n"
-"PO-Revision-Date: 2026-02-02 06:13+0000\n"
+"POT-Creation-Date: 2026-06-01 05:18+0000\n"
+"PO-Revision-Date: 2026-06-01 05:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -586,6 +586,12 @@ msgid "AT,646,101,58,58,0,0E,0,0,"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Account"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 msgid "Account:"
@@ -609,6 +615,16 @@ msgstr ""
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 msgid "Amount"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_tl
+msgid "Amount (TL)"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_usd
+msgid "Amount (USD)"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -712,6 +728,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__cancelled
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__cancel
 msgid "Cancelled"
 msgstr ""
 
@@ -733,6 +750,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_change_ids
@@ -744,6 +762,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_ids
@@ -778,6 +797,11 @@ msgid "Commission Type"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__company_id
+msgid "Company"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__concluded
 msgid "Concluded"
 msgstr ""
@@ -795,6 +819,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_changesets
@@ -806,6 +831,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changeset_changes
@@ -817,6 +843,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changesets
@@ -836,6 +863,7 @@ msgid "Created on"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__credit
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Credit"
@@ -847,13 +875,16 @@ msgid "DESİ"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__date
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Date"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__debit
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Debit"
@@ -911,17 +942,14 @@ msgid "Desc."
 msgstr ""
 
 #. module: altinkaya_reports
-#: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__manual_discount_percentage
-msgid "Difference between actual price and pricelist price in percentage."
-msgstr ""
-
-#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__display_name
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__display_name
 msgid "Display Name"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__draft
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__draft
 msgid "Draft"
 msgstr ""
 
@@ -943,6 +971,34 @@ msgid "Expected unit price according to pricelist, in USD."
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.actions.act_window,name:altinkaya_reports.action_expense_analysis_report
+#: model:ir.model,name:altinkaya_reports.model_expense_analysis_report
+#: model:ir.ui.menu,name:altinkaya_reports.menu_expense_analysis_report
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_graph
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_pivot
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Analysis"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_item_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Item"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_type_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Type"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_unit_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Unit"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Explanation"
 msgstr ""
@@ -955,6 +1011,11 @@ msgstr ""
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.altinkaya_mrp_report_data_table
 msgid "Gerçekleşen Miktar"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Group By"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -974,6 +1035,7 @@ msgid "Hesabı:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__id
 msgid "ID"
 msgstr ""
@@ -1026,6 +1088,7 @@ msgid ""
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report____last_update
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard____last_update
 msgid "Last Modified on"
 msgstr ""
@@ -1057,7 +1120,6 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__manual_discount_percentage
-#: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__manual_discount_percentage
 msgid "Manual Discount Percentage"
 msgstr ""
 
@@ -1138,6 +1200,7 @@ msgid "Paid"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
 msgid "Partner"
 msgstr ""
@@ -1200,6 +1263,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__partner_ids
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_utm_campaign_form_inherit_altinkaya
 msgid "Partners"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__posted
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Posted"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1330,6 +1399,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__smart_search
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__smart_search
@@ -1345,6 +1415,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__state_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__state
 msgid "State"
 msgstr ""
 
@@ -1420,6 +1491,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changeset_changes
@@ -1431,6 +1503,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changesets
@@ -1442,6 +1515,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_changesets
@@ -1453,6 +1527,16 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__acquirer_id
 msgid "The user who acquired this customer."
+msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "This Year"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_tree
+msgid "Total"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1494,6 +1578,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__user_can_see_changeset

--- a/altinkaya_reports/i18n/altinkaya_reports.pot
+++ b/altinkaya_reports/i18n/altinkaya_reports.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 05:18+0000\n"
-"PO-Revision-Date: 2026-06-01 05:18+0000\n"
+"POT-Creation-Date: 2026-06-01 09:32+0000\n"
+"PO-Revision-Date: 2026-06-01 09:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -981,18 +981,21 @@ msgid "Expense Analysis"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_item_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_item_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Item"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_type_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_type_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Type"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_unit_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_unit_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Unit"

--- a/altinkaya_reports/i18n/altinkaya_reports.pot
+++ b/altinkaya_reports/i18n/altinkaya_reports.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 10:38+0000\n"
-"PO-Revision-Date: 2026-06-01 10:38+0000\n"
+"POT-Creation-Date: 2026-06-02 08:51+0000\n"
+"PO-Revision-Date: 2026-06-02 08:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -589,6 +589,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__account_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Account"
 msgstr ""
 
@@ -685,6 +686,11 @@ msgid "Balance"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__bank
+msgid "Bank"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_payment_receipt_document_altinkaya
 msgid "Banka Ödemesi"
 msgstr ""
@@ -757,6 +763,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__category
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Category"
 msgstr ""
 
@@ -788,6 +795,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__channel
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Channel"
 msgstr ""
 
@@ -899,6 +907,11 @@ msgid "Credit"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__credit_card
+msgid "Credit Card"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__customer_collection
 msgid "Customer Collection"
 msgstr ""
@@ -915,6 +928,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Date"
 msgstr ""
 
@@ -1054,6 +1068,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Group By"
 msgstr ""
 
@@ -1254,6 +1269,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__partner_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Partner"
 msgstr ""
 
@@ -1318,7 +1334,12 @@ msgid "Partners"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.actions.act_window,name:altinkaya_reports.action_payment_analysis_report
 #: model:ir.model,name:altinkaya_reports.model_payment_analysis_report
+#: model:ir.ui.menu,name:altinkaya_reports.menu_payment_analysis_report
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_graph
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_pivot
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Payment Analysis"
 msgstr ""
 
@@ -1607,11 +1628,13 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "This Year"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_tree
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_tree
 msgid "Total"
 msgstr ""
 
@@ -1642,8 +1665,18 @@ msgid "UTM Campaign"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_subtotal_abs
+msgid "Untaxed Total Abs"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_total_usd
 msgid "Untaxed Total USD"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_total_usd_abs
+msgid "Untaxed Total USD Abs"
 msgstr ""
 
 #. module: altinkaya_reports

--- a/altinkaya_reports/i18n/en_US.po
+++ b/altinkaya_reports/i18n/en_US.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 09:32+0000\n"
-"PO-Revision-Date: 2026-06-01 09:32+0000\n"
+"POT-Creation-Date: 2026-06-01 10:38+0000\n"
+"PO-Revision-Date: 2026-06-01 10:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -587,6 +587,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__account_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Account"
 msgstr ""
@@ -619,11 +620,13 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_tl
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__amount_tl
 msgid "Amount (TL)"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_usd
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__amount_usd
 msgid "Amount (USD)"
 msgstr ""
 
@@ -748,11 +751,22 @@ msgid "Cari:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__cash
+msgid "Cash"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__category
+msgid "Category"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__changeset_change_ids
@@ -765,10 +779,21 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__changeset_ids
 msgid "Changesets"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__channel
+msgid "Channel"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__cheque
+msgid "Cheque"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -798,6 +823,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__company_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__company_id
 msgid "Company"
 msgstr ""
 
@@ -822,6 +848,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_changesets
@@ -834,6 +861,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_pending_changeset_changes
@@ -846,6 +874,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_pending_changesets
@@ -870,12 +899,18 @@ msgid "Credit"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__customer_collection
+msgid "Customer Collection"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_delivery_carrier_report_data
 msgid "DESİ"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__date
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__date
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
@@ -944,6 +979,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__display_name
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__display_name
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__display_name
 msgid "Display Name"
 msgstr ""
 
@@ -1040,6 +1076,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__id
 msgid "ID"
 msgstr ""
 
@@ -1093,6 +1130,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report____last_update
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard____last_update
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report____last_update
 msgid "Last Modified on"
 msgstr ""
 
@@ -1104,6 +1142,11 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__loan
+msgid "Loan"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1198,6 +1241,11 @@ msgid "P.12.F.03 Yazdıran:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__pos
+msgid "POS"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__paid
 msgid "Paid"
 msgstr ""
@@ -1205,6 +1253,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__partner_id
 msgid "Partner"
 msgstr ""
 
@@ -1266,6 +1315,16 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__partner_ids
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_utm_campaign_form_inherit_altinkaya
 msgid "Partners"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model,name:altinkaya_reports.model_payment_analysis_report
+msgid "Payment Analysis"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__personnel
+msgid "Personnel"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1405,6 +1464,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__smart_search
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__smart_search
@@ -1420,6 +1480,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__state_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__state
 msgid "State"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__supplier_payment
+msgid "Supplier Payment"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1455,6 +1520,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_delivery_carrier_report_data
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_picking_altinkaya
 msgid "Tarih:"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__tax
+msgid "Tax"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1497,6 +1567,7 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_pending_changeset_changes
@@ -1509,6 +1580,7 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_pending_changesets
@@ -1521,6 +1593,7 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_changesets
@@ -1584,6 +1657,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__user_can_see_changeset

--- a/altinkaya_reports/i18n/en_US.po
+++ b/altinkaya_reports/i18n/en_US.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-02 06:13+0000\n"
-"PO-Revision-Date: 2026-02-02 06:13+0000\n"
+"POT-Creation-Date: 2026-06-01 05:18+0000\n"
+"PO-Revision-Date: 2026-06-01 05:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -586,6 +586,12 @@ msgid "AT,646,101,58,58,0,0E,0,0,"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Account"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 msgid "Account:"
@@ -609,6 +615,16 @@ msgstr ""
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 msgid "Amount"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_tl
+msgid "Amount (TL)"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_usd
+msgid "Amount (USD)"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -712,6 +728,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__cancelled
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__cancel
 msgid "Cancelled"
 msgstr ""
 
@@ -733,6 +750,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_change_ids
@@ -744,6 +762,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_ids
@@ -778,6 +797,11 @@ msgid "Commission Type"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__company_id
+msgid "Company"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__concluded
 msgid "Concluded"
 msgstr ""
@@ -795,6 +819,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_changesets
@@ -806,6 +831,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changeset_changes
@@ -817,6 +843,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changesets
@@ -836,6 +863,7 @@ msgid "Created on"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__credit
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Credit"
@@ -847,13 +875,16 @@ msgid "DESİ"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__date
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Date"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__debit
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Debit"
@@ -911,17 +942,14 @@ msgid "Desc."
 msgstr ""
 
 #. module: altinkaya_reports
-#: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__manual_discount_percentage
-msgid "Difference between actual price and pricelist price in percentage."
-msgstr ""
-
-#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__display_name
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__display_name
 msgid "Display Name"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__draft
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__draft
 msgid "Draft"
 msgstr ""
 
@@ -943,6 +971,34 @@ msgid "Expected unit price according to pricelist, in USD."
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.actions.act_window,name:altinkaya_reports.action_expense_analysis_report
+#: model:ir.model,name:altinkaya_reports.model_expense_analysis_report
+#: model:ir.ui.menu,name:altinkaya_reports.menu_expense_analysis_report
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_graph
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_pivot
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Analysis"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_item_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Item"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_type_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Type"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_unit_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Unit"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Explanation"
 msgstr ""
@@ -955,6 +1011,11 @@ msgstr ""
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.altinkaya_mrp_report_data_table
 msgid "Gerçekleşen Miktar"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Group By"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -974,6 +1035,7 @@ msgid "Hesabı:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__id
 msgid "ID"
 msgstr ""
@@ -1026,6 +1088,7 @@ msgid ""
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report____last_update
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard____last_update
 msgid "Last Modified on"
 msgstr ""
@@ -1057,7 +1120,6 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__manual_discount_percentage
-#: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__manual_discount_percentage
 msgid "Manual Discount Percentage"
 msgstr ""
 
@@ -1138,6 +1200,7 @@ msgid "Paid"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
 msgid "Partner"
 msgstr ""
@@ -1200,6 +1263,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__partner_ids
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_utm_campaign_form_inherit_altinkaya
 msgid "Partners"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__posted
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Posted"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1330,6 +1399,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__smart_search
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__smart_search
@@ -1345,6 +1415,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__state_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__state
 msgid "State"
 msgstr ""
 
@@ -1420,6 +1491,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changeset_changes
@@ -1431,6 +1503,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changesets
@@ -1442,6 +1515,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_changesets
@@ -1453,6 +1527,16 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__acquirer_id
 msgid "The user who acquired this customer."
+msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "This Year"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_tree
+msgid "Total"
 msgstr ""
 
 #. module: altinkaya_reports
@@ -1494,6 +1578,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__user_can_see_changeset

--- a/altinkaya_reports/i18n/en_US.po
+++ b/altinkaya_reports/i18n/en_US.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 05:18+0000\n"
-"PO-Revision-Date: 2026-06-01 05:18+0000\n"
+"POT-Creation-Date: 2026-06-01 09:32+0000\n"
+"PO-Revision-Date: 2026-06-01 09:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -981,18 +981,21 @@ msgid "Expense Analysis"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_item_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_item_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Item"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_type_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_type_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Type"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_unit_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_unit_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Unit"

--- a/altinkaya_reports/i18n/en_US.po
+++ b/altinkaya_reports/i18n/en_US.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 10:38+0000\n"
-"PO-Revision-Date: 2026-06-01 10:38+0000\n"
+"POT-Creation-Date: 2026-06-02 08:51+0000\n"
+"PO-Revision-Date: 2026-06-02 08:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -589,6 +589,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__account_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Account"
 msgstr ""
 
@@ -685,6 +686,11 @@ msgid "Balance"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__bank
+msgid "Bank"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_payment_receipt_document_altinkaya
 msgid "Banka Ödemesi"
 msgstr ""
@@ -757,6 +763,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__category
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Category"
 msgstr ""
 
@@ -788,6 +795,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__channel
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Channel"
 msgstr ""
 
@@ -899,6 +907,11 @@ msgid "Credit"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__credit_card
+msgid "Credit Card"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__customer_collection
 msgid "Customer Collection"
 msgstr ""
@@ -915,6 +928,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Date"
 msgstr ""
 
@@ -1054,6 +1068,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Group By"
 msgstr ""
 
@@ -1254,6 +1269,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__partner_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Partner"
 msgstr ""
 
@@ -1318,7 +1334,12 @@ msgid "Partners"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.actions.act_window,name:altinkaya_reports.action_payment_analysis_report
 #: model:ir.model,name:altinkaya_reports.model_payment_analysis_report
+#: model:ir.ui.menu,name:altinkaya_reports.menu_payment_analysis_report
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_graph
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_pivot
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Payment Analysis"
 msgstr ""
 
@@ -1607,11 +1628,13 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "This Year"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_tree
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_tree
 msgid "Total"
 msgstr ""
 
@@ -1642,8 +1665,18 @@ msgid "UTM Campaign"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_subtotal_abs
+msgid "Untaxed Total Abs"
+msgstr ""
+
+#. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_total_usd
 msgid "Untaxed Total USD"
+msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_total_usd_abs
+msgid "Untaxed Total USD Abs"
 msgstr ""
 
 #. module: altinkaya_reports

--- a/altinkaya_reports/i18n/tr.po
+++ b/altinkaya_reports/i18n/tr.po
@@ -1230,7 +1230,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model,name:altinkaya_reports.model_account_invoice_report
 msgid "Invoices Statistics"
-msgstr "Fatura İsatistikleri"
+msgstr "Fatura İstatistikleri"
 
 #. module: altinkaya_reports
 #: model:ir.model,name:altinkaya_reports.model_account_move_line

--- a/altinkaya_reports/i18n/tr.po
+++ b/altinkaya_reports/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 10:38+0000\n"
-"PO-Revision-Date: 2026-06-01 10:38+0000\n"
+"POT-Creation-Date: 2026-06-02 08:51+0000\n"
+"PO-Revision-Date: 2026-06-02 08:51+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -716,6 +716,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__account_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Account"
 msgstr "Hesap"
 
@@ -812,6 +813,11 @@ msgid "Balance"
 msgstr "Bakiye"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__bank
+msgid "Bank"
+msgstr "Banka"
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_payment_receipt_document_altinkaya
 msgid "Banka Ödemesi"
 msgstr ""
@@ -884,6 +890,7 @@ msgstr "Nakit"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__category
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Category"
 msgstr "Kategori"
 
@@ -915,6 +922,7 @@ msgstr "Değişiklikler"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__channel
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Channel"
 msgstr "Kanal"
 
@@ -1026,6 +1034,11 @@ msgid "Credit"
 msgstr "Alacak"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__credit_card
+msgid "Credit Card"
+msgstr "Kredi Kartı"
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__customer_collection
 msgid "Customer Collection"
 msgstr "Müşteri Tahsilatı"
@@ -1042,6 +1055,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Date"
 msgstr "Tarih"
 
@@ -1181,6 +1195,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Group By"
 msgstr "Grupla"
 
@@ -1370,7 +1385,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__pos
 msgid "POS"
-msgstr "POS"
+msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__paid
@@ -1381,6 +1396,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__partner_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Partner"
 msgstr "İş Ortağı"
 
@@ -1445,7 +1461,12 @@ msgid "Partners"
 msgstr "İş Ortakları"
 
 #. module: altinkaya_reports
+#: model:ir.actions.act_window,name:altinkaya_reports.action_payment_analysis_report
 #: model:ir.model,name:altinkaya_reports.model_payment_analysis_report
+#: model:ir.ui.menu,name:altinkaya_reports.menu_payment_analysis_report
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_graph
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_pivot
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "Payment Analysis"
 msgstr "Ödeme Analizi"
 
@@ -1734,11 +1755,13 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_search
 msgid "This Year"
 msgstr "Bu Yıl"
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_tree
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_payment_analysis_report_tree
 msgid "Total"
 msgstr "Toplam"
 
@@ -1769,9 +1792,19 @@ msgid "UTM Campaign"
 msgstr "UTM kampanyası"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_subtotal_abs
+msgid "Untaxed Total Abs"
+msgstr "Toplam (Mutlak)"
+
+#. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_total_usd
 msgid "Untaxed Total USD"
 msgstr "Toplam USD"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__price_total_usd_abs
+msgid "Untaxed Total USD Abs"
+msgstr "Toplam USD (Mutlak)"
 
 #. module: altinkaya_reports
 #: model:ir.model,name:altinkaya_reports.model_res_users

--- a/altinkaya_reports/i18n/tr.po
+++ b/altinkaya_reports/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 05:18+0000\n"
-"PO-Revision-Date: 2026-06-01 05:18+0000\n"
+"POT-Creation-Date: 2026-06-01 09:32+0000\n"
+"PO-Revision-Date: 2026-06-01 09:32+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1108,18 +1108,21 @@ msgid "Expense Analysis"
 msgstr "Gider Analizi"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_item_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_item_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Item"
 msgstr "Gider Kalemi"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_type_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_type_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Type"
 msgstr "Harcama Türü"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__expense_unit_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_unit_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Expense Unit"

--- a/altinkaya_reports/i18n/tr.po
+++ b/altinkaya_reports/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-02 06:13+0000\n"
-"PO-Revision-Date: 2026-02-02 06:13+0000\n"
+"POT-Creation-Date: 2026-06-01 05:18+0000\n"
+"PO-Revision-Date: 2026-06-01 05:18+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -713,6 +713,12 @@ msgid "AT,646,101,58,58,0,0E,0,0,"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Account"
+msgstr "Hesap"
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 msgid "Account:"
@@ -737,6 +743,16 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 msgid "Amount"
 msgstr "Tutar"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_tl
+msgid "Amount (TL)"
+msgstr "Tutar (TL)"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_usd
+msgid "Amount (USD)"
+msgstr "Tutar (USD)"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__kdv_amount
@@ -839,8 +855,9 @@ msgstr "İptal"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__cancelled
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__cancel
 msgid "Cancelled"
-msgstr ""
+msgstr "İptal Edildi"
 
 #. module: altinkaya_reports
 #: model:mail.template,subject:altinkaya_reports.email_template_edi_send_statement
@@ -860,6 +877,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_change_ids
@@ -871,6 +889,7 @@ msgstr "Changeset Değişiklikleri"
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_ids
@@ -905,6 +924,11 @@ msgid "Commission Type"
 msgstr "Komisyon Türü"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__company_id
+msgid "Company"
+msgstr "Şirket"
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__concluded
 msgid "Concluded"
 msgstr "Sonuçlandı"
@@ -912,7 +936,7 @@ msgstr "Sonuçlandı"
 #. module: altinkaya_reports
 #: model:ir.model,name:altinkaya_reports.model_res_partner
 msgid "Contact"
-msgstr "İletişim"
+msgstr "Kontak"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__context_def_label_printer
@@ -922,6 +946,7 @@ msgstr "Varsayılan Etiket Yazıcısı"
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_changesets
@@ -933,6 +958,7 @@ msgstr "Sayım Değişiklik Setleri"
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changeset_changes
@@ -944,6 +970,7 @@ msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changesets
@@ -963,6 +990,7 @@ msgid "Created on"
 msgstr "Oluşturulma"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__credit
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Credit"
@@ -974,13 +1002,16 @@ msgid "DESİ"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__date
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Date"
 msgstr "Tarih"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__debit
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Debit"
@@ -1038,19 +1069,16 @@ msgid "Desc."
 msgstr "Azalan"
 
 #. module: altinkaya_reports
-#: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__manual_discount_percentage
-msgid "Difference between actual price and pricelist price in percentage."
-msgstr ""
-
-#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__display_name
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__display_name
 msgid "Display Name"
 msgstr "Görünüm Adı"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__draft
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__draft
 msgid "Draft"
-msgstr ""
+msgstr "Taslak"
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
@@ -1070,6 +1098,34 @@ msgid "Expected unit price according to pricelist, in USD."
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.actions.act_window,name:altinkaya_reports.action_expense_analysis_report
+#: model:ir.model,name:altinkaya_reports.model_expense_analysis_report
+#: model:ir.ui.menu,name:altinkaya_reports.menu_expense_analysis_report
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_graph
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_pivot
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Analysis"
+msgstr "Gider Analizi"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_item_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Item"
+msgstr "Gider Kalemi"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_type_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Type"
+msgstr "Harcama Türü"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__expense_unit_id
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Expense Unit"
+msgstr "Birim"
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
 msgid "Explanation"
 msgstr "Açıklama"
@@ -1083,6 +1139,11 @@ msgstr "Faks:"
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.altinkaya_mrp_report_data_table
 msgid "Gerçekleşen Miktar"
 msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Group By"
+msgstr "Grupla"
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.altinkaya_mrp_report_data_table
@@ -1101,6 +1162,7 @@ msgid "Hesabı:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__id
 msgid "ID"
 msgstr ""
@@ -1153,6 +1215,7 @@ msgid ""
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report____last_update
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard____last_update
 msgid "Last Modified on"
 msgstr "Son Güncelleme"
@@ -1184,7 +1247,6 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__manual_discount_percentage
-#: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__manual_discount_percentage
 msgid "Manual Discount Percentage"
 msgstr "Manuel İndirim Yüzdesi"
 
@@ -1265,6 +1327,7 @@ msgid "Paid"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
 msgid "Partner"
 msgstr "İş Ortağı"
@@ -1328,6 +1391,12 @@ msgstr "Cari"
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_utm_campaign_form_inherit_altinkaya
 msgid "Partners"
 msgstr "İş Ortakları"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__posted
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "Posted"
+msgstr "Kaydedildi"
 
 #. module: altinkaya_reports
 #. odoo-python
@@ -1457,6 +1526,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__smart_search
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__smart_search
@@ -1472,6 +1542,7 @@ msgstr "Başlangıç Tarihi"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__state_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__state
 msgid "State"
 msgstr "Durum"
 
@@ -1547,6 +1618,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changeset_changes
@@ -1558,6 +1630,7 @@ msgstr "Bu kaydın bekleyen değişiklik sayısı"
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changesets
@@ -1569,6 +1642,7 @@ msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__count_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_changesets
@@ -1581,6 +1655,16 @@ msgstr "Bu kaydın toplam değişiklik seti sayısı"
 #: model:ir.model.fields,help:altinkaya_reports.field_account_invoice_report__acquirer_id
 msgid "The user who acquired this customer."
 msgstr ""
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
+msgid "This Year"
+msgstr "Bu Yıl"
+
+#. module: altinkaya_reports
+#: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_tree
+msgid "Total"
+msgstr "Toplam"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,help:altinkaya_reports.field_account_move_line__kdv_amount
@@ -1616,11 +1700,12 @@ msgstr "Toplam USD"
 #. module: altinkaya_reports
 #: model:ir.model,name:altinkaya_reports.model_res_users
 msgid "User"
-msgstr "Kullanıcılar"
+msgstr "Kullanıcı"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__user_can_see_changeset

--- a/altinkaya_reports/i18n/tr.po
+++ b/altinkaya_reports/i18n/tr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-01 09:32+0000\n"
-"PO-Revision-Date: 2026-06-01 09:32+0000\n"
+"POT-Creation-Date: 2026-06-01 10:38+0000\n"
+"PO-Revision-Date: 2026-06-01 10:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -714,6 +714,7 @@ msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__account_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__account_id
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_expense_analysis_report_search
 msgid "Account"
 msgstr "Hesap"
@@ -746,11 +747,13 @@ msgstr "Tutar"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_tl
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__amount_tl
 msgid "Amount (TL)"
 msgstr "Tutar (TL)"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__balance_usd
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__amount_usd
 msgid "Amount (USD)"
 msgstr "Tutar (USD)"
 
@@ -875,11 +878,22 @@ msgid "Cari:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__cash
+msgid "Cash"
+msgstr "Nakit"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__category
+msgid "Category"
+msgstr "Kategori"
+
+#. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_move_line__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_change_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__changeset_change_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__changeset_change_ids
@@ -892,11 +906,22 @@ msgstr "Changeset Değişiklikleri"
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__changeset_ids
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__changeset_ids
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__changeset_ids
 msgid "Changesets"
 msgstr "Değişiklikler"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__channel
+msgid "Channel"
+msgstr "Kanal"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__cheque
+msgid "Cheque"
+msgstr "Çek"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__sale_commission_amount
@@ -925,6 +950,7 @@ msgstr "Komisyon Türü"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__company_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__company_id
 msgid "Company"
 msgstr "Şirket"
 
@@ -949,6 +975,7 @@ msgstr "Varsayılan Etiket Yazıcısı"
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_changesets
@@ -961,6 +988,7 @@ msgstr "Sayım Değişiklik Setleri"
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_pending_changeset_changes
@@ -973,6 +1001,7 @@ msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__count_pending_changesets
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__count_pending_changesets
@@ -997,12 +1026,18 @@ msgid "Credit"
 msgstr "Alacak"
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__customer_collection
+msgid "Customer Collection"
+msgstr "Müşteri Tahsilatı"
+
+#. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_delivery_carrier_report_data
 msgid "DESİ"
 msgstr ""
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__date
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__date
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_currency_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_en_try_table
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_partner_statement_wizard_document
@@ -1071,6 +1106,7 @@ msgstr "Azalan"
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__display_name
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__display_name
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__display_name
 msgid "Display Name"
 msgstr "Görünüm Adı"
 
@@ -1167,6 +1203,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__id
 msgid "ID"
 msgstr ""
 
@@ -1220,6 +1257,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report____last_update
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard____last_update
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report____last_update
 msgid "Last Modified on"
 msgstr "Son Güncelleme"
 
@@ -1232,6 +1270,11 @@ msgstr "Son Güncelleyen"
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__write_date
 msgid "Last Updated on"
 msgstr "Son Güncelleme"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__loan
+msgid "Loan"
+msgstr "Kredi"
 
 #. module: altinkaya_reports
 #: model:ir.actions.report,name:altinkaya_reports.label_stock_location
@@ -1325,6 +1368,11 @@ msgid "P.12.F.03 Yazdıran:"
 msgstr ""
 
 #. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__channel__pos
+msgid "POS"
+msgstr "POS"
+
+#. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__account_invoice_report__sale_commission_state__paid
 msgid "Paid"
 msgstr ""
@@ -1332,6 +1380,7 @@ msgstr ""
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__partner_id
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__partner_id
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__partner_id
 msgid "Partner"
 msgstr "İş Ortağı"
 
@@ -1394,6 +1443,16 @@ msgstr "Cari"
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.view_utm_campaign_form_inherit_altinkaya
 msgid "Partners"
 msgstr "İş Ortakları"
+
+#. module: altinkaya_reports
+#: model:ir.model,name:altinkaya_reports.model_payment_analysis_report
+msgid "Payment Analysis"
+msgstr "Ödeme Analizi"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__personnel
+msgid "Personnel"
+msgstr "Personel"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields.selection,name:altinkaya_reports.selection__expense_analysis_report__state__posted
@@ -1532,6 +1591,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__smart_search
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__smart_search
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__smart_search
@@ -1548,6 +1608,11 @@ msgstr "Başlangıç Tarihi"
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__state
 msgid "State"
 msgstr "Durum"
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__supplier_payment
+msgid "Supplier Payment"
+msgstr "Tedarikçi Ödemesi"
 
 #. module: altinkaya_reports
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_payment_receipt_document_altinkaya
@@ -1583,6 +1648,11 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:altinkaya_reports.report_picking_altinkaya
 msgid "Tarih:"
 msgstr ""
+
+#. module: altinkaya_reports
+#: model:ir.model.fields.selection,name:altinkaya_reports.selection__payment_analysis_report__category__tax
+msgid "Tax"
+msgstr "Vergi"
 
 #. module: altinkaya_reports
 #: model:ir.model.fields,field_description:altinkaya_reports.field_account_invoice_report__total_tax
@@ -1624,6 +1694,7 @@ msgstr ""
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changeset_changes
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_pending_changeset_changes
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_pending_changeset_changes
@@ -1636,6 +1707,7 @@ msgstr "Bu kaydın bekleyen değişiklik sayısı"
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_pending_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_pending_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_pending_changesets
@@ -1648,6 +1720,7 @@ msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
 #: model:ir.model.fields,help:altinkaya_reports.field_expense_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_ir_actions_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_partner_statement_wizard__count_changesets
+#: model:ir.model.fields,help:altinkaya_reports.field_payment_analysis_report__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_partner__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_res_users__count_changesets
 #: model:ir.model.fields,help:altinkaya_reports.field_utm_campaign__count_changesets
@@ -1711,6 +1784,7 @@ msgstr "Kullanıcı"
 #: model:ir.model.fields,field_description:altinkaya_reports.field_expense_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_ir_actions_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_partner_statement_wizard__user_can_see_changeset
+#: model:ir.model.fields,field_description:altinkaya_reports.field_payment_analysis_report__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_partner__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_res_users__user_can_see_changeset
 #: model:ir.model.fields,field_description:altinkaya_reports.field_utm_campaign__user_can_see_changeset

--- a/altinkaya_reports/report/account_invoice_report.py
+++ b/altinkaya_reports/report/account_invoice_report.py
@@ -108,6 +108,9 @@ class AccountInvoiceReport(models.Model):
     )
     invoice_count = fields.Integer(string="Partner Invoice Count", readonly=True)
     industry_id = fields.Many2one("res.partner.industry", readonly=True)
+    expense_item_id = fields.Many2one("expense.item", readonly=True)
+    expense_unit_id = fields.Many2one("expense.unit", readonly=True)
+    expense_type_id = fields.Many2one("expense.type", readonly=True)
     # Fields from account.move.line
     origin_price_usd = fields.Float(
         string="Pricelist Price USD",
@@ -134,6 +137,9 @@ class AccountInvoiceReport(models.Model):
             so_utm.sale_campaign_id,
             so_utm.sale_medium_id,
             partner.create_date as partner_create_date,
+            account.expense_item_id as expense_item_id,
+            account.expense_unit_id as expense_unit_id,
+            account.expense_type_id as expense_type_id,
             line.kdv_amount as total_tax,
             template.id as product_tmpl_id,
             -line.balance * currency_table.rate * move.usd_rate AS price_total_usd,

--- a/altinkaya_reports/report/account_invoice_report.py
+++ b/altinkaya_reports/report/account_invoice_report.py
@@ -26,6 +26,8 @@ class AccountInvoiceReport(models.Model):
     )
     state_id = fields.Many2one("res.country.state", readonly=True)
     price_total_usd = fields.Float(string="Untaxed Total USD", readonly=True)
+    price_total_usd_abs = fields.Float(string="Untaxed Total USD Abs", readonly=True)
+    price_subtotal_abs = fields.Float(string="Untaxed Total Abs", readonly=True)
     total_tax = fields.Float(string="Tax Total", readonly=True)
     price_average_usd = fields.Float(
         string="Average Price USD", readonly=True, group_operator="avg"
@@ -143,6 +145,10 @@ class AccountInvoiceReport(models.Model):
             line.kdv_amount as total_tax,
             template.id as product_tmpl_id,
             -line.balance * currency_table.rate * move.usd_rate AS price_total_usd,
+            abs(
+                line.balance * currency_table.rate * move.usd_rate
+            ) AS price_total_usd_abs,
+            abs(line.balance * currency_table.rate) AS price_subtotal_abs,
             -COALESCE(
                -- Average line price
                (line.balance / NULLIF(line.quantity, 0.0)) *

--- a/altinkaya_reports/report/expense_analysis_report.py
+++ b/altinkaya_reports/report/expense_analysis_report.py
@@ -1,0 +1,61 @@
+from odoo import fields, models
+
+
+class ExpenseAnalysisReport(models.Model):
+    _name = "expense.analysis.report"
+    _description = "Expense Analysis"
+    _auto = False
+    _order = "date desc"
+
+    date = fields.Date(readonly=True)
+    state = fields.Selection(
+        [("draft", "Draft"), ("posted", "Posted"), ("cancel", "Cancelled")],
+        readonly=True,
+    )
+    account_id = fields.Many2one("account.account", readonly=True)
+    expense_item_id = fields.Many2one("expense.item", readonly=True)
+    expense_unit_id = fields.Many2one("expense.unit", readonly=True)
+    expense_type_id = fields.Many2one("expense.type", readonly=True)
+    partner_id = fields.Many2one("res.partner", readonly=True)
+    company_id = fields.Many2one("res.company", readonly=True)
+    balance_tl = fields.Float(string="Amount (TL)", readonly=True)
+    balance_usd = fields.Float(string="Amount (USD)", readonly=True)
+    debit = fields.Float(readonly=True)
+    credit = fields.Float(readonly=True)
+
+    @property
+    def _table_query(self):
+        return f"{self._select()} {self._from()} {self._where()}"
+
+    def _select(self):
+        return """
+            SELECT
+                aml.id                                   AS id,
+                aml.date                                 AS date,
+                am.state                                 AS state,
+                aml.account_id                           AS account_id,
+                acc.expense_item_id                      AS expense_item_id,
+                acc.expense_unit_id                      AS expense_unit_id,
+                acc.expense_type_id                      AS expense_type_id,
+                aml.partner_id                           AS partner_id,
+                aml.company_id                           AS company_id,
+                aml.balance                              AS balance_tl,
+                aml.balance * COALESCE(am.usd_rate, 1.0) AS balance_usd,
+                aml.debit                                AS debit,
+                aml.credit                               AS credit
+        """
+
+    def _from(self):
+        return """
+            FROM account_move_line aml
+            JOIN account_account acc ON acc.id = aml.account_id
+            JOIN account_move am ON am.id = aml.move_id
+        """
+
+    def _where(self):
+        return """
+            WHERE aml.display_type NOT IN ('line_section', 'line_note')
+              AND (acc.expense_item_id IS NOT NULL
+                   OR acc.expense_unit_id IS NOT NULL
+                   OR acc.expense_type_id IS NOT NULL)
+        """

--- a/altinkaya_reports/report/payment_analysis_report.py
+++ b/altinkaya_reports/report/payment_analysis_report.py
@@ -75,13 +75,35 @@ class PaymentAnalysisReport(models.Model):
                       WHERE c.move_id = aml.move_id AND ca.code ~ '^320'
                   )
                 UNION ALL
+                -- vergi: KDV + KDV2 paid to the tax office (liability pay-off)
                 SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
                        'tax', NULL, aml.debit
                 FROM account_move_line aml
                 JOIN account_account acc ON acc.id = aml.account_id
                 WHERE aml.parent_state = 'posted' AND aml.debit > 0
-                  AND acc.code IN ('770.01.12','770.01.13','770.01.14','770.01.16',
-                                   '770.01.17','770.50.06','770.50.20')
+                  AND acc.code ~ '^360\.01\.0[12]($|\.)'
+                UNION ALL
+                -- vergi: muhtasar (stopaj) personel disi (non-payroll accrual)
+                SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
+                       'tax', NULL, aml.credit
+                FROM account_move_line aml
+                JOIN account_account acc ON acc.id = aml.account_id
+                WHERE aml.parent_state = 'posted' AND aml.credit > 0
+                  AND acc.code ~ '^360\.03($|\.)'
+                  AND NOT EXISTS (
+                      SELECT 1 FROM account_move_line w
+                      JOIN account_account wa ON wa.id = w.account_id
+                      WHERE w.move_id = aml.move_id
+                        AND wa.code ~ '^(335|361|720|760)'
+                  )
+                UNION ALL
+                -- vergi: MTV + DAMGA + belediye (EMLAK / CEVRE) expense
+                SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
+                       'tax', NULL, aml.debit
+                FROM account_move_line aml
+                JOIN account_account acc ON acc.id = aml.account_id
+                WHERE aml.parent_state = 'posted' AND aml.debit > 0
+                  AND acc.code IN ('770.01.12','770.01.13','770.01.14')
                 UNION ALL
                 SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
                        'personnel', NULL, aml.debit

--- a/altinkaya_reports/report/payment_analysis_report.py
+++ b/altinkaya_reports/report/payment_analysis_report.py
@@ -22,7 +22,13 @@ class PaymentAnalysisReport(models.Model):
         readonly=True,
     )
     channel = fields.Selection(
-        [("cash", "Cash"), ("pos", "POS"), ("cheque", "Cheque")],
+        [
+            ("cash", "Cash"),
+            ("pos", "POS"),
+            ("cheque", "Cheque"),
+            ("bank", "Bank"),
+            ("credit_card", "Credit Card"),
+        ],
         readonly=True,
     )
     amount_tl = fields.Float(string="Amount (TL)", readonly=True)
@@ -30,7 +36,7 @@ class PaymentAnalysisReport(models.Model):
 
     @property
     def _table_query(self):
-        return """
+        return r"""
             SELECT b.id, b.date, b.partner_id, b.company_id, b.account_id,
                    b.category, b.channel, b.amount_tl,
                    b.amount_tl * COALESCE(usd.rate, 0.0) AS amount_usd
@@ -52,11 +58,22 @@ class PaymentAnalysisReport(models.Model):
                   )
                 UNION ALL
                 SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
-                       'supplier_payment', NULL, aml.debit
+                       'supplier_payment',
+                       CASE WHEN acc.code ~ '^309($|\.)' THEN 'credit_card'
+                            WHEN acc.code ~ '^(102|103)($|\.)' THEN 'bank'
+                            WHEN acc.code ~ '^100($|\.)' THEN 'cash'
+                            ELSE NULL END,
+                       aml.credit
                 FROM account_move_line aml
                 JOIN account_account acc ON acc.id = aml.account_id
-                WHERE aml.parent_state = 'posted' AND aml.debit > 0
-                  AND acc.code ~ '^320'
+                WHERE aml.parent_state = 'posted' AND aml.credit > 0
+                  AND acc.code ~ '^(100|102|103|309)($|\.)'
+                  AND acc.code !~ '^(100\.D|102\.99|102\.X)'
+                  AND EXISTS (
+                      SELECT 1 FROM account_move_line c
+                      JOIN account_account ca ON ca.id = c.account_id
+                      WHERE c.move_id = aml.move_id AND ca.code ~ '^320'
+                  )
                 UNION ALL
                 SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
                        'tax', NULL, aml.debit

--- a/altinkaya_reports/report/payment_analysis_report.py
+++ b/altinkaya_reports/report/payment_analysis_report.py
@@ -1,0 +1,91 @@
+from odoo import fields, models
+
+
+class PaymentAnalysisReport(models.Model):
+    _name = "payment.analysis.report"
+    _description = "Payment Analysis"
+    _auto = False
+    _order = "date desc"
+
+    date = fields.Date(readonly=True)
+    partner_id = fields.Many2one("res.partner", readonly=True)
+    company_id = fields.Many2one("res.company", readonly=True)
+    account_id = fields.Many2one("account.account", readonly=True)
+    category = fields.Selection(
+        [
+            ("customer_collection", "Customer Collection"),
+            ("supplier_payment", "Supplier Payment"),
+            ("tax", "Tax"),
+            ("personnel", "Personnel"),
+            ("loan", "Loan"),
+        ],
+        readonly=True,
+    )
+    channel = fields.Selection(
+        [("cash", "Cash"), ("pos", "POS"), ("cheque", "Cheque")],
+        readonly=True,
+    )
+    amount_tl = fields.Float(string="Amount (TL)", readonly=True)
+    amount_usd = fields.Float(string="Amount (USD)", readonly=True)
+
+    @property
+    def _table_query(self):
+        return """
+            SELECT b.id, b.date, b.partner_id, b.company_id, b.account_id,
+                   b.category, b.channel, b.amount_tl,
+                   b.amount_tl * COALESCE(usd.rate, 0.0) AS amount_usd
+            FROM (
+                SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
+                       'customer_collection' AS category,
+                       CASE WHEN acc.code ~ '^108' THEN 'pos'
+                            WHEN acc.code ~ '^101' THEN 'cheque'
+                            ELSE 'cash' END AS channel,
+                       aml.debit AS amount_tl
+                FROM account_move_line aml
+                JOIN account_account acc ON acc.id = aml.account_id
+                WHERE aml.parent_state = 'posted' AND aml.debit > 0
+                  AND acc.code ~ '^(100|101|102|108)'
+                  AND EXISTS (
+                      SELECT 1 FROM account_move_line c
+                      JOIN account_account ca ON ca.id = c.account_id
+                      WHERE c.move_id = aml.move_id AND ca.code ~ '^120'
+                  )
+                UNION ALL
+                SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
+                       'supplier_payment', NULL, aml.debit
+                FROM account_move_line aml
+                JOIN account_account acc ON acc.id = aml.account_id
+                WHERE aml.parent_state = 'posted' AND aml.debit > 0
+                  AND acc.code ~ '^320'
+                UNION ALL
+                SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
+                       'tax', NULL, aml.debit
+                FROM account_move_line aml
+                JOIN account_account acc ON acc.id = aml.account_id
+                WHERE aml.parent_state = 'posted' AND aml.debit > 0
+                  AND acc.code IN ('770.01.12','770.01.13','770.01.14','770.01.16',
+                                   '770.01.17','770.50.06','770.50.20')
+                UNION ALL
+                SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
+                       'personnel', NULL, aml.debit
+                FROM account_move_line aml
+                JOIN account_account acc ON acc.id = aml.account_id
+                WHERE aml.parent_state = 'posted' AND aml.debit > 0
+                  AND acc.code ~ '^(335|361)'
+                UNION ALL
+                SELECT aml.id, aml.date, aml.partner_id, aml.company_id, aml.account_id,
+                       'loan', NULL, aml.debit
+                FROM account_move_line aml
+                JOIN account_account acc ON acc.id = aml.account_id
+                WHERE aml.parent_state = 'posted' AND aml.debit > 0
+                  AND acc.code ~ '^303'
+            ) b
+            LEFT JOIN LATERAL (
+                SELECT r.rate FROM res_currency_rate r
+                WHERE r.currency_id = (SELECT id FROM res_currency WHERE name = 'USD')
+                  AND r.company_id = b.company_id
+                  AND r.name <= b.date
+                ORDER BY r.name DESC
+                LIMIT 1
+            ) usd ON TRUE
+        """

--- a/altinkaya_reports/security/ir.model.access.csv
+++ b/altinkaya_reports/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_partner_statement_wizard,access_partner_statement_wizard,model_partner_statement_wizard,base.group_user,1,0,0,0
+access_expense_analysis_report,expense.analysis.report,model_expense_analysis_report,account.group_account_user,1,0,0,0

--- a/altinkaya_reports/security/ir.model.access.csv
+++ b/altinkaya_reports/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_partner_statement_wizard,access_partner_statement_wizard,model_partner_statement_wizard,base.group_user,1,0,0,0
 access_expense_analysis_report,expense.analysis.report,model_expense_analysis_report,account.group_account_user,1,0,0,0
+access_payment_analysis_report,payment.analysis.report,model_payment_analysis_report,account.group_account_user,1,0,0,0

--- a/altinkaya_reports/views/account_invoice_report_views.xml
+++ b/altinkaya_reports/views/account_invoice_report_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="inherit_view_account_invoice_report_pivot_usd" model="ir.ui.view">
+        <field name="name">account.invoice.report.pivot.usd</field>
+        <field name="model">account.invoice.report</field>
+        <field name="inherit_id" ref="account.view_account_invoice_report_pivot" />
+        <field name="priority" eval="110" />
+        <field name="arch" type="xml">
+            <xpath expr="//pivot" position="inside">
+                <field name="price_total_usd" type="measure" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/altinkaya_reports/views/expense_analysis_report_views.xml
+++ b/altinkaya_reports/views/expense_analysis_report_views.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_expense_analysis_report_pivot" model="ir.ui.view">
+        <field name="name">expense.analysis.report.pivot</field>
+        <field name="model">expense.analysis.report</field>
+        <field name="arch" type="xml">
+            <pivot string="Expense Analysis" sample="1">
+                <field name="expense_item_id" type="row" />
+                <field name="date" interval="month" type="col" />
+                <field name="balance_tl" type="measure" />
+            </pivot>
+        </field>
+    </record>
+
+    <record id="view_expense_analysis_report_graph" model="ir.ui.view">
+        <field name="name">expense.analysis.report.graph</field>
+        <field name="model">expense.analysis.report</field>
+        <field name="arch" type="xml">
+            <graph string="Expense Analysis" type="bar" sample="1">
+                <field name="expense_item_id" />
+                <field name="balance_tl" type="measure" />
+            </graph>
+        </field>
+    </record>
+
+    <record id="view_expense_analysis_report_tree" model="ir.ui.view">
+        <field name="name">expense.analysis.report.tree</field>
+        <field name="model">expense.analysis.report</field>
+        <field name="arch" type="xml">
+            <tree create="0">
+                <field name="date" optional="show" />
+                <field name="account_id" optional="show" />
+                <field name="partner_id" optional="show" />
+                <field name="expense_item_id" optional="show" />
+                <field name="expense_unit_id" optional="show" />
+                <field name="expense_type_id" optional="show" />
+                <field name="balance_tl" sum="Total" optional="show" />
+                <field name="balance_usd" sum="Total" optional="hide" />
+                <field name="debit" sum="Total" optional="hide" />
+                <field name="credit" sum="Total" optional="hide" />
+                <field name="state" optional="hide" />
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="hide"
+                />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_expense_analysis_report_search" model="ir.ui.view">
+        <field name="name">expense.analysis.report.search</field>
+        <field name="model">expense.analysis.report</field>
+        <field name="arch" type="xml">
+            <search string="Expense Analysis">
+                <field name="account_id" />
+                <field name="partner_id" />
+                <field name="expense_item_id" />
+                <field name="expense_unit_id" />
+                <field name="expense_type_id" />
+                <filter
+                    name="posted"
+                    string="Posted"
+                    domain="[('state', '=', 'posted')]"
+                />
+                <filter
+                    name="thisyear"
+                    string="This Year"
+                    domain="['&amp;', ('date', '&gt;=', time.strftime('%Y-01-01')), ('date', '&lt;=', time.strftime('%Y-12-31'))]"
+                />
+                <separator />
+                <group expand="0" string="Group By">
+                    <filter
+                        name="group_expense_item"
+                        string="Expense Item"
+                        context="{'group_by': 'expense_item_id'}"
+                    />
+                    <filter
+                        name="group_expense_unit"
+                        string="Expense Unit"
+                        context="{'group_by': 'expense_unit_id'}"
+                    />
+                    <filter
+                        name="group_expense_type"
+                        string="Expense Type"
+                        context="{'group_by': 'expense_type_id'}"
+                    />
+                    <filter
+                        name="group_account"
+                        string="Account"
+                        context="{'group_by': 'account_id'}"
+                    />
+                    <filter
+                        name="group_date"
+                        string="Date"
+                        context="{'group_by': 'date'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_expense_analysis_report" model="ir.actions.act_window">
+        <field name="name">Expense Analysis</field>
+        <field name="res_model">expense.analysis.report</field>
+        <field name="view_mode">pivot,graph,tree</field>
+        <field name="search_view_id" ref="view_expense_analysis_report_search" />
+        <field
+            name="context"
+        >{'search_default_posted': 1, 'search_default_thisyear': 1, 'search_default_group_expense_item': 1}</field>
+    </record>
+
+    <menuitem
+        id="menu_expense_analysis_report"
+        name="Expense Analysis"
+        parent="account.menu_finance_reports"
+        action="action_expense_analysis_report"
+        groups="account.group_account_user"
+        sequence="90"
+    />
+</odoo>

--- a/altinkaya_reports/views/payment_analysis_report_views.xml
+++ b/altinkaya_reports/views/payment_analysis_report_views.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="view_payment_analysis_report_pivot" model="ir.ui.view">
+        <field name="name">payment.analysis.report.pivot</field>
+        <field name="model">payment.analysis.report</field>
+        <field name="arch" type="xml">
+            <pivot string="Payment Analysis" sample="1">
+                <field name="category" type="row" />
+                <field name="date" interval="month" type="col" />
+                <field name="amount_tl" type="measure" />
+            </pivot>
+        </field>
+    </record>
+
+    <record id="view_payment_analysis_report_graph" model="ir.ui.view">
+        <field name="name">payment.analysis.report.graph</field>
+        <field name="model">payment.analysis.report</field>
+        <field name="arch" type="xml">
+            <graph string="Payment Analysis" type="bar" sample="1">
+                <field name="category" />
+                <field name="amount_tl" type="measure" />
+            </graph>
+        </field>
+    </record>
+
+    <record id="view_payment_analysis_report_tree" model="ir.ui.view">
+        <field name="name">payment.analysis.report.tree</field>
+        <field name="model">payment.analysis.report</field>
+        <field name="arch" type="xml">
+            <tree create="0">
+                <field name="date" optional="show" />
+                <field name="partner_id" optional="show" />
+                <field name="account_id" optional="show" />
+                <field name="category" optional="show" />
+                <field name="channel" optional="show" />
+                <field name="amount_tl" sum="Total" optional="show" />
+                <field name="amount_usd" sum="Total" optional="hide" />
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="hide"
+                />
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_payment_analysis_report_search" model="ir.ui.view">
+        <field name="name">payment.analysis.report.search</field>
+        <field name="model">payment.analysis.report</field>
+        <field name="arch" type="xml">
+            <search string="Payment Analysis">
+                <field name="account_id" />
+                <field name="partner_id" />
+                <field name="category" />
+                <field name="channel" />
+                <filter
+                    name="thisyear"
+                    string="This Year"
+                    domain="['&amp;', ('date', '&gt;=', time.strftime('%Y-01-01')), ('date', '&lt;=', time.strftime('%Y-12-31'))]"
+                />
+                <separator />
+                <group expand="0" string="Group By">
+                    <filter
+                        name="group_category"
+                        string="Category"
+                        context="{'group_by': 'category'}"
+                    />
+                    <filter
+                        name="group_channel"
+                        string="Channel"
+                        context="{'group_by': 'channel'}"
+                    />
+                    <filter
+                        name="group_account"
+                        string="Account"
+                        context="{'group_by': 'account_id'}"
+                    />
+                    <filter
+                        name="group_partner"
+                        string="Partner"
+                        context="{'group_by': 'partner_id'}"
+                    />
+                    <filter
+                        name="group_date"
+                        string="Date"
+                        context="{'group_by': 'date'}"
+                    />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_payment_analysis_report" model="ir.actions.act_window">
+        <field name="name">Payment Analysis</field>
+        <field name="res_model">payment.analysis.report</field>
+        <field name="view_mode">pivot,graph,tree</field>
+        <field name="search_view_id" ref="view_payment_analysis_report_search" />
+        <field
+            name="context"
+        >{'search_default_thisyear': 1, 'search_default_group_category': 1}</field>
+    </record>
+
+    <menuitem
+        id="menu_payment_analysis_report"
+        name="Payment Analysis"
+        parent="account.menu_finance_reports"
+        action="action_payment_analysis_report"
+        groups="account.group_account_user"
+        sequence="91"
+    />
+</odoo>


### PR DESCRIPTION
## What

Adds expense classification to the chart of accounts and the reporting/dashboard layer that consumes it.

### altinkaya_account
- New lookup models: `expense.item`, `expense.unit`, `expense.type`
- New Many2one fields on `account.account`: `expense_item_id`, `expense_unit_id`, `expense_type_id`
- Fields on the account form, list (optional columns) and search group-by
- Accounting > Configuration menus to manage the three lists
- `en_US` / `tr` translations

### altinkaya_reports (now depends on altinkaya_account)
- New SQL-view model `expense.analysis.report` (`_auto=False` / `_table_query`) over `account_move_line` joined to `account.account` (classification) and `account.move` (state, USD rate). Exposes `balance_tl`, `balance_usd`, `debit`, `credit`, `date`, `state` and the three expense dimensions for move lines on classified accounts. Used as a Dashboard Ninja data source.
- New SQL-view model `payment.analysis.report` (`_auto=False` / `_table_query`, UNION ALL over `account_move_line`) classifying posted cash movements by purpose via a `category` field (customer collection / supplier payment / tax / personnel / loan), with a `channel` for the cash side. Customer collections are measured from the cash-debit side (channel cash / POS / cheque); supplier payments from the cash-credit side, isolated by an EXISTS-320 counterpart, with channel bank / cash / credit_card so the real cash-out can be split by payment method. Exposes `amount_tl` and `amount_usd` (TRY converted at line date via `res_currency_rate`). Drives the payment/cash-flow dashboard tiles.
- The `tax` category matches the business definition of "vergi ödemeleri" (KDV + KDV2 + muhtasar excl. payroll + MTV + DAMGA + EMLAK/ÇEVRE): KDV/KDV2 from the liability pay-off (debit 360.01.01 / 360.01.02), muhtasar from the accrual side (credit 360.03 on non-payroll moves, since the lump payment to the tax office cannot be split personnel vs non-personnel by account), MTV / DAMGA / belediye (emlak + çevre share one account) from the expense debit (770.01.14 / 770.01.12 / 770.01.13). An earlier draft summed 7 expense accounts only, missing KDV/muhtasar (~92% of tax paid); verified live (all-time 811K → 5.08M TL).
- "Expense Analysis" and "Payment Analysis" screens under **Accounting > Reporting**: pivot (default) + graph + tree + search, gated to `account.group_account_user`. (The Payment Analysis views also fix the Dashboard Ninja drilldown, which otherwise showed only the record id.)
- `expense_item_id` / `expense_unit_id` / `expense_type_id` also exposed on `account.invoice.report` (read from the joined account), so fatura dashboards can group/filter by the same classification.
- `price_total_usd_abs` / `price_subtotal_abs` on `account.invoice.report`: absolute (magnitude) of the untaxed totals. Core signs `out_refund` / `in_invoice` with `×-1` (so sales and returns net out), which makes the refund slice of a composition doughnut render as a negative percentage; the abs columns let those charts measure the magnitude.
- Turkish + en_US / .pot translations.

### Layering fix (upgrade-order bug this PR would otherwise expose)
`altinkaya_account`'s pivot inherit referenced `price_total_usd`, a field defined by `altinkaya_reports`. That violation was latent, but this PR's new `altinkaya_reports -> altinkaya_account` dependency fixes the load order so any upgrade pass touching `altinkaya_account` (e.g. `-u altinkaya_base`) re-validates the view before the field exists and aborts the registry load. Fixed by moving the measure into a new inherited pivot view inside `altinkaya_reports` (the field's owner); `altinkaya_account` now only removes the core `price_subtotal` measure. Combined pivot arch is unchanged.

## Why these additions (design rationale)

Every new model and field was checked against existing Odoo mechanisms before being added. Summary of the decisions, so reviewers can justify the footprint:

### Three lookup models (`expense.item` / `expense.unit` / `expense.type`) + the three `account.account` fields
The three dimensions are genuine shared classification axes, not per-account attributes: in the live DB 94 classified accounts map onto 22 distinct items / 25 units / 39 types (~4 accounts per value). Alternatives evaluated and rejected:
- **Free-text `Char` on the account**: values are shared and reused, so free text would lose referential integrity, allow typos, and break chart group-by.
- **`Selection` field**: 39 expense types are business-maintained; a Selection would need a code deploy every time accounting adds a value. Lookup models are editable in the UI.
- **`account.account.tag` (existing m2m tags)**: untyped and many-to-many, cannot cleanly model three orthogonal single-select dimensions, and group-by on m2m is awkward.
- **`account.group` (existing)**: a single code-prefix hierarchy, not three free dimensions.
- **`account.analytic.account` (existing)**: posting-time cost center with ~1.4% move-line coverage; reusing it would conflate analytic posting with a static account attribute and give incomplete data. The dedicated fields give 100% coverage on classified accounts.

The classification is stored on `account.account` (931 rows) rather than on `account_move_line` (~4M rows) on purpose: it is an attribute of the account, and keeping it off the move-line table avoids bloating the large table. The fields are indexed because the report joins and search group-by hit them.

### `expense.analysis.report` (SQL view, not stored columns)
Mirrors the core `account.invoice.report` pattern (`_auto=False` + `_table_query`). It reads the classification live from the joined account, so there is no data duplication and nothing is stored on the 4M-row move-line table. A plain stored model or extra columns on `account_move_line` would have been heavier for no benefit.

### `payment.analysis.report` (SQL view)
No existing model classifies cash movements by purpose: `account.payment` covers only part of these flows (tax / personnel / loan are journal/expense postings, not payment records), carries no USD amount, and has no purpose category. The report model adds TL + USD and a single `category` filter per metric. Category membership is defined by account-code sets in SQL because the isolation of real customer collections (a move that also has a 120 customer counterpart) is structural, not an account attribute. Known trade-off: adding accounts to those families requires editing the code sets; this is documented in the model.

### `account.invoice.report` fields
Read-only, pulled via a SQL join to the account (no new storage). Lets the existing invoice/fatura dashboards group and filter by the same classification. Null on sales-side accounts, which is expected.

## Notes
- Identifiers and source strings are English; Turkish is provided via `.po`.
- No data import in code: classification is populated manually (94 expense accounts already classified in the live DB and verified against the source workbook).

## Test
1. `-u altinkaya_account altinkaya_reports`
2. Account form/list/search: the 3 fields are editable; Accounting > Configuration > Expense Classification lists work.
3. Accounting > Reporting > Expense Analysis: pivot opens (Posted + This Year, grouped by Expense Item); graph / tree / group-by work.
4. Dashboard Ninja: build charts on `account.invoice.report`, `expense.analysis.report` or `payment.analysis.report` grouped by Expense Item / Unit / Type or by payment `category` / `channel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



