### PR TITLE
[FIX] altinkaya_stock: cap inconsistent unreserve requests

### DIFF
--- a/altinkaya_stock/i18n/altinkaya_stock.pot
+++ b/altinkaya_stock/i18n/altinkaya_stock.pot
@@ -687,6 +687,15 @@ msgid "Invoice Address"
 msgstr ""
 
 #. module: altinkaya_stock
+#. odoo-python
+#: code:addons/altinkaya_stock/models/stock_quant.py:0
+#, python-format
+msgid ""
+"It is not possible to unreserve more products of %s than you have in stock.\n"
+"Please contact your system administrator to rectify this issue."
+msgstr ""
+
+#. module: altinkaya_stock
 #: model:ir.model.fields,field_description:altinkaya_stock.field_stock_package_type__is_pallet
 #: model:ir.model.fields,field_description:altinkaya_stock.field_stock_quant_package__is_pallet
 msgid "Is Pallet"

--- a/altinkaya_stock/i18n/tr.po
+++ b/altinkaya_stock/i18n/tr.po
@@ -687,6 +687,18 @@ msgid "Invoice Address"
 msgstr "Fatura Adresi"
 
 #. module: altinkaya_stock
+#. odoo-python
+#: code:addons/altinkaya_stock/models/stock_quant.py:0
+#, python-format
+msgid ""
+"It is not possible to unreserve more products of %s than you have in stock.\n"
+"Please contact your system administrator to rectify this issue."
+msgstr ""
+"%s ürünü için mevcut rezervasyondan daha fazla miktarın rezervasyonu "
+"kaldırılamaz.\n"
+"Sorunu düzeltmek için lütfen sistem yöneticinize başvurun."
+
+#. module: altinkaya_stock
 #: model:ir.model.fields,field_description:altinkaya_stock.field_stock_package_type__is_pallet
 #: model:ir.model.fields,field_description:altinkaya_stock.field_stock_quant_package__is_pallet
 msgid "Is Pallet"

--- a/altinkaya_stock/models/stock_quant.py
+++ b/altinkaya_stock/models/stock_quant.py
@@ -1,4 +1,10 @@
-from odoo import api, fields, models
+import logging
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools.float_utils import float_compare, float_is_zero
+
+_logger = logging.getLogger(__name__)
 
 
 class StockQuant(models.Model):
@@ -32,3 +38,78 @@ class StockQuant(models.Model):
         if removal_strategy == "priorityfifo":
             return "priority, in_date ASC, id"
         return super()._get_removal_strategy_order(removal_strategy)
+
+    @api.model
+    def _update_reserved_quantity(
+        self,
+        product_id,
+        location_id,
+        quantity,
+        lot_id=None,
+        package_id=None,
+        owner_id=None,
+        strict=False,
+    ):
+        """Cap unreserve to what is actually reserved on matching quants."""
+        rounding = product_id.uom_id.rounding
+        if float_compare(quantity, 0, precision_rounding=rounding) < 0:
+            quants = self.sudo()._gather(
+                product_id,
+                location_id,
+                lot_id=lot_id,
+                package_id=package_id,
+                owner_id=owner_id,
+                strict=strict,
+            )
+            negative_quants = quants.filtered(
+                lambda quant: (
+                    float_compare(
+                        quant.reserved_quantity, 0, precision_rounding=rounding
+                    )
+                    < 0
+                )
+            )
+            if negative_quants:
+                _logger.warning(
+                    "Skipping unreserve of %s of %s at %s because quants %s have "
+                    "negative reserved quantities",
+                    abs(quantity),
+                    product_id.display_name,
+                    location_id.display_name,
+                    negative_quants.ids,
+                )
+                self._raise_fix_unreserve_action(product_id)
+                raise UserError(
+                    _(
+                        "It is not possible to unreserve more products of %s than "
+                        "you have in stock.\nPlease contact your system administrator "
+                        "to rectify this issue.",
+                        product_id.display_name,
+                    )
+                )
+            available_reserved = sum(quants.mapped("reserved_quantity"))
+            if (
+                float_compare(
+                    abs(quantity), available_reserved, precision_rounding=rounding
+                )
+                > 0
+            ):
+                _logger.warning(
+                    "Capping unreserve of %s of %s at %s to the %s actually reserved",
+                    abs(quantity),
+                    product_id.display_name,
+                    location_id.display_name,
+                    available_reserved,
+                )
+                quantity = -available_reserved
+                if float_is_zero(quantity, precision_rounding=rounding):
+                    return []
+        return super()._update_reserved_quantity(
+            product_id,
+            location_id,
+            quantity,
+            lot_id=lot_id,
+            package_id=package_id,
+            owner_id=owner_id,
+            strict=strict,
+        )

