### PR TITLE
[ADD] ideasoft_xml_export: active field kill switch for backend

### DIFF
--- a/ideasoft_xml_export/models/ideasoft_backend.py
+++ b/ideasoft_xml_export/models/ideasoft_backend.py
@@ -25,6 +25,10 @@ class IdeasoftBackend(models.Model):
     _description = "Ideasoft Backend Configuration"
 
     name = fields.Char(required=True)
+    active = fields.Boolean(
+        default=True,
+        help="Archive to stop XML export generation without uninstalling the module.",
+    )
     product_domain = fields.Char(
         help="Domain to filter products for export. Example: [('sale_ok', '=', True)]",
     )

--- a/ideasoft_xml_export/views/ideasoft_backend_view.xml
+++ b/ideasoft_xml_export/views/ideasoft_backend_view.xml
@@ -15,7 +15,14 @@
                 </header>
 
                 <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
                     <group>
+                        <field name="active" invisible="1" />
                         <field name="name" />
                         <field name="access_token" />
                         <field name="xml_url" widget="url" />


### PR DESCRIPTION
## Why

The `Generate Ideasoft XML Files` cron runs every 2h and spawns a `generate_export_xml` queue job **per `ideasoft.backend` record**. That job builds the **entire product catalog** into one in-memory lxml tree (`_build_export_xml`, `search([])` with no batching), then `etree.tostring` serializes it — holding 2–3 full copies at once. On a large catalog this can push a worker past `limit_memory_hard` (8 GB) → worker SIGKILLed mid-job → `queue_job` re-queues the dead job → next worker dies the same way.

This pattern showed up in a production incident (2026-06-11): a worker crash-loop (same jobs re-queued ~80–90×) alongside repeated full Odoo restarts with no graceful shutdown (systemd `Restart=on-failure` respawn), consistent with memory exhaustion.

The module is no longer used in production but should not be uninstalled.

## What

- Add `active` field (default `True`) to `ideasoft.backend`.
- Show an **Archived** ribbon + keep `active` togglable via the standard Action menu.
- No logic change needed: `regenerate_all_records` uses `search([])`, which skips archived records via the default `active_test`, so archiving a backend stops its generation while preserving config (token, domain, locations).

## How to use

Upgrade the module, then archive the unused backend record → generation stops. Un-archive to resume.

For an immediate stop before the next cron tick (no upgrade), disable the scheduled action `ideasoft_xml_export.ir_cron_generate_ideasoft_xml_export`.

## Note

This stops *this* OOM source only. The underlying risk (heavy queue jobs sharing memory limits with HTTP workers) remains — follow-up: isolate queue_job into a dedicated worker and batch the remaining heavy jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)