### PR TITLE
[FIX] trendyol_integration: import orders despite invalid partner VAT

### DIFF
--- a/trendyol_integration/models/trendyol_order.py
+++ b/trendyol_integration/models/trendyol_order.py
@@ -329,6 +329,29 @@ class TrendyolOrder(models.Model):
         return False
 
     @api.model
+    def _is_duplicate_vat_conflict(self, exc, vat):
+        """Return True when partner create failed because this VAT already exists."""
+        if not vat:
+            return False
+        msg = (getattr(exc, "name", None) or str(exc) or "").lower()
+        vat_token = vat.lower()
+        vat_digits = self._partner_vat_digits(vat)
+        mentions_vat = (
+            "vat" in msg or vat_token in msg or (vat_digits and vat_digits in msg)
+        )
+        if not mentions_vat:
+            return False
+        return any(
+            token in msg
+            for token in (
+                "unique",
+                "already exist",
+                "already registered",
+                "duplicate",
+            )
+        )
+
+    @api.model
     def _create_main_partner(self, Partner, partner_vals):
         """Create the invoice partner, dropping an invalid VAT if needed."""
         try:
@@ -338,21 +361,26 @@ class TrendyolOrder(models.Model):
             vat = partner_vals.get("vat")
             if not vat or vat in PLACEHOLDER_VATS:
                 raise
