### PR TITLE
[ADD] altinkaya_reports: Ostim location label + drop broken barcode button

### DIFF
--- a/altinkaya_reports/report/location_reports.xml
+++ b/altinkaya_reports/report/location_reports.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
-    <template id="location_report_godex" name="location report godex">
-        <t t-if="user.context_def_label_printer.type=='GODEX'">
+    <template id="location_report_godex_body" name="location report godex body">
+        <t t-if="printer_type=='GODEX'">
 ^Q50,3
 ^W104
 ^H10
@@ -47,7 +47,7 @@ E
 ^P1
 E</t>
 </t>
-        <t t-if="user.context_def_label_printer.type=='GODEX300'">
+        <t t-if="printer_type=='GODEX300'">
 ^Q50,3
 ^W104
 ^H10
@@ -95,5 +95,15 @@ E</t>
 ^P1
 E</t>
  </t>
+    </template>
+    <!-- Dialect follows the clicking user's own label printer, routes to their default printer. -->
+    <template id="location_report_godex" name="location report godex">
+        <t t-set="printer_type" t-value="user.context_def_label_printer.type" />
+        <t t-call="altinkaya_reports.location_report_godex_body" />
+    </template>
+    <!-- Ostim variant: forces GODEX dialect; printing_printer_id (Ostim Barkod 2250) is set on the action in DB. -->
+    <template id="location_report_godex_ostim" name="location report godex ostim">
+        <t t-set="printer_type" t-value="'GODEX'" />
+        <t t-call="altinkaya_reports.location_report_godex_body" />
     </template>
 </odoo>

--- a/altinkaya_reports/report/reports.xml
+++ b/altinkaya_reports/report/reports.xml
@@ -10,6 +10,21 @@
         <field name="binding_type">report</field>
     </record>
 
+    <!-- Remove core "Location Barcode" (qweb-pdf) from the Print menu; we use the GODEX label report instead. -->
+    <record id="stock.action_report_location_barcode" model="ir.actions.report">
+        <field name="binding_model_id" eval="False" />
+    </record>
+
+    <record id="label_stock_location_ostim" model="ir.actions.report">
+        <field name="name">Localation Label (Ostim)</field>
+        <field name="model">stock.location</field>
+        <field name="report_type">qweb-text</field>
+        <field name="report_name">altinkaya_reports.location_report_godex_ostim</field>
+        <field name="report_file">altinkaya_reports.location_report_godex_ostim</field>
+        <field name="binding_model_id" ref="stock.model_stock_location" />
+        <field name="binding_type">report</field>
+    </record>
+
     <record id="stock_pickingaltinkaya" model="ir.actions.report">
         <field name="name">Depo Fişi Ekrana</field>
         <field name="model">stock.picking</field>


### PR DESCRIPTION
## What

Location-barcode printing on `stock.location`:

1. **New "Localation Label (Ostim)" button** — prints location labels to the Ostim printer. `location_report_godex` is refactored into a reusable `location_report_godex_body` driven by a `printer_type` variable; the Ostim wrapper forces the `GODEX` dialect (Ostim Barkod 2250 is a GODEX printer). Existing "Localation Label (GODEX)" behaviour is unchanged (still follows the clicking user's own label printer).
2. **Removed the broken "Konum Barkodu" button** — core `stock.action_report_location_barcode` (qweb-pdf) is unbound from the location Print menu (non-destructive; report still callable). The GODEX label report is the one in use.

## Follow-up (DB, post-upgrade)

CUPS printers have no stable XML id, so the printer can't be set in XML. After upgrade, set `printing_printer_id` on `label_stock_location_ostim` to **Ostim Barkod 2250 (id 230)** — same convention as the other Ostim branch report variants. Without it the button renders correctly but routes to the clicker's default printer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)