### PR TITLE
[FIX] postmark_connector: switch to official Postmark SDK (multi-worker safe)

### DIFF
--- a/postmark_connector/README.rst
+++ b/postmark_connector/README.rst
@@ -16,7 +16,7 @@ email delivery and tracking.
 ## Requirements
 
 - Postmark account and server token
-- Python package: `postmarker`
+- Python package: `postmark` (official SDK, >= 0.3.1)
 - OCA modules: `mail_tracking`, `queue_job`
 
 ## Installation
@@ -24,7 +24,7 @@ email delivery and tracking.
 1. Install Python dependency:
 
    ```bash
-   pip install postmarker==1.0
+   pip install "postmark>=0.3.1"
    ```
 
 2. Install the module in Odoo

--- a/postmark_connector/__manifest__.py
+++ b/postmark_connector/__manifest__.py
@@ -16,7 +16,7 @@
 
 {
     "name": "Postmark Connector",
-    "version": "16.0.0.1.2",
+    "version": "16.0.0.1.3",
     "license": "LGPL-3",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "author": "Ahmet Yiğit Budak, Altinkaya Enclosures",
@@ -24,7 +24,7 @@
     "depends": ["mail_tracking", "queue_job"],
     "external_dependencies": {
         "python": [
-            "postmarker",
+            "postmark",
         ]
     },
     "data": [],

--- a/postmark_connector/migrations/16.0.0.1.3/post-migration.py
+++ b/postmark_connector/migrations/16.0.0.1.3/post-migration.py
@@ -1,0 +1,15 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Import existing Postmark suppressions into Odoo's email blacklist."""
+    if not version:
+        return
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    count = env["mail.mail"]._postmark_sync_suppressions("outbound")
+    _logger.info("Postmark suppression migration imported %s blacklist entries.", count)

--- a/postmark_connector/models/mail_mail.py
+++ b/postmark_connector/models/mail_mail.py
@@ -17,14 +17,11 @@ import logging
 import re
 from ast import literal_eval
 
-import requests
-
 from odoo import _, api, fields, models, tools
 from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
-POSTMARK_API_URL = "https://api.postmarkapp.com"
 POSTMARK_DEFAULT_TIMEOUT = 15
 POSTMARK_INACTIVE_ADDRESS_PATTERNS = (
     r"Found inactive addresses: ([^.]+)",
@@ -37,14 +34,17 @@ class MissingRecipientError(Exception):
 
 
 try:
-    from postmarker.core import PostmarkClient
-    from postmarker.exceptions import ClientError
+    import postmark.sync as postmark_sync
+    from postmark.exceptions import InactiveRecipientException, PostmarkAPIException
 except ImportError:
-    _logger.error("Please install the 'postmarker' Python package.")
-    PostmarkClient = None
+    _logger.error("Please install the 'postmark' Python package.")
+    postmark_sync = None
 
-    class ClientError(Exception):
-        """Fallback class used when postmarker is not installed."""
+    class InactiveRecipientException(Exception):
+        """Fallback class used when postmark is not installed."""
+
+    class PostmarkAPIException(Exception):
+        """Fallback class used when postmark is not installed."""
 
 
 class MailMail(models.Model):
@@ -52,7 +52,7 @@ class MailMail(models.Model):
 
     def send(self, auto_commit=False, raise_exception=False):
         """Override send to select the method to send the e-mail."""
-        if PostmarkClient and config.get("postmark_api_key"):
+        if postmark_sync and config.get("postmark_api_key"):
             return self.send_postmark(auto_commit=auto_commit)
         return super().send(auto_commit=auto_commit, raise_exception=raise_exception)
 
@@ -66,96 +66,113 @@ class MailMail(models.Model):
             )
             return True
 
-        postmark = PostmarkClient(
-            server_token=api_key,
-            timeout=self._postmark_get_timeout(),
-        )
-        for email in outgoing:
-            try:
-                (
-                    recipients,
-                    blacklisted_recipients,
-                    cc_recipients,
-                    blacklisted_cc_recipients,
-                ) = email._postmark_prepare_recipient_values()
-                if not recipients:
-                    if not blacklisted_recipients:
-                        raise MissingRecipientError(
-                            _("No recipient email address found.")
+        with postmark_sync.ServerClient(
+            api_key, timeout=self._postmark_get_timeout()
+        ) as postmark:
+            for email in outgoing:
+                try:
+                    (
+                        recipients,
+                        blacklisted_recipients,
+                        cc_recipients,
+                        blacklisted_cc_recipients,
+                    ) = email._postmark_prepare_recipient_values()
+                    if not recipients:
+                        if not blacklisted_recipients:
+                            raise MissingRecipientError(
+                                _("No recipient email address found.")
+                            )
+                        email._postmark_cancel_blacklisted_message(
+                            blacklisted_recipients
                         )
-                    email._postmark_cancel_blacklisted_message(blacklisted_recipients)
+                        continue
+
+                    params = email._prepare_postmark_email_params(
+                        recipients, cc_recipients=cc_recipients
+                    )
+                    _logger.info("Sending mail.mail %s through Postmark.", email.id)
+                    response = postmark.outbound.send(params)
+                    email._postmark_validate_response(response)
+
+                    email.write(
+                        {
+                            "postmark_message_id": response.message_id,
+                            "sent_date": fields.Datetime.now(),
+                            "state": "sent",
+                        }
+                    )
+                    tracking_vals = email._tracking_email_prepare(
+                        partner=fields.first(email.recipient_ids.filtered("email")),
+                        email={"email_to": recipients},
+                    )
+                    self.env["mail.tracking.email"].sudo().create(tracking_vals)
+                    blacklisted_emails = (
+                        blacklisted_recipients + blacklisted_cc_recipients
+                    )
+                    failure_reason = (
+                        email._postmark_get_blacklisted_failure_reason(
+                            blacklisted_emails
+                        )
+                        if blacklisted_recipients
+                        else False
+                    )
+                    failure_type = "mail_bl" if blacklisted_recipients else None
+                    email._postprocess_sent_message(
+                        success_pids=email._postmark_get_success_partner_ids(
+                            recipients
+                        ),
+                        failure_reason=failure_reason,
+                        failure_type=failure_type,
+                    )
+
+                    # Commit at each e-mail processed to avoid any errors
+                    # invalidating state.
+                    self.env.cr.commit()  # pylint: disable=invalid-commit
+
+                except MissingRecipientError as exc:
+                    failure_reason = str(exc)
+                    _logger.info(
+                        "Skipping Postmark email %s without recipients: %s",
+                        email.id,
+                        failure_reason,
+                    )
+                    email.write(
+                        {"state": "exception", "failure_reason": failure_reason}
+                    )
+                    email._postprocess_sent_message(
+                        success_pids=[],
+                        failure_reason=failure_reason,
+                        failure_type="mail_email_missing",
+                    )
                     continue
 
-                params = email._prepare_postmark_email_params(
-                    recipients, cc_recipients=cc_recipients
-                )
-                _logger.info("Sending mail.mail %s through Postmarker.", email.id)
-                response = postmark.emails.send(**params)
-                email._postmark_validate_response(response)
+                except InactiveRecipientException as exc:
+                    inactive_emails = email._postmark_get_exception_inactive_emails(exc)
+                    email._postmark_blacklist_emails(
+                        inactive_emails, source="Postmark inactive recipient"
+                    )
+                    email._postmark_handle_send_exception(
+                        exc,
+                        failure_type=(
+                            "mail_email_invalid" if inactive_emails else "mail_smtp"
+                        ),
+                    )
+                    continue
 
-                email.write(
-                    {
-                        "postmark_message_id": response["MessageID"],
-                        "sent_date": fields.Datetime.now(),
-                        "state": "sent",
-                    }
-                )
-                tracking_vals = email._tracking_email_prepare(
-                    partner=fields.first(email.recipient_ids.filtered("email")),
-                    email={"email_to": recipients},
-                )
-                self.env["mail.tracking.email"].sudo().create(tracking_vals)
-                blacklisted_emails = blacklisted_recipients + blacklisted_cc_recipients
-                failure_reason = (
-                    email._postmark_get_blacklisted_failure_reason(blacklisted_emails)
-                    if blacklisted_recipients
-                    else False
-                )
-                failure_type = "mail_bl" if blacklisted_recipients else None
-                email._postprocess_sent_message(
-                    success_pids=email._postmark_get_success_partner_ids(recipients),
-                    failure_reason=failure_reason,
-                    failure_type=failure_type,
-                )
+                except PostmarkAPIException as exc:
+                    email._postmark_handle_send_exception(
+                        exc,
+                        failure_type=(
+                            "mail_email_invalid"
+                            if getattr(exc, "error_code", None) == 300
+                            else "mail_smtp"
+                        ),
+                    )
+                    continue
 
-                # Commit at each e-mail processed to avoid any errors
-                # invalidating state. This preserves the known-good Postmarker
-                # behavior from 2f459db5.
-                self.env.cr.commit()  # pylint: disable=invalid-commit
-
-            except MissingRecipientError as exc:
-                failure_reason = str(exc)
-                _logger.info(
-                    "Skipping Postmark email %s without recipients: %s",
-                    email.id,
-                    failure_reason,
-                )
-                email.write({"state": "exception", "failure_reason": failure_reason})
-                email._postprocess_sent_message(
-                    success_pids=[],
-                    failure_reason=failure_reason,
-                    failure_type="mail_email_missing",
-                )
-                continue
-
-            except ClientError as exc:
-                inactive_emails = email._postmark_get_exception_inactive_emails(exc)
-                email._postmark_blacklist_emails(
-                    inactive_emails, source="Postmark inactive recipient"
-                )
-                email._postmark_handle_send_exception(
-                    exc,
-                    failure_type=(
-                        "mail_email_invalid"
-                        if inactive_emails or getattr(exc, "error_code", None) == 300
-                        else "mail_smtp"
-                    ),
-                )
-                continue
-
-            except Exception as exc:
-                email._postmark_handle_send_exception(exc, failure_type="mail_smtp")
-                continue
+                except Exception as exc:
+                    email._postmark_handle_send_exception(exc, failure_type="mail_smtp")
+                    continue
         return True
 
     @api.model
@@ -173,17 +190,20 @@ class MailMail(models.Model):
             return POSTMARK_DEFAULT_TIMEOUT
 
     def _postmark_validate_response(self, response):
-        """Validate a Postmarker send response and blacklist inactive recipients."""
+        """Validate a Postmark send response and blacklist inactive recipients."""
         self.ensure_one()
-        if response.get("ErrorCode") == 0:
+        if response.success and response.message == "OK":
             return
 
-        message = response.get("Message")
-        inactive_emails = self._postmark_extract_inactive_recipients(message)
+        inactive_emails = self._postmark_extract_inactive_recipients(response.message)
         self._postmark_blacklist_emails(
             inactive_emails, source="Postmark send response"
         )
-        raise ClientError(message, error_code=response.get("ErrorCode"))
+        raise PostmarkAPIException(
+            response.message,
+            error_code=response.error_code,
+            http_status=200,
+        )
 
     def _postmark_handle_send_exception(self, exc, failure_type):
         """Store a Postmark send failure and update mail notifications."""
@@ -214,8 +234,10 @@ class MailMail(models.Model):
 
     @api.model
     def _postmark_get_exception_inactive_emails(self, exc):
-        """Return inactive recipients exposed by Postmarker exceptions."""
-        return self._postmark_extract_inactive_recipients(str(exc))
+        """Return inactive recipients exposed by official SDK exceptions."""
+        return getattr(
+            exc, "inactive_recipients", []
+        ) or self._postmark_extract_inactive_recipients(str(exc))
 
     @api.model
     def _postmark_blacklist_emails(self, emails, source=False):
@@ -248,25 +270,20 @@ class MailMail(models.Model):
         if not api_key:
             _logger.info("Skipping Postmark suppression sync: no postmark_api_key.")
             return 0
+        if not postmark_sync:
+            _logger.info("Skipping Postmark suppression sync: SDK is unavailable.")
+            return 0
 
         try:
-            response = requests.get(
-                f"{POSTMARK_API_URL}/message-streams/{stream_id}/suppressions/dump",
-                headers={
-                    "Accept": "application/json",
-                    "X-Postmark-Server-Token": api_key,
-                },
-                timeout=self._postmark_get_timeout(),
-            )
-            response.raise_for_status()
+            with postmark_sync.ServerClient(
+                api_key, timeout=self._postmark_get_timeout()
+            ) as postmark:
+                suppressions = postmark.suppressions.dump(stream_id)
         except Exception as exc:
             _logger.error("Postmark suppression sync failed: %s", exc)
             return 0
 
-        emails = [
-            suppression.get("EmailAddress")
-            for suppression in response.json().get("Suppressions", [])
-        ]
+        emails = [suppression.email_address for suppression in suppressions]
         count = self._postmark_blacklist_emails(
             emails, source=f"Postmark {stream_id} suppression sync"
         )
@@ -419,10 +436,10 @@ class MailMail(models.Model):
         if "@altinkaya.com" not in str(msg_from):
             msg_from = '"ALTINKAYA" <erp@altinkaya.com>'
 
-        params["From"] = msg_from
-        params["MessageStream"] = "outbound"
+        params["sender"] = msg_from
+        params["message_stream"] = "outbound"
         if self.reply_to:
-            params["ReplyTo"] = self.reply_to
+            params["reply_to"] = self.reply_to
 
         headers = {"Message-Id": self.message_id}
         if self.headers:
@@ -433,30 +450,32 @@ class MailMail(models.Model):
                     "Error while parsing headers for email %s: %s", self.id, exc
                 )
 
-        params["Headers"] = headers
+        params["headers"] = [
+            {"name": name, "value": str(value)} for name, value in headers.items()
+        ]
 
         # Debrand the body.
-        params["HtmlBody"] = self.env["mail.render.mixin"].remove_href_odoo(
+        params["html_body"] = self.env["mail.render.mixin"].remove_href_odoo(
             str(self.body_content) or "", to_keep=self.body
         )
-        params["Subject"] = self.subject or _("(No subject)")
+        params["subject"] = self.subject or _("(No subject)")
 
         recipients = recipients or self._get_postmark_recipients()
         if not recipients:
             raise MissingRecipientError(_("No recipient email address found."))
-        params["To"] = recipients
+        params["to"] = ", ".join(recipients)
 
         if cc_recipients is None:
             cc_recipients = self._get_postmark_cc_recipients()
         if cc_recipients:
-            params["Cc"] = cc_recipients
+            params["cc"] = ", ".join(cc_recipients)
 
         if self.attachment_ids:
-            params["Attachments"] = [
+            params["attachments"] = [
                 {
-                    "Name": attachment.name,
-                    "Content": attachment.datas.decode("utf-8"),
-                    "ContentType": attachment.mimetype,
+                    "name": attachment.name,
+                    "content": attachment.datas.decode("utf-8"),
+                    "content_type": attachment.mimetype,
                 }
                 for attachment in self.attachment_ids
             ]


### PR DESCRIPTION
## Summary

Re-migrates `postmark_connector` from the `postmarker` library back to ActiveCampaign's **official `postmark` SDK** (pinned `>= 0.3.1`). The earlier official-SDK migration (2431660) was reverted to postmarker (aaff2290) because the official SDK had a multi-worker bug — that bug has since been **fixed upstream and the fix is merged**, so the official SDK is safe again.

This keeps every blacklist/feature enhancement that the "Restore Postmarker mail transport" commit had added — it is **not** a plain revert.

## Changes

- **`models/mail_mail.py`**
  - Import `postmark.sync` + `InactiveRecipientException` / `PostmarkAPIException` (with ImportError fallbacks).
  - `send_postmark` uses `with postmark_sync.ServerClient(api_key, timeout=...)` as a **context manager** so the SDK's background event-loop thread is always torn down (the multi-worker safety point), and sends via `postmark.outbound.send(params)`.
  - Exception flow follows the SDK hierarchy — `InactiveRecipientException` (uses the SDK's `.inactive_recipients`) is caught **before** its parent `PostmarkAPIException` (error_code `300` → `mail_email_invalid`), then a generic fallback.
  - `_postmark_validate_response` adapted from dict to the `SendResponse` object.
  - `_postmark_sync_suppressions` uses `postmark.suppressions.dump(stream_id)` instead of a raw `requests` call (dropped the `requests` / `POSTMARK_API_URL` usage).
  - `_prepare_postmark_email_params` switched to the SDK's snake_case keys (`sender`, `message_stream`, `html_body`, comma-joined `to`/`cc`, `headers` as `[{name, value}]`, `attachments` as `[{name, content, content_type}]`).
- **`__manifest__.py`** — version `16.0.0.1.2` → `16.0.0.1.3`; python dependency `postmarker` → `postmark`.
- **`migrations/16.0.0.1.3/post-migration.py`** — added; re-syncs Postmark suppressions into `mail.blacklist` (matches the existing per-version pattern).
- **`README.rst`** — `postmark` / `pip install "postmark>=0.3.1"`.

Kept intact: pre-send blacklist filtering, Cc handling, per-recipient suppression, configurable timeout, and the `_postprocess_sent_message` override.

## Companion change

The requirements pin lives in the parent deployment repo (`altinkaya-opensource/odoo`): `postmarker==1.0` → `postmark>=0.3.1` (separate PR).

## Testing

- `python -m py_compile` passes; `pre-commit` (run from `repos/odoo-addons/`) is clean.
- API surface verified against `ActiveCampaign/postmark-python` @ `v0.3.1` (client/send/response/exceptions/suppressions schemas).
- ⚠️ Not yet runtime-tested with the package installed — install `postmark>=0.3.1` and verify a live send on a worker before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)