-            existing = Partner.search(
-                [
+            if self._is_duplicate_vat_conflict(exc, vat):
+                domain = [
                     ("vat", "=", vat),
                     ("parent_id", "=", False),
-                ],
-                limit=1,
-            )
-            if existing:
-                _logger.warning(
-                    "Reusing partner %s for Trendyol VAT %s after create error: %s",
-                    existing.display_name,
-                    vat,
-                    exc,
-                )
-                return existing
+                ]
+                company_id = partner_vals.get("company_id")
+                if company_id:
+                    domain.append(("company_id", "in", [False, company_id]))
+                existing = Partner.search(domain, limit=1)
+                if existing:
+                    customer_id = partner_vals.get("trendyol_customer_id")
+                    if customer_id and not existing.trendyol_customer_id:
+                        existing.trendyol_customer_id = customer_id
+                    _logger.warning(
+                        "Reusing partner %s for Trendyol VAT %s after create error: %s",
+                        existing.display_name,
+                        vat,
+                        exc,
+                    )
+                    return existing
             _logger.warning(
                 "Invalid VAT %s for Trendyol partner %s: %s; creating without VAT",
                 vat,

--- a/trendyol_integration/models/trendyol_order.py
+++ b/trendyol_integration/models/trendyol_order.py
@@ -3,10 +3,11 @@
 
 import json
 import logging
+import re
 from datetime import datetime
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 from .trendyol_backend import _trendyol_ts_to_utc, _utc_to_trendyol_ts
 from .trendyol_request import TrendyolAPIError
@@ -14,6 +15,7 @@ from .trendyol_request import TrendyolAPIError
 _logger = logging.getLogger(__name__)
 
 INDIVIDUAL_VAT = "11111111111"
+PLACEHOLDER_VATS = frozenset({INDIVIDUAL_VAT, "2222222222"})
 
 
 class TrendyolOrder(models.Model):
@@ -290,6 +292,78 @@ class TrendyolOrder(models.Model):
         return status_map.get(trendyol_status)
 
     @api.model
+    def _partner_vat_digits(self, vat):
+        """Return the digits-only form of a tax number."""
+        return re.sub(r"\D+", "", vat or "")
+
+    @api.model
+    def _sanitize_partner_vat(self, vat):
+        """Return a VAT that partner constraints accept, or False.
+
+        Trendyol tax numbers are often mistyped. An invalid VAT must not
+        abort the whole order import.
+        """
+        digits = self._partner_vat_digits(vat)
+        if not digits:
+            return False
+        if digits in PLACEHOLDER_VATS:
+            return digits
+        Partner = self.env["res.partner"]
+        candidates = [digits]
+        if len(digits) == 11:
+            candidates.extend((digits[:10], digits[1:]))
+        elif len(digits) > 11:
+            candidates.extend((digits[:11], digits[:10], digits[-11:], digits[-10:]))
+        check_vat_tr = getattr(Partner, "check_vat_tr", None)
+        seen = set()
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            if check_vat_tr:
+                if check_vat_tr(candidate):
+                    return candidate
+                continue
+            if len(candidate) in (10, 11):
+                return candidate
+        return False
+
+    @api.model
+    def _create_main_partner(self, Partner, partner_vals):
+        """Create the invoice partner, dropping an invalid VAT if needed."""
+        try:
+            with self.env.cr.savepoint():
+                return Partner.create(partner_vals)
+        except (ValidationError, UserError) as exc:
+            vat = partner_vals.get("vat")
+            if not vat or vat in PLACEHOLDER_VATS:
+                raise
+            existing = Partner.search(
+                [
+                    ("vat", "=", vat),
+                    ("parent_id", "=", False),
+                ],
+                limit=1,
+            )
+            if existing:
+                _logger.warning(
+                    "Reusing partner %s for Trendyol VAT %s after create error: %s",
+                    existing.display_name,
+                    vat,
+                    exc,
+                )
+                return existing
+            _logger.warning(
+                "Invalid VAT %s for Trendyol partner %s: %s; creating without VAT",
+                vat,
+                partner_vals.get("name"),
+                exc,
+            )
+            partner_vals = dict(partner_vals)
+            partner_vals["vat"] = False
+            return Partner.create(partner_vals)
+
+    @api.model
     def _get_or_create_partner(self, backend, order_data):
         """Get or create partner(s) from order data.
 
@@ -324,26 +398,28 @@ class TrendyolOrder(models.Model):
 
         customer_id = str(order_data.get("customerId", ""))
         invoice_address = order_data.get("invoiceAddress", {})
-        is_commercial = bool(invoice_address.get("taxNumber"))
+        raw_tax = (invoice_address.get("taxNumber") or "").strip()
+        vat = self._sanitize_partner_vat(raw_tax)
+        is_commercial = bool(raw_tax) and (
+            self._partner_vat_digits(raw_tax) not in PLACEHOLDER_VATS
+        )
 
         # For commercial orders, try VAT matching first
         # Skip matching for dummy/individual VAT to avoid address mismatches
-        if is_commercial:
-            vat = invoice_address.get("taxNumber", "").strip()
-            if vat and vat != INDIVIDUAL_VAT:
-                partner = Partner.search(
-                    [
-                        ("vat", "=", vat),
-                        ("company_id", "in", [False, backend.company_id.id]),
-                        ("parent_id", "=", False),
-                    ],
-                    limit=1,
-                )
-                if partner:
-                    # Update trendyol_customer_id if missing
-                    if customer_id and not partner.trendyol_customer_id:
-                        partner.trendyol_customer_id = customer_id
-                    return partner
+        if is_commercial and vat:
+            partner = Partner.search(
+                [
+                    ("vat", "=", vat),
+                    ("company_id", "in", [False, backend.company_id.id]),
+                    ("parent_id", "=", False),
+                ],
+                limit=1,
+            )
+            if partner:
+                # Update trendyol_customer_id if missing
+                if customer_id and not partner.trendyol_customer_id:
+                    partner.trendyol_customer_id = customer_id
+                return partner
 
         # Try to find by Trendyol customer ID
         if customer_id:
@@ -365,7 +441,8 @@ class TrendyolOrder(models.Model):
         partner_vals["trendyol_customer_id"] = customer_id
 
         if is_commercial:
-            partner_vals["vat"] = invoice_address.get("taxNumber", "").strip()
+            if vat:
+                partner_vals["vat"] = vat
             partner_vals["company_type"] = "company"
             tax_office = invoice_address.get("taxOffice", "").strip()
             if tax_office:
@@ -376,7 +453,7 @@ class TrendyolOrder(models.Model):
         else:
             partner_vals["vat"] = INDIVIDUAL_VAT
 
-        return Partner.create(partner_vals)
+        return self._create_main_partner(Partner, partner_vals)
 
     @api.model
     def _get_or_create_shipping_partner(self, backend, order_data, main_partner):

--- a/trendyol_integration/tests/test_trendyol_order.py
+++ b/trendyol_integration/tests/test_trendyol_order.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from odoo import fields
+from odoo.exceptions import ValidationError
 
 from .common import TrendyolTestCase
 
@@ -175,3 +176,101 @@ class TestTrendyolOrder(TrendyolTestCase):
         )
         self.assertFalse(created.vat)
         self.assertEqual(created.name, "Bad VAT Co")
+
+    def _patch_create_failing_on_vat(self, Partner, message_template):
+        PartnerClass = type(Partner)
+        real_create = PartnerClass.create
+
+        def create_side_effect(this, vals):
+            if isinstance(vals, dict) and vals.get("vat"):
+                raise ValidationError(message_template % vals["vat"])
+            return real_create(this, vals)
+
+        return patch.object(PartnerClass, "create", create_side_effect)
+
+    def test_create_main_partner_reuses_same_company_on_duplicate_vat(self):
+        Partner = self.env["res.partner"]
+        existing = Partner.create(
+            {
+                "name": "Same Company VAT",
+                "vat": "11111111110",
+                "company_id": self.env.company.id,
+            }
+        )
+        with self._patch_create_failing_on_vat(
+            Partner, "The VAT %s already exists in another partner."
+        ):
+            reused = self.env["trendyol.order"]._create_main_partner(
+                Partner,
+                {
+                    "name": "New Import",
+                    "vat": "11111111110",
+                    "company_id": self.env.company.id,
+                    "trendyol_customer_id": "ty-reuse-1",
+                    "company_type": "company",
+                    "country_id": self.env.ref("base.tr").id,
+                },
+            )
+
+        self.assertEqual(reused, existing)
+        self.assertEqual(existing.trendyol_customer_id, "ty-reuse-1")
+
+    def test_create_main_partner_does_not_reuse_other_company_on_duplicate_vat(self):
+        Partner = self.env["res.partner"]
+        other_company = self.env["res.company"].create({"name": "Other Trendyol Co"})
+        other = Partner.create(
+            {
+                "name": "Other Company VAT",
+                "vat": "11111111110",
+                "company_id": other_company.id,
+            }
+        )
+        with self._patch_create_failing_on_vat(
+            Partner, "The VAT %s already exists in another partner."
+        ):
+            created = self.env["trendyol.order"]._create_main_partner(
+                Partner,
+                {
+                    "name": "This Company Import",
+                    "vat": "11111111110",
+                    "company_id": self.env.company.id,
+                    "trendyol_customer_id": "ty-other-co",
+                    "company_type": "company",
+                    "country_id": self.env.ref("base.tr").id,
+                },
+            )
+
+        self.assertNotEqual(created, other)
+        self.assertFalse(created.vat)
+        self.assertEqual(created.trendyol_customer_id, "ty-other-co")
+        self.assertEqual(created.company_id, self.env.company)
+        self.assertFalse(other.trendyol_customer_id)
+
+    def test_create_main_partner_does_not_reuse_on_invalid_vat_error(self):
+        Partner = self.env["res.partner"]
+        decoy = Partner.create({"name": "Decoy VAT Partner"})
+        PartnerClass = type(Partner)
+        with (
+            self._patch_create_failing_on_vat(
+                Partner,
+                "The VAT number [%s] for partner [X] does not seem to be valid.",
+            ),
+            patch.object(PartnerClass, "search", return_value=decoy) as search_mock,
+        ):
+            created = self.env["trendyol.order"]._create_main_partner(
+                Partner,
+                {
+                    "name": "Invalid VAT Import",
+                    "vat": "80012349540",
+                    "company_id": self.env.company.id,
+                    "trendyol_customer_id": "ty-invalid-reuse",
+                    "company_type": "company",
+                    "country_id": self.env.ref("base.tr").id,
+                },
+            )
+
+        search_mock.assert_not_called()
+        self.assertNotEqual(created, decoy)
+        self.assertFalse(created.vat)
+        self.assertEqual(created.trendyol_customer_id, "ty-invalid-reuse")
+        self.assertFalse(decoy.trendyol_customer_id)

--- a/trendyol_integration/tests/test_trendyol_order.py
+++ b/trendyol_integration/tests/test_trendyol_order.py
@@ -122,3 +122,56 @@ class TestTrendyolOrder(TrendyolTestCase):
             self.backend._import_orders()
 
         self.assertEqual(self.backend.last_order_sync, old_cursor)
+
+    def test_sanitize_partner_vat_drops_invalid_number(self):
+        Order = self.env["trendyol.order"]
+        self.assertFalse(Order._sanitize_partner_vat("80012349540"))
+        self.assertFalse(Order._sanitize_partner_vat(""))
+        self.assertEqual(Order._sanitize_partner_vat("11111111111"), "11111111111")
+        self.assertEqual(Order._sanitize_partner_vat("2222222222"), "2222222222")
+
+    def test_sanitize_partner_vat_uses_valid_vkn_prefix(self):
+        Order = self.env["trendyol.order"]
+        PartnerClass = type(self.env["res.partner"])
+        with patch.object(
+            PartnerClass,
+            "check_vat_tr",
+            side_effect=lambda vat: vat == "8001234007",
+        ):
+            self.assertEqual(Order._sanitize_partner_vat("8001234007"), "8001234007")
+            self.assertEqual(Order._sanitize_partner_vat("80012340070"), "8001234007")
+
+    def test_main_partner_created_without_invalid_vat(self):
+        partner = self.env["trendyol.order"]._get_or_create_main_partner(
+            self.backend,
+            {
+                "customerId": "ty-cust-invalid-vat",
+                "invoiceAddress": {
+                    "company": "WARMER INNOVATION",
+                    "taxNumber": "80012349540",
+                    "firstName": "Ali",
+                    "lastName": "Yilmaz",
+                    "address1": "Test Street 1",
+                    "city": "Ankara",
+                    "countryCode": "TR",
+                },
+            },
+        )
+        self.assertEqual(partner.name, "WARMER INNOVATION")
+        self.assertFalse(partner.vat)
+        self.assertEqual(partner.company_type, "company")
+        self.assertEqual(partner.trendyol_customer_id, "ty-cust-invalid-vat")
+
+    def test_create_main_partner_drops_vat_on_validation_error(self):
+        Partner = self.env["res.partner"]
+        created = self.env["trendyol.order"]._create_main_partner(
+            Partner,
+            {
+                "name": "Bad VAT Co",
+                "vat": "80012349540",
+                "company_type": "company",
+                "country_id": self.env.ref("base.tr").id,
+            },
+        )
+        self.assertFalse(created.vat)
+        self.assertEqual(created.name, "Bad VAT Co")


### PR DESCRIPTION
## Summary
- Invalid Trendyol tax numbers (Bugsink ODOO-90) raised on `res.partner` create and aborted the package import.
- `_import_orders` then kept `last_order_sync` (ODOO-117), so one poison package retried on every queue job and stalled the feed.
- Sanitize Turkish VAT before create (drop it when it cannot be repaired) and retry partner create without VAT inside a savepoint.

## Test plan
- [x] `TestTrendyolOrder` on 16test2: 0 failed, 0 errors of 9 tests
- [x] pre-commit on the changed files
- [ ] After deploy, confirm ODOO-90 / ODOO-117 stop firing on the next Trendyol order sync (order 11550132651 / VAT 80012349540)


Made with [Cursor](https://cursor.com)