### PR TITLE
[FIX] altinkaya_reports: omit cancelled raw moves on Üretim Emri

### DIFF
--- a/altinkaya_reports/report/report_mrp_production.xml
+++ b/altinkaya_reports/report/report_mrp_production.xml
@@ -190,59 +190,54 @@
                             <span t-field="o.sale_id.partner_id.display_name" />
                         </div>
 
-                        <table class="table table-condensed" t-if="o.move_raw_ids">
-                            <t t-if="o.move_raw_ids">
-                                <thead>
-                                    <tr>
-                                        <th>
-                                            <strong
-                                            >Üretimde Kullanılacak Ürünler</strong>
-                                        </th>
-                                        <th class="text-right">
-                                            <strong>Quantity</strong>
-                                        </th>
-                                        <th class="text-center">
-                                            <strong>Kaynak Konum</strong>
-                                        </th>
-                                    </tr>
-                                </thead>
-                            </t>
+                        <t
+                            t-set="raw_moves"
+                            t-value="o.move_raw_ids.filtered(lambda m: m.state != 'cancel')"
+                        />
+                        <table class="table table-condensed" t-if="raw_moves">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <strong>Üretimde Kullanılacak Ürünler</strong>
+                                    </th>
+                                    <th class="text-right">
+                                        <strong>Quantity</strong>
+                                    </th>
+                                    <th class="text-center">
+                                        <strong>Kaynak Konum</strong>
+                                    </th>
+                                </tr>
+                            </thead>
                             <tbody>
-                                <t t-if="o.move_raw_ids">
-                                    <tr t-foreach="o.move_raw_ids" t-as="line">
-                                        <td style="font-size:11px; line-heigh:80%;">
-                                            <span
-                                                t-if="line.product_id and line.product_id.barcode"
-                                            >
-                                                <img
-                                                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', line.product_id.barcode, 200, 15)"
-                                                    style="width:200px;height:15px"
-                                                />
-                                            </span>
-                                            <span
-                                                t-field="line.product_id.display_name"
+                                <tr t-foreach="raw_moves" t-as="line">
+                                    <td style="font-size:11px; line-heigh:80%;">
+                                        <span
+                                            t-if="line.product_id and line.product_id.barcode"
+                                        >
+                                            <img
+                                                t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('EAN13', line.product_id.barcode, 200, 15)"
+                                                style="width:200px;height:15px"
                                             />
-                                        </td>
+                                        </span>
+                                        <span t-field="line.product_id.display_name" />
+                                    </td>
 
-                                        <td style="font-size:12px;" class="text-right">
-                                            <t>
-                                                <t
-                                                    t-out="int(round(line.product_uom_qty, 2)) if round(line.product_uom_qty, 2).is_integer() else '{:.2f}'.format(line.product_uom_qty)"
-                                                />
-                                                <span
-                                                    t-field="line.product_uom.name"
-                                                    groups="product.group_uom"
-                                                />
-                                            </t>
-                                        </td>
-
-                                        <td style="font-size:10px;" class="text-center">
-                                            <span
-                                                t-field="line.location_id.display_name"
+                                    <td style="font-size:12px;" class="text-right">
+                                        <t>
+                                            <t
+                                                t-out="int(round(line.product_uom_qty, 2)) if round(line.product_uom_qty, 2).is_integer() else '{:.2f}'.format(line.product_uom_qty)"
                                             />
-                                        </td>
-                                    </tr>
-                                </t>
+                                            <span
+                                                t-field="line.product_uom.name"
+                                                groups="product.group_uom"
+                                            />
+                                        </t>
+                                    </td>
+
+                                    <td style="font-size:10px;" class="text-center">
+                                        <span t-field="line.location_id.display_name" />
+                                    </td>
+                                </tr>
                             </tbody>
                         </table>
 


### PR DESCRIPTION
## Summary
- The Üretim Emri QWeb listed every `move_raw_ids` line under **Üretimde Kullanılacak Ürünler**, including cancelled `stock.move` records.
- Filter those lines with `state != 'cancel'` and hide the table when nothing remains.

## Test plan
- [ ] Upgrade `altinkaya_reports` so the QWeb template reloads
- [ ] Print Üretim Emri for an MO whose components include a cancelled raw move and confirm that line is absent
- [ ] Print an MO with only active raw moves and confirm the table is unchanged
- [ ] Print an MO whose raw moves are all cancelled and confirm the components table is omitted


Made with [Cursor](https://cursor.com)