### PR TITLE
[FEAT] kardex: kardex_manager group gates Call/Return (Odoo + mobile)

### DIFF
--- a/altinkaya_kardex/__manifest__.py
+++ b/altinkaya_kardex/__manifest__.py
@@ -10,6 +10,7 @@
     "category": "Stock",
     "depends": ["stock", "base_sparse_field"],
     "data": [
+        "security/kardex_security.xml",
         "security/ir.model.access.csv",
         "views/stock_location_tray_type_views.xml",
         "views/stock_kardex_views.xml",

--- a/altinkaya_kardex/models/stock_kardex.py
+++ b/altinkaya_kardex/models/stock_kardex.py
@@ -3,7 +3,7 @@
 import uuid
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import AccessError, UserError
 
 from .jmif_request import JmifRequest
 
@@ -152,12 +152,33 @@ class StockKardex(models.Model):
             raise UserError(errors[code])
         return response
 
+    def _check_kardex_manager(self):
+        """Guard every operator-facing bring/return call.
+
+        This is the single chokepoint: the picking buttons, the per-tray
+        location buttons and the manual-drive path all funnel through
+        bring_tray/return_tray, and none of them run under sudo, so one check
+        here gates them all (Odoo forms and the mobile JSON-RPC path alike).
+        Internal automation (sudo) is allowed through; a real user must hold
+        the Kardex Manager group, with no admin bypass.
+        """
+        if self.env.su:
+            return
+        if not self.env.user.has_group("altinkaya_kardex.group_kardex_manager"):
+            raise AccessError(
+                _(
+                    "You are not allowed to operate the Kardex. "
+                    "Ask an administrator for the Kardex Manager permission."
+                )
+            )
+
     def bring_tray(self, carrier):
         """Bring a tray (storage unit ``carrier``) to the opening.
 
         Blocks until the tray has physically arrived, so the caller knows it is
         ready to scan.
         """
+        self._check_kardex_manager()
         return self._send("count", carrier)
 
     def return_tray(self, carrier):
@@ -165,6 +186,7 @@ class StockKardex(models.Model):
 
         Blocks until the machine confirms the tray has been taken back.
         """
+        self._check_kardex_manager()
         return self._send("release_tray", carrier)
 
     def action_test_connection(self):

--- a/altinkaya_kardex/security/kardex_security.xml
+++ b/altinkaya_kardex/security/kardex_security.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <!-- Grants the right to call/return Kardex trays, in Odoo and in the
+         mobile app. Assigned through a res.users.role; without it the
+         Call/Return buttons are hidden and the underlying methods refuse
+         to run (see stock_kardex._check_kardex_manager). -->
+    <record id="group_kardex_manager" model="res.groups">
+        <field name="name">Kardex Manager</field>
+        <field name="category_id" ref="base.module_category_hidden" />
+        <field
+            name="comment"
+        >Users allowed to call/return Kardex trays (Odoo + mobile).</field>
+    </record>
+</odoo>

--- a/altinkaya_kardex/views/stock_picking_views.xml
+++ b/altinkaya_kardex/views/stock_picking_views.xml
@@ -13,6 +13,7 @@
                     string="Call Kardex Trays"
                     icon="fa-arrow-down"
                     attrs="{'invisible': [('has_kardex_operation', '=', False)]}"
+                    groups="altinkaya_kardex.group_kardex_manager"
                 />
                 <button
                     name="action_return_kardex_trays"
@@ -20,6 +21,7 @@
                     string="Send Trays Back"
                     icon="fa-arrow-up"
                     attrs="{'invisible': [('has_kardex_operation', '=', False)]}"
+                    groups="altinkaya_kardex.group_kardex_manager"
                 />
             </field>
         </field>


### PR DESCRIPTION
> Migrated from [Forgejo altinkaya-opensource/odoo-addons PR #63](https://git.altinkaya.com/altinkaya-opensource/odoo-addons/pulls/63).
> Original author: `IKBAL812` on Forgejo · Created: `2026-07-09T09:06:50Z`
> Original head: `IKBAL812/odoo-addons:kardex-manager-gate` at `0a7a07588a36b1bd0b3b33d243e523681d3499f0`

## What
Introduces a Kardex Manager permission so not everyone who can see a picking may call/return trays.

- New group `group_kardex_manager` (altinkaya_kardex/security/kardex_security.xml).
- Hard gate at the single chokepoint: `stock.kardex.bring_tray`/`return_tray` raise AccessError unless the user holds the group. Every call/return path funnels through these two (picking `action_call/return_kardex_trays`, per-tray `action_bring/return_tray`, manual drive), and no caller sudo's them, so one guard covers Odoo buttons and the mobile JSON-RPC path alike. `action_test_connection` is unaffected (it bypasses these).
- sudo/automation passes the guard; there is intentionally no admin bypass.
- The picking-form Call/Return buttons get `groups="altinkaya_kardex.group_kardex_manager"`. Config-screen buttons (machine form Bring / Test Connection, location tray buttons) keep their existing visibility and stay protected by the method guard.

## Paired changes
- Mobile app (per-raf Call/Return in the active-transfer view + button gating): altinkaya_flutter PR #62.
- The mobile session flag `is_kardex_manager` is surfaced in altinkaya_mobile (separate PR against altinkaya-opensource/odoo:16.0).

## Test
Module upgrade clean on 16test2; the group is created; a non-member calling `bring_tray` raises AccessError while a member proceeds; `mobile_get_session_info` reflects membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- migrated-from-forgejo-pr:altinkaya-opensource/odoo-addons#63 -->