--- a/altinkaya_stock/tests/__init__.py
+++ b/altinkaya_stock/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_stock_quant

--- a/altinkaya_stock/tests/test_stock_quant.py
+++ b/altinkaya_stock/tests/test_stock_quant.py
@@ -1,0 +1,83 @@
+from odoo.exceptions import RedirectWarning
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestUnreserveCap(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Reservation discrepancy product",
+                "type": "product",
+                "categ_id": cls.env.ref("product.product_category_all").id,
+            }
+        )
+
+    def _confirm_and_assign(self, qty):
+        self.env["stock.quant"]._update_available_quantity(
+            self.product, self.stock_location, qty
+        )
+        move = self.env["stock.move"].create(
+            {
+                "name": "reservation discrepancy move",
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "product_id": self.product.id,
+                "product_uom": self.uom_unit.id,
+                "product_uom_qty": qty,
+            }
+        )
+        move._action_confirm()
+        move._action_assign()
+        return move
+
+    def test_unreserve_caps_when_quant_reserved_is_lower(self):
+        move = self._confirm_and_assign(10)
+        quant = self.env["stock.quant"]._gather(self.product, self.stock_location)
+        self.assertEqual(quant.reserved_quantity, 10)
+        quant.sudo().write({"reserved_quantity": 1})
+
+        move._do_unreserve()
+
+        self.assertEqual(move.state, "confirmed")
+        self.assertEqual(quant.reserved_quantity, 0)
+
+    def test_unreserve_rejects_negative_reserved_quant(self):
+        move = self._confirm_and_assign(10)
+        quant = self.env["stock.quant"]._gather(self.product, self.stock_location)
+        quant.sudo().write({"reserved_quantity": -5})
+
+        with self.assertRaises(RedirectWarning):
+            move._do_unreserve()
+
+        self.assertEqual(move.state, "assigned")
+        self.assertEqual(quant.reserved_quantity, -5)
+
+    def test_unreserve_rejects_mixed_negative_reserved_quants(self):
+        move = self._confirm_and_assign(10)
+        first_quant = self.env["stock.quant"]._gather(self.product, self.stock_location)
+        first_quant.sudo().write({"reserved_quantity": -5})
+        second_quant = (
+            self.env["stock.quant"]
+            .sudo()
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "location_id": self.stock_location.id,
+                    "quantity": 10,
+                    "reserved_quantity": 10,
+                }
+            )
+        )
+
+        with self.assertRaises(RedirectWarning):
+            move._do_unreserve()
+
+        self.assertEqual(move.state, "assigned")
+        self.assertEqual(first_quant.reserved_quantity, -5)
+        self.assertEqual(second_quant.reserved_quantity, 10)


### PR DESCRIPTION
## Summary

- Cap unreserve requests when a move line reserves more than the matching non-negative stock quants actually hold, so transfer validation or cancellation can continue.
- Preserve Odoo's standard administrator Fix discrepancies flow whenever any matching quant has a negative reservation, including mixed negative and positive duplicate quants.
- Keep the change runtime-only in altinkaya_stock; no scheduled cron or custom batch repair action is added.
- Add the user-facing error to the translation template and provide its Turkish translation.

This replaces the implementation proposed in the closed altinkaya-opensource/odoo#726, which targeted the wrong module.

## Validation

- [x] Three targeted altinkaya_stock Odoo tests passed on 16test2.
- [x] Module upgrade loaded the Turkish PO entry without translation errors.
- [x] pre-commit run -a passed.
