### PR TITLE
[FIX] altinkaya_account: keep Zirve partner export codes unique

### DIFF
--- a/altinkaya_account/__manifest__.py
+++ b/altinkaya_account/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Altinkaya Account",
     "summary": "Accounting Extension for Altinkaya Enclosures",
-    "version": "16.0.1.5.0",
+    "version": "16.0.1.6.0",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "author": "Ismail Çağan Yılmaz, Altinkaya Enclosures",
     "license": "AGPL-3",

--- a/altinkaya_account/migrations/16.0.1.6.0/post-migration.py
+++ b/altinkaya_account/migrations/16.0.1.6.0/post-migration.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Altinkaya Enclosures
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Stop the portal template from handing its ref to every storefront signup.
+
+    ``res.users._create_user_from_template`` copies the portal template user.
+    Because users inherit partners, that copy reused partner 6's ref (92997)
+    and the Zirve codes derived from it. Clearing the template's ref/export
+    codes is a belt-and-suspenders fix next to copy=False on those fields.
+    """
+    cr.execute(
+        """
+        UPDATE res_partner p
+           SET ref = NULL,
+               z_receivable_export = NULL,
+               z_payable_export = NULL
+          FROM ir_config_parameter icp
+          JOIN res_users u ON u.id = NULLIF(icp.value, '')::integer
+         WHERE icp.key = 'base.template_portal_user_id'
+           AND icp.value ~ '^[0-9]+$'
+           AND p.id = u.partner_id
+           AND (
+                p.ref IS NOT NULL
+                OR p.z_receivable_export IS NOT NULL
+                OR p.z_payable_export IS NOT NULL
+           )
+        RETURNING p.id, p.name
+        """
+    )
+    rows = cr.fetchall()
+    if rows:
+        _logger.info(
+            "Cleared ref and Zirve export codes on portal template partner %s (%s).",
+            rows[0][0],
+            rows[0][1],
+        )

--- a/altinkaya_account/models/res_partner.py
+++ b/altinkaya_account/models/res_partner.py
@@ -234,8 +234,16 @@ class ResPartner(models.Model):
     z_muhasebe_kodu = fields.Char(
         "Zirve Muhasebe kodu", size=64, required=False, translate=False
     )
-    z_receivable_export = fields.Char("Receivable Export", size=64, required=False)
-    z_payable_export = fields.Char("Payable Export", size=64, required=False)
+    # Do not copy ref/export codes: storefront signup copies the portal
+    # template user via res.users._inherits, which would otherwise reuse
+    # the template partner's ref (and the Zirve codes derived from it).
+    ref = fields.Char(copy=False)
+    z_receivable_export = fields.Char(
+        "Receivable Export", size=64, required=False, copy=False
+    )
+    z_payable_export = fields.Char(
+        "Payable Export", size=64, required=False, copy=False
+    )
     purchase_default_account_id = fields.Many2one(
         "account.account",
         required=False,
@@ -264,6 +272,33 @@ class ResPartner(models.Model):
             else:
                 record.due_days = 0
 
+    def _ref_is_taken(self, ref):
+        """Return whether ``ref`` is already used by a commercial partner."""
+        if not ref:
+            return False
+        return bool(
+            self.sudo()
+            .with_context(active_test=False)
+            .search([("ref", "=", ref), ("parent_id", "=", False)], limit=1)
+        )
+
+    def _ensure_unique_ref_vals(self, vals):
+        """Assign a unique sequence ref when the given one is missing or taken.
+
+        Storefront registration copies the portal template user. Because
+        ``res.users`` inherits ``res.partner``, that copy feeds the template's
+        ``ref`` into ``create()`` vals and ``base_partner_sequence`` then
+        skips sequence assignment. Replace a missing or colliding ref so
+        each commercial partner keeps unique Zirve export codes.
+        """
+        if not self._needs_ref(vals=vals):
+            return
+        ref = (vals.get("ref") or "").strip()
+        if ref:
+            vals["ref"] = ref
+        if not ref or self._ref_is_taken(ref):
+            vals["ref"] = self._get_next_ref(vals=vals)
+
     def _update_export_account_codes(self):
         """Update export account codes from the partner country and reference."""
         for partner in self.filtered(
@@ -282,6 +317,8 @@ class ResPartner(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        for vals in vals_list:
+            self._ensure_unique_ref_vals(vals)
         partners = super().create(vals_list)
         partners._update_export_account_codes()
         return partners

--- a/altinkaya_account/tests/test_res_partner.py
+++ b/altinkaya_account/tests/test_res_partner.py
@@ -33,3 +33,56 @@ class TestResPartnerExportAccounts(TransactionCase):
             foreign_partner.z_payable_export,
             f"320.Y{foreign_partner.ref.strip()}",
         )
+
+    def test_create_does_not_reuse_an_existing_commercial_ref(self):
+        turkey = self.env.ref("base.tr")
+        original = self.env["res.partner"].create(
+            {"name": "Original commercial partner", "country_id": turkey.id}
+        )
+        duplicate = self.env["res.partner"].create(
+            {
+                "name": "Must not reuse original ref",
+                "country_id": turkey.id,
+                "ref": original.ref,
+            }
+        )
+        self.assertTrue(duplicate.ref)
+        self.assertNotEqual(duplicate.ref, original.ref)
+        self.assertNotEqual(duplicate.z_receivable_export, original.z_receivable_export)
+        self.assertEqual(duplicate.z_receivable_export, f"120.{duplicate.ref.strip()}")
+
+    def test_portal_template_user_copy_gets_unique_ref_and_export_codes(self):
+        """Storefront signup copies the portal template user via _inherits."""
+        template_user_id = int(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("base.template_portal_user_id")
+        )
+        template_user = self.env["res.users"].browse(template_user_id)
+        self.assertTrue(template_user.exists())
+
+        united_states = self.env.ref("base.us")
+        template_partner = template_user.partner_id
+        template_partner.write(
+            {
+                "ref": "92997",
+                "country_id": united_states.id,
+                "z_receivable_export": "120.Y92997",
+                "z_payable_export": "320.Y92997",
+            }
+        )
+
+        user = template_user.with_context(no_reset_password=True).copy(
+            {
+                "name": "Storefront signup unique ref",
+                "login": "signup-unique-ref@example.com",
+                "email": "signup-unique-ref@example.com",
+                "active": True,
+            }
+        )
+        partner = user.partner_id
+        self.assertTrue(partner.ref)
+        self.assertNotEqual(partner.ref, "92997")
+        self.assertNotEqual(partner.z_receivable_export, "120.Y92997")
+        self.assertEqual(partner.z_receivable_export, f"120.Y{partner.ref.strip()}")
+        self.assertEqual(partner.z_payable_export, f"320.Y{partner.ref.strip()}")


### PR DESCRIPTION
## Summary
- Storefront signup copies the portal template user, so every new customer reused partner ref `92997` and the derived Zirve codes (`120.92997` / `120.Y92997`).
- Assign a fresh sequence `ref` when create vals already contain a taken commercial ref, and stop copying `ref` / export-code fields from the template.
- Clear those fields on the portal template partner on module update. Existing duplicate codes are left unchanged for accounting to repair.

## Test plan
- [ ] Upgrade `altinkaya_account` to 16.0.1.6.0 and confirm the portal template partner (`portaltemplate`) has empty `ref` / `z_receivable_export` / `z_payable_export`.
- [ ] Register a new storefront account (or copy the portal template user) and confirm it gets a unique sequence `ref` and matching `120.` / `320.` codes, not `92997`.
- [ ] Create a partner with an already-used `ref` and confirm it is replaced with a new sequence value.
- [ ] Create a Turkish and a foreign partner and confirm export codes still follow `120.{ref}` / `120.Y{ref}`.
- [ ] Confirm existing partners that already share `120.Y92997` are not rewritten by this upgrade.


Made with [Cursor](https://cursor.com)