### PR TITLE
[FEAT] altinkaya_mrp: GS1 QR on the maintenance-log form + fix product label

### DIFF
--- a/altinkaya_mrp/__manifest__.py
+++ b/altinkaya_mrp/__manifest__.py
@@ -16,6 +16,7 @@
         "hr",
         "mrp_sale_info",
         "stock_related_move_shortcut",
+        "gs1_digital_link",
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/altinkaya_mrp/i18n/tr.po
+++ b/altinkaya_mrp/i18n/tr.po
@@ -589,7 +589,7 @@ msgstr "Üretim Emri Yazdır"
 #: model:ir.model.fields,field_description:altinkaya_mrp.field_maintenance_log__product_id
 #: model:ir.model.fields,field_description:altinkaya_mrp.field_mrp_bom_template_line__product_id
 msgid "Product"
-msgstr "Ürün Şablonu"
+msgstr "Ürün"
 
 #. module: altinkaya_mrp
 #: model:ir.ui.menu,name:altinkaya_mrp.menu_product_category_on_mrp

--- a/altinkaya_mrp/models/maintenance_log.py
+++ b/altinkaya_mrp/models/maintenance_log.py
@@ -1,4 +1,6 @@
-from odoo import fields, models
+import base64
+
+from odoo import api, fields, models
 
 
 class MaintenanceLog(models.Model):
@@ -23,4 +25,21 @@ class MaintenanceLog(models.Model):
         ],
     )
     performed_by_id = fields.Many2one("hr.employee")
+    qr_code = fields.Binary(compute="_compute_qr_code", string="QR Code")
     # created_by = create_uid, date = create_date (automatic)
+
+    @api.depends("product_id.barcode")
+    def _compute_qr_code(self):
+        # The product's GS1 Digital Link QR, so a saved log can be scanned from
+        # the mobile maintenance applet. Rendered through the same barcode engine
+        # the SOP procedure sheet uses. No-op without a product barcode.
+        for rec in self:
+            rec.qr_code = False
+            product = rec.product_id
+            if not (product and product.barcode):
+                continue
+            url = self.env["gs1.digital.link"].build_product_link(product.barcode)
+            img = self.env["ir.actions.report"].barcode(
+                "QR", url, width=200, height=200
+            )
+            rec.qr_code = base64.b64encode(img)

--- a/altinkaya_mrp/views/maintenance_views.xml
+++ b/altinkaya_mrp/views/maintenance_views.xml
@@ -50,6 +50,7 @@
         <field name="arch" type="xml">
             <form>
                 <sheet>
+                    <field name="qr_code" widget="image" class="oe_avatar" />
                     <group>
                         <field name="product_id" />
                         <field name="performed_by_id" />


### PR DESCRIPTION
> Migrated from [Forgejo altinkaya-opensource/odoo-addons PR #82](https://git.altinkaya.com/altinkaya-opensource/odoo-addons/pulls/82).
> Original author: `IKBAL812` on Forgejo · Created: `2026-07-17T07:49:00Z`
> Original head: `IKBAL812/odoo-addons:maintenance-log-qr-product-label` at `fb19153c686621948de6196d0e2e7145157006af`

## What

`altinkaya_mrp` maintenance-log changes (paired with the merged `altinkaya_flutter` PR). Branched off `origin/16.0`.

- **GS1 QR on the maintenance-log form**: a computed `qr_code` (the product's GS1 Digital Link, rendered via the shared `ir.actions.report.barcode` engine) is shown top-right (`oe_avatar`) on the `maintenance.log` form, so a saved log can be scanned from the mobile maintenance applet. No-ops when the product has no barcode. Adds the `gs1_digital_link` dependency.
- **Turkish product label fix**: `maintenance.log.product_id` (a `product.product` field, auto-labeled "Product") was mistranslated to "Ürün Şablonu" in `tr.po`. Fix the shared `"Product"` msgid to **"Ürün"**. No source `string=` needed (it would be a redundant auto-label).

## Notes

- Deploy needs `-u altinkaya_mrp` (new field, view, and manifest dependency).
- i18n: only the one-line `tr.po` fix is included here; the full `altinkaya_mrp` translation regeneration (which also drops the x_makine strings) belongs with the separate x.makine PR, not this branch, since `origin/16.0` still has x_makine.

## Verification

The QR compute was verified against 16test2 via shell (a real mold log renders a valid ~7.8 KB QR PNG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- migrated-from-forgejo-pr:altinkaya-opensource/odoo-addons#82 -->
