### PR TITLE
[codex] Skip mail workflows without recipient emails

### DIFF
--- a/delivery_integration_base/__manifest__.py
+++ b/delivery_integration_base/__manifest__.py
@@ -7,7 +7,7 @@
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "license": "AGPL-3",
     "category": "Delivery",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.1.1",
     "depends": [
         "stock",
         "delivery",

--- a/delivery_integration_base/migrations/16.0.1.1.1/post-migration.py
+++ b/delivery_integration_base/migrations/16.0.1.1.1/post-migration.py
@@ -1,0 +1,20 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Update delivery email recipient template after noupdate changes."""
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    template = env.ref(
+        "delivery_integration_base.delivery_mail_template",
+        raise_if_not_found=False,
+    )
+    if template:
+        template.write(
+            {
+                "email_to": False,
+                "partner_to": "{{ object._get_delivery_mail_partner().id or '' }}",
+            }
+        )

--- a/delivery_integration_base/models/stock_picking.py
+++ b/delivery_integration_base/models/stock_picking.py
@@ -1,8 +1,11 @@
 # # Copyright 2023 Yiğit Budak (https://github.com/yibudak)
 # # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import base64
+import logging
 
 from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
 
 
 class StockPicking(models.Model):
@@ -188,20 +191,34 @@ class StockPicking(models.Model):
                         content=base64.b64decode(doc.datas),
                     )
 
+    def _get_delivery_mail_partner(self):
+        """Return the partner that should receive delivery tracking emails."""
+        self.ensure_one()
+        if self.partner_id.email:
+            return self.partner_id
+        if self.sale_id.partner_id.email:
+            return self.sale_id.partner_id
+        return self.env["res.partner"]
+
     def button_mail_send(self):
         """
         Send the shipment status by email
         :return: boolean
         """
         mail_template = self.env.ref("delivery_integration_base.delivery_mail_template")
-        email = self.partner_id.email or self.sale_id.partner_id.email
-        if email and not self.mail_sent:
-            self.with_delay().message_post_with_template(mail_template.id)
-            self.write(
-                {
-                    "mail_sent": True,
-                }
-            )
+        for picking in self:
+            partner = picking._get_delivery_mail_partner()
+            if picking.mail_sent:
+                continue
+            if not partner:
+                _logger.info(
+                    "Skipping delivery email for picking %s without recipient email.",
+                    picking.name,
+                )
+                continue
+
+            picking.with_delay().message_post_with_template(mail_template.id)
+            picking.mail_sent = True
         return True
 
     def _add_delivery_cost_to_so(self):

--- a/delivery_integration_base/report/delivery_mail_template.xml
+++ b/delivery_integration_base/report/delivery_mail_template.xml
@@ -7,7 +7,10 @@
         ><![CDATA[
                 {{ object.company_id.name }} Picking (Ref {{ object.name or 'n/a' }})
             ]]></field>
-        <field name="email_to">{{ object.partner_id.email or '' }}</field>
+        <field name="email_to" />
+        <field
+            name="partner_to"
+        >{{ object._get_delivery_mail_partner().id or '' }}</field>
         <field name="model_id" ref="stock.model_stock_picking" />
         <field name="auto_delete" eval="True" />
         <field name="report_name">{{ (object.name or '').replace('/','_') }}</field>

--- a/sale_quotation_reminder/__manifest__.py
+++ b/sale_quotation_reminder/__manifest__.py
@@ -15,7 +15,7 @@
 
 {
     "name": "Sale Quotation Reminder",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "category": "Sales",
     "summary": "Automatic quotation follow-up reminders before expiration",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",

--- a/sale_quotation_reminder/data/mail_template_data.xml
+++ b/sale_quotation_reminder/data/mail_template_data.xml
@@ -12,7 +12,9 @@
         <field
             name="email_from"
         >{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
-        <field name="partner_to">{{ object.partner_id.id }}</field>
+        <field
+            name="partner_to"
+        >{{ object.partner_id.email and object.partner_id.id or '' }}</field>
         <field
             name="description"
         >Sent to customers as a reminder before their quotation expires</field>

--- a/sale_quotation_reminder/migrations/16.0.1.0.1/post-migration.py
+++ b/sale_quotation_reminder/migrations/16.0.1.0.1/post-migration.py
@@ -1,0 +1,17 @@
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Update quotation reminder recipient template after noupdate changes."""
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    template = env.ref(
+        "sale_quotation_reminder.email_template_quotation_reminder",
+        raise_if_not_found=False,
+    )
+    if template:
+        template.partner_to = (
+            "{{ object.partner_id.email and object.partner_id.id or '' }}"
+        )

--- a/sale_quotation_reminder/models/sale_order.py
+++ b/sale_quotation_reminder/models/sale_order.py
@@ -45,6 +45,14 @@ class SaleOrder(models.Model):
             return outgoing_emails[0]
         return False
 
+    def _mark_quotation_reminder_sent(self, reminder_type):
+        """Mark the given reminder stage as processed."""
+        self.ensure_one()
+        if reminder_type == "first":
+            self.first_reminder_mail_sent = True
+        else:
+            self.second_reminder_mail_sent = True
+
     def action_send_quotation_reminder(self, reminder_type="first"):
         """Send a quotation reminder email with threading headers.
 
@@ -52,6 +60,17 @@ class SaleOrder(models.Model):
             reminder_type: Either 'first' or 'second' to indicate which reminder.
         """
         self.ensure_one()
+        if not self.partner_id.email:
+            _logger.info(
+                "Skipping quotation reminder (%s) for %s because "
+                "partner %s has no email.",
+                reminder_type,
+                self.name,
+                self.partner_id.display_name,
+            )
+            self._mark_quotation_reminder_sent(reminder_type)
+            return False
+
         template = self.env.ref(
             "sale_quotation_reminder.email_template_quotation_reminder"
         )
@@ -63,13 +82,10 @@ class SaleOrder(models.Model):
             email_values["reply_to"] = original_msg.message_id
 
         template.send_mail(self.id, email_values=email_values, force_send=True)
-
-        if reminder_type == "first":
-            self.first_reminder_mail_sent = True
-        else:
-            self.second_reminder_mail_sent = True
+        self._mark_quotation_reminder_sent(reminder_type)
 
         _logger.info("Quotation reminder (%s) sent for %s", reminder_type, self.name)
+        return True
 
     @api.model
     def _cron_send_quotation_reminders(self):


### PR DESCRIPTION
## Summary
- make delivery tracking emails choose the same recipient partner they validate
- skip quotation reminders for customers without an email and mark the reminder stage processed
- update noupdate mail templates through module migrations so installed databases use guarded recipients

## Root Cause
Delivery and quotation templates generated partner recipients without requiring an email. Delivery also checked sale partner fallback email but the installed template still targeted the delivery partner, allowing no-email delivery contacts to become mail.mail recipients.

## Validation
- ../../venv/bin/python -m compileall delivery_integration_base/models/stock_picking.py sale_quotation_reminder/models/sale_order.py delivery_integration_base/migrations/16.0.1.1.1/post-migration.py sale_quotation_reminder/migrations/16.0.1.0.1/post-migration.py
- pre-commit run -a