### PR TITLE
[codex] Replace postmarker with official Postmark SDK

### DIFF
--- a/postmark_connector/README.rst
+++ b/postmark_connector/README.rst
@@ -13,7 +13,7 @@ email delivery and tracking.
 ## Requirements
 
 - Postmark account and server token
-- Python package: `postmarker`
+- Python package: `postmark-python`
 - OCA modules: `mail_tracking`, `queue_job`
 
 ## Installation
@@ -21,7 +21,7 @@ email delivery and tracking.
 1. Install Python dependency:
 
    ```bash
-   pip install postmarker
+   pip install postmark-python
    ```
 
 2. Install the module in Odoo
@@ -48,6 +48,10 @@ https://your-odoo-domain.com/mail/postmark/webhook
 ```
 
 Enable events: Delivery, Bounce, Open, Click, Spam Complaint
+
+Bounce and spam complaint events are mirrored into Odoo's email blacklist. During
+module upgrade, existing Postmark suppressions from the `outbound` message stream are
+also imported into `mail.blacklist`.
 
 ## Usage
 

--- a/postmark_connector/__manifest__.py
+++ b/postmark_connector/__manifest__.py
@@ -16,7 +16,7 @@
 
 {
     "name": "Postmark Connector",
-    "version": "16.0.0.1.0",
+    "version": "16.0.0.1.1",
     "license": "LGPL-3",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "author": "Ahmet Yiğit Budak, Altinkaya Enclosures",
@@ -24,7 +24,7 @@
     "depends": ["mail_tracking", "queue_job"],
     "external_dependencies": {
         "python": [
-            "postmarker",
+            "postmark",
         ]
     },
     "data": [],

--- a/postmark_connector/controllers/main.py
+++ b/postmark_connector/controllers/main.py
@@ -36,8 +36,17 @@ class PostmarkController(http.Controller):
         message_id = data.get("MessageID")
         event_type = data.get("RecordType")
 
-        if not (message_id and event_type):
+        if not event_type:
             return False
+
+        if event_type in ("Bounce", "SpamComplaint"):
+            email = data.get("Email") or data.get("Recipient")
+            request.env["mail.mail"].sudo()._postmark_blacklist_emails(
+                [email], source=f"Postmark {event_type} webhook"
+            )
+
+        if not message_id:
+            return event_type in ("Bounce", "SpamComplaint")
 
         mail_message = (
             request.env["mail.message"]

--- a/postmark_connector/migrations/16.0.0.1.1/post-migration.py
+++ b/postmark_connector/migrations/16.0.0.1.1/post-migration.py
@@ -1,0 +1,15 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Import existing Postmark suppressions into Odoo's email blacklist."""
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    count = env["mail.mail"]._postmark_sync_suppressions("outbound")
+    _logger.info("Postmark suppression migration imported %s blacklist entries.", count)

--- a/postmark_connector/models/mail_mail.py
+++ b/postmark_connector/models/mail_mail.py
@@ -72,8 +72,25 @@ class MailMail(models.Model):
         with postmark_sync.ServerClient(api_key) as postmark:
             for email in outgoing:
                 try:
-                    recipients = email._get_postmark_recipients()
-                    params = email._prepare_postmark_email_params(recipients)
+                    (
+                        recipients,
+                        blacklisted_recipients,
+                        cc_recipients,
+                        blacklisted_cc_recipients,
+                    ) = email._postmark_prepare_recipient_values()
+                    if not recipients:
+                        if not blacklisted_recipients:
+                            raise MissingRecipientError(
+                                _("No recipient email address found.")
+                            )
+                        email._postmark_cancel_blacklisted_message(
+                            blacklisted_recipients
+                        )
+                        continue
+
+                    params = email._prepare_postmark_email_params(
+                        recipients, cc_recipients=cc_recipients
+                    )
                     response = postmark.outbound.send(params)
 
                     if not response.success or response.message != "OK":
@@ -97,8 +114,21 @@ class MailMail(models.Model):
                         email={"email_to": recipients},
                     )
                     self.env["mail.tracking.email"].sudo().create(tracking_vals)
+                    blacklisted_emails = (
+                        blacklisted_recipients + blacklisted_cc_recipients
+                    )
+                    failure_reason = (
+                        email._postmark_get_blacklisted_failure_reason(
+                            blacklisted_emails
+                        )
+                        if blacklisted_recipients
+                        else False
+                    )
+                    failure_type = "mail_bl" if blacklisted_recipients else None
                     email._postprocess_sent_message(
-                        success_pids=email.recipient_ids.filtered("email").ids
+                        success_pids=email._postmark_get_success_partners(recipients),
+                        failure_reason=failure_reason,
+                        failure_type=failure_type,
                     )
 
                     # Commit at each e-mail processed to avoid any errors
@@ -235,6 +265,117 @@ class MailMail(models.Model):
         )
         return count
 
+    def _postmark_prepare_recipient_values(self):
+        """Return Postmark To/Cc recipients with blacklisted addresses removed."""
+        self.ensure_one()
+        recipients, blacklisted_recipients = (
+            self._postmark_filter_blacklisted_recipients(
+                self._get_postmark_recipients()
+            )
+        )
+        cc_recipients, blacklisted_cc_recipients = (
+            self._postmark_filter_blacklisted_recipients(
+                self._get_postmark_cc_recipients()
+            )
+        )
+        blacklisted_emails = blacklisted_recipients + blacklisted_cc_recipients
+        if blacklisted_emails:
+            _logger.info(
+                "Skipping blacklisted Postmark recipient(s) for mail %s: %s",
+                self.id,
+                ", ".join(blacklisted_emails),
+            )
+        return (
+            recipients,
+            blacklisted_recipients,
+            cc_recipients,
+            blacklisted_cc_recipients,
+        )
+
+    def _postmark_filter_blacklisted_recipients(self, recipients):
+        """Remove active Odoo blacklist addresses from the recipient list."""
+        self.ensure_one()
+        normalized_by_recipient = [
+            (recipient, tools.email_normalize(recipient, strict=False))
+            for recipient in recipients
+        ]
+        normalized_emails = {
+            normalized_email
+            for _recipient, normalized_email in normalized_by_recipient
+            if normalized_email
+        }
+        if not normalized_emails:
+            return recipients, []
+
+        blacklisted_emails = set(
+            self.env["mail.blacklist"]
+            .sudo()
+            .search(
+                [
+                    ("active", "=", True),
+                    ("email", "in", list(normalized_emails)),
+                ]
+            )
+            .mapped("email")
+        )
+        if not blacklisted_emails:
+            return recipients, []
+
+        allowed_recipients = []
+        blacklisted_recipients = []
+        for recipient, normalized_email in normalized_by_recipient:
+            if normalized_email in blacklisted_emails:
+                blacklisted_recipients.append(recipient)
+            else:
+                allowed_recipients.append(recipient)
+        return allowed_recipients, blacklisted_recipients
+
+    def _postmark_cancel_blacklisted_message(self, blacklisted_recipients):
+        """Cancel a Postmark email when all To recipients are blacklisted."""
+        self.ensure_one()
+        failure_reason = self._postmark_get_blacklisted_failure_reason(
+            blacklisted_recipients
+        )
+        _logger.info(
+            "Skipping Postmark email %s because all recipients are blacklisted: %s",
+            self.id,
+            ", ".join(blacklisted_recipients),
+        )
+        self.write(
+            {
+                "state": "cancel",
+                "failure_type": "mail_bl",
+                "failure_reason": failure_reason,
+            }
+        )
+        self._postprocess_sent_message(
+            success_pids=[],
+            failure_reason=failure_reason,
+            failure_type="mail_bl",
+        )
+
+    def _postmark_get_success_partners(self, recipients):
+        """Return recipient partners that stayed in the Postmark To list."""
+        self.ensure_one()
+        normalized_recipients = {
+            tools.email_normalize(recipient, strict=False)
+            for recipient in recipients
+            if tools.email_normalize(recipient, strict=False)
+        }
+        return self.recipient_ids.filtered(
+            lambda partner: (
+                tools.email_normalize(partner.email, strict=False)
+                in normalized_recipients
+            )
+        )
+
+    @api.model
+    def _postmark_get_blacklisted_failure_reason(self, blacklisted_recipients):
+        """Return a user-facing failure reason for blacklisted recipients."""
+        return _("Blacklisted recipient email address(es): %s") % ", ".join(
+            blacklisted_recipients
+        )
+
     def _get_postmark_recipients(self):
         """Return unique non-empty recipient email strings for Postmark."""
         self.ensure_one()
@@ -250,7 +391,12 @@ class MailMail(models.Model):
                 recipients.append(email)
         return recipients
 
-    def _prepare_postmark_email_params(self, recipients=None):
+    def _get_postmark_cc_recipients(self):
+        """Return Cc recipient email strings for Postmark."""
+        self.ensure_one()
+        return tools.email_split_and_format(self.email_cc or "")
+
+    def _prepare_postmark_email_params(self, recipients=None, cc_recipients=None):
         """
         Prepare and creates the Postmark Email object
         :return: Dictionary with the email parameters
@@ -292,8 +438,10 @@ class MailMail(models.Model):
             raise MissingRecipientError(_("No recipient email address found."))
         params["to"] = ", ".join(recipients)
 
-        if self.email_cc:
-            params["cc"] = self.email_cc
+        if cc_recipients is None:
+            cc_recipients = self._get_postmark_cc_recipients()
+        if cc_recipients:
+            params["cc"] = ", ".join(cc_recipients)
 
         if self.attachment_ids:
             params["attachments"] = [

--- a/postmark_connector/models/mail_mail.py
+++ b/postmark_connector/models/mail_mail.py
@@ -14,12 +14,18 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
+import re
 from ast import literal_eval
 
-from odoo import _, fields, models
+from odoo import _, api, fields, models, tools
 from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
+
+POSTMARK_INACTIVE_ADDRESS_PATTERNS = (
+    r"Found inactive addresses: ([^.]+)",
+    r"inactive addresses: ([^.]+)",
+)
 
 
 class MissingRecipientError(Exception):
@@ -27,10 +33,17 @@ class MissingRecipientError(Exception):
 
 
 try:
-    from postmarker.core import PostmarkClient
+    import postmark.sync as postmark_sync
+    from postmark.exceptions import InactiveRecipientException, PostmarkAPIException
 except ImportError:
-    _logger.error("Please install the 'postmarker' Python package.")
-    PostmarkClient = None
+    _logger.error("Please install the 'postmark-python' Python package.")
+    postmark_sync = None
+
+    class InactiveRecipientException(Exception):
+        """Fallback class used when postmark-python is not installed."""
+
+    class PostmarkAPIException(Exception):
+        """Fallback class used when postmark-python is not installed."""
 
 
 class MailMail(models.Model):
@@ -38,7 +51,7 @@ class MailMail(models.Model):
 
     def send(self, auto_commit=False, raise_exception=False):
         """Override send to select the method to send the e-mail."""
-        if PostmarkClient and config.get("postmark_api_key"):
+        if postmark_sync and config.get("postmark_api_key"):
             return self.send_postmark()
         else:
             return super().send(
@@ -56,62 +69,171 @@ class MailMail(models.Model):
             )
             return
 
-        postmark = PostmarkClient(server_token=api_key)
-        for email in outgoing:
-            try:
-                params = email._prepare_postmark_email_params()
-                response = postmark.emails.send(**params)
+        with postmark_sync.ServerClient(api_key) as postmark:
+            for email in outgoing:
+                try:
+                    recipients = email._get_postmark_recipients()
+                    params = email._prepare_postmark_email_params(recipients)
+                    response = postmark.outbound.send(params)
 
-                if response["Message"] != "OK":
-                    raise Exception(response["Message"])
+                    if not response.success or response.message != "OK":
+                        inactive_emails = email._postmark_extract_inactive_recipients(
+                            response.message
+                        )
+                        email._postmark_blacklist_emails(
+                            inactive_emails, source="Postmark send response"
+                        )
+                        raise Exception(response.message)
 
-                email.write(
-                    {
-                        "postmark_message_id": response["MessageID"],
-                        "sent_date": fields.Datetime.now(),
-                        "state": "sent",
-                    }
-                )
-                tracking_vals = email._tracking_email_prepare(
-                    partner=fields.first(email.recipient_ids.filtered("email")),
-                    email={"email_to": params["To"]},
-                )
-                self.env["mail.tracking.email"].sudo().create(tracking_vals)
-                email._postprocess_sent_message(
-                    success_pids=email.recipient_ids.filtered("email").ids
-                )
+                    email.write(
+                        {
+                            "postmark_message_id": response.message_id,
+                            "sent_date": fields.Datetime.now(),
+                            "state": "sent",
+                        }
+                    )
+                    tracking_vals = email._tracking_email_prepare(
+                        partner=fields.first(email.recipient_ids.filtered("email")),
+                        email={"email_to": recipients},
+                    )
+                    self.env["mail.tracking.email"].sudo().create(tracking_vals)
+                    email._postprocess_sent_message(
+                        success_pids=email.recipient_ids.filtered("email").ids
+                    )
 
-                # Commit at each e-mail processed to avoid any errors
-                # invalidating state.
-                self.env.cr.commit()  # pylint: disable=invalid-commit
+                    # Commit at each e-mail processed to avoid any errors
+                    # invalidating state.
+                    self.env.cr.commit()  # pylint: disable=invalid-commit
 
-            except MissingRecipientError as exc:
-                failure_reason = str(exc)
-                _logger.info(
-                    "Skipping Postmark email %s without recipients: %s",
-                    email.id,
-                    failure_reason,
-                )
-                email.write({"state": "exception", "failure_reason": failure_reason})
-                email._postprocess_sent_message(
-                    success_pids=[],
-                    failure_reason=failure_reason,
-                    failure_type="mail_email_missing",
-                )
-                continue
+                except MissingRecipientError as exc:
+                    failure_reason = str(exc)
+                    _logger.info(
+                        "Skipping Postmark email %s without recipients: %s",
+                        email.id,
+                        failure_reason,
+                    )
+                    email.write(
+                        {"state": "exception", "failure_reason": failure_reason}
+                    )
+                    email._postprocess_sent_message(
+                        success_pids=[],
+                        failure_reason=failure_reason,
+                        failure_type="mail_email_missing",
+                    )
+                    continue
 
-            except Exception as exc:
-                failure_reason = str(exc)
-                _logger.error(
-                    "Error sending email %s with Postmark: %s", email.id, failure_reason
-                )
-                email.write({"state": "exception", "failure_reason": failure_reason})
-                email._postprocess_sent_message(
-                    success_pids=[],
-                    failure_reason=failure_reason,
-                    failure_type="mail_smtp",
-                )
-                continue
+                except InactiveRecipientException as exc:
+                    inactive_emails = email._postmark_get_exception_inactive_emails(exc)
+                    email._postmark_blacklist_emails(
+                        inactive_emails, source="Postmark inactive recipient"
+                    )
+                    email._postmark_handle_send_exception(
+                        exc,
+                        failure_type=(
+                            "mail_email_invalid" if inactive_emails else "mail_smtp"
+                        ),
+                    )
+                    continue
+
+                except PostmarkAPIException as exc:
+                    email._postmark_handle_send_exception(
+                        exc,
+                        failure_type=(
+                            "mail_email_invalid"
+                            if getattr(exc, "error_code", None) == 300
+                            else "mail_smtp"
+                        ),
+                    )
+                    continue
+
+                except Exception as exc:
+                    email._postmark_handle_send_exception(exc, failure_type="mail_smtp")
+                    continue
+
+    def _postmark_handle_send_exception(self, exc, failure_type):
+        """Store a Postmark send failure and update mail notifications."""
+        self.ensure_one()
+        failure_reason = str(exc)
+        _logger.error(
+            "Error sending email %s with Postmark: %s", self.id, failure_reason
+        )
+        self.write({"state": "exception", "failure_reason": failure_reason})
+        self._postprocess_sent_message(
+            success_pids=[],
+            failure_reason=failure_reason,
+            failure_type=failure_type,
+        )
+
+    @api.model
+    def _postmark_extract_inactive_recipients(self, message):
+        """Extract inactive recipient emails from Postmark response text."""
+        for pattern in POSTMARK_INACTIVE_ADDRESS_PATTERNS:
+            match = re.search(pattern, message or "")
+            if match:
+                return [
+                    email.strip()
+                    for email in match.group(1).split(",")
+                    if email.strip()
+                ]
+        return []
+
+    @api.model
+    def _postmark_get_exception_inactive_emails(self, exc):
+        """Return inactive recipients exposed by official SDK exceptions."""
+        return getattr(
+            exc, "inactive_recipients", []
+        ) or self._postmark_extract_inactive_recipients(str(exc))
+
+    @api.model
+    def _postmark_blacklist_emails(self, emails, source=False):
+        """Add emails to Odoo's blacklist and return the number added."""
+        normalized_emails = []
+        for email in emails:
+            normalized_email = tools.email_normalize(email, strict=False)
+            if normalized_email and normalized_email not in normalized_emails:
+                normalized_emails.append(normalized_email)
+
+        if not normalized_emails:
+            return 0
+
+        blacklist = self.env["mail.blacklist"].sudo()
+        for email in normalized_emails:
+            blacklist._add(email)
+
+        _logger.info(
+            "Blacklisted %s Postmark recipient(s)%s: %s",
+            len(normalized_emails),
+            f" from {source}" if source else "",
+            ", ".join(normalized_emails),
+        )
+        return len(normalized_emails)
+
+    @api.model
+    def _postmark_sync_suppressions(self, stream_id="outbound"):
+        """Import Postmark suppressions into Odoo's mail blacklist."""
+        api_key = config.get("postmark_api_key")
+        if not api_key:
+            _logger.info("Skipping Postmark suppression sync: no postmark_api_key.")
+            return 0
+        if not postmark_sync:
+            _logger.info("Skipping Postmark suppression sync: SDK is unavailable.")
+            return 0
+
+        try:
+            with postmark_sync.ServerClient(api_key) as postmark:
+                suppressions = postmark.suppressions.dump(stream_id)
+        except Exception as exc:
+            _logger.error("Postmark suppression sync failed: %s", exc)
+            return 0
+
+        emails = [suppression.email_address for suppression in suppressions]
+        count = self._postmark_blacklist_emails(
+            emails, source=f"Postmark {stream_id} suppression sync"
+        )
+        _logger.info(
+            "Imported %s Postmark suppression(s) from stream %s.", count, stream_id
+        )
+        return count
 
     def _get_postmark_recipients(self):
         """Return unique non-empty recipient email strings for Postmark."""
@@ -128,7 +250,7 @@ class MailMail(models.Model):
                 recipients.append(email)
         return recipients
 
-    def _prepare_postmark_email_params(self):
+    def _prepare_postmark_email_params(self, recipients=None):
         """
         Prepare and creates the Postmark Email object
         :return: Dictionary with the email parameters
@@ -140,9 +262,10 @@ class MailMail(models.Model):
         if "@altinkaya.com" not in str(msg_from):
             msg_from = '"ALTINKAYA" <erp@altinkaya.com>'
 
-        params["From"] = msg_from
+        params["sender"] = msg_from
+        params["message_stream"] = "outbound"
         if self.reply_to:
-            params["ReplyTo"] = self.reply_to
+            params["reply_to"] = self.reply_to
 
         headers = {"Message-Id": self.message_id}
         if self.headers:
@@ -154,27 +277,30 @@ class MailMail(models.Model):
                 )
                 pass
 
-        params["Headers"] = headers
+        params["headers"] = [
+            {"name": name, "value": str(value)} for name, value in headers.items()
+        ]
 
         # Debrand the body
-        params["HtmlBody"] = self.env["mail.render.mixin"].remove_href_odoo(
+        params["html_body"] = self.env["mail.render.mixin"].remove_href_odoo(
             str(self.body_content) or "", to_keep=self.body
         )
-        params["Subject"] = self.subject or _("(No subject)")
+        params["subject"] = self.subject or _("(No subject)")
 
-        params["To"] = self._get_postmark_recipients()
-        if not params["To"]:
+        recipients = recipients or self._get_postmark_recipients()
+        if not recipients:
             raise MissingRecipientError(_("No recipient email address found."))
+        params["to"] = ", ".join(recipients)
 
         if self.email_cc:
-            params["Cc"] = self.email_cc
+            params["cc"] = self.email_cc
 
         if self.attachment_ids:
-            params["Attachments"] = [
+            params["attachments"] = [
                 {
-                    "Name": attachment.name,
-                    "Content": attachment.datas.decode("utf-8"),
-                    "ContentType": attachment.mimetype,
+                    "name": attachment.name,
+                    "content": attachment.datas.decode("utf-8"),
+                    "content_type": attachment.mimetype,
                 }
                 for attachment in self.attachment_ids
             ]


### PR DESCRIPTION
## What changed

- Replace the unofficial `postmarker` client with the official `postmark-python` SDK.
- Send outbound mail through `postmark.sync.ServerClient(...).outbound.send(...)`.
- Convert Postmark payload construction to the official SDK field schema.
- Mirror inactive Postmark recipients into `mail.blacklist` from send failures and webhook bounce/spam complaint events.
- Add a module migration that imports existing Postmark suppressions from the `outbound` stream into `mail.blacklist`.
- Update the module version, Python dependency metadata, and README installation notes.

## Why

Postmark inactive and suppressed recipients were staying retryable in Odoo, so failed `mail.mail` records kept accumulating for addresses Postmark already refuses to deliver to. This makes Odoo learn those suppressions and skip future sends through the normal blacklist flow.

## Validation

- `../../venv/bin/python -m compileall postmark_connector`
- `pre-commit run -a`

OCR was not run.
