### PR TITLE
[FIX] db_retention: reject non-stored retention date fields

### DIFF
--- a/db_retention/i18n/tr.po
+++ b/db_retention/i18n/tr.po
@@ -199,6 +199,13 @@ msgid "Run Now"
 msgstr "Şimdi Çalıştır"
 
 #. module: db_retention
+#. odoo-python
+#: code:addons/db_retention/models/db_retention_rule.py:0
+#, python-format
+msgid "Select a stored Date or Datetime field from the rule's model."
+msgstr "Kuralın modelinden veritabanında saklanan bir Tarih veya Tarih-Saat alanı seçin."
+
+#. module: db_retention
 #: model:ir.model.fields,field_description:db_retention.field_db_retention_rule__sequence
 msgid "Sequence"
 msgstr "Sıra"

--- a/db_retention/models/db_retention_rule.py
+++ b/db_retention/models/db_retention_rule.py
@@ -31,7 +31,8 @@ class DbRetentionRule(models.Model):
         "ir.model.fields",
         required=True,
         ondelete="cascade",
-        domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime'))]",
+        domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime')), "
+        "('store', '=', True)]",
         help="Date/Datetime field compared against the retention threshold.",
     )
     date_field_name = fields.Char(
@@ -67,6 +68,16 @@ class DbRetentionRule(models.Model):
     def _get_domain(self):
         """Build the search domain: date threshold plus the optional user domain."""
         self.ensure_one()
+        date_field = self.env[self.model_name]._fields.get(self.date_field_name)
+        if (
+            self.date_field_id.model_id != self.model_id
+            or not date_field
+            or not date_field.store
+            or date_field.type not in ("date", "datetime")
+        ):
+            raise ValidationError(
+                _("Select a stored Date or Datetime field from the rule's model.")
+            )
         threshold = fields.Datetime.now() - relativedelta(days=self.retention_days)
         domain = [(self.date_field_name, "<", threshold)]
         extra = safe_eval(self.domain or "[]")

--- a/db_retention/tests/__init__.py
+++ b/db_retention/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Yiğit Budak (https://github.com/yibudak)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_retention_date_field

--- a/db_retention/tests/test_retention_date_field.py
+++ b/db_retention/tests/test_retention_date_field.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Yiğit Budak (https://github.com/yibudak)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestRetentionDateField(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.log_model = cls.env["ir.model"]._get("ir.logging")
+        cls.rule = cls.env["db.retention.rule"].create(
+            {
+                "name": "Retention date validation test",
+                "model_id": cls.log_model.id,
+                "date_field_id": cls.env["ir.model.fields"]
+                ._get("ir.logging", "create_date")
+                .id,
+                "retention_days": 30,
+                "active": False,
+            }
+        )
+
+    def test_invalid_date_field_stops_before_search(self):
+        for model_name, field_name in (
+            ("ir.logging", "__last_update"),
+            ("ir.logging", "name"),
+            ("res.partner", "create_date"),
+        ):
+            with self.subTest(model=model_name, field=field_name):
+                self.rule.date_field_id = self.env["ir.model.fields"]._get(
+                    model_name, field_name
+                )
+                with (
+                    patch.object(
+                        type(self.env["ir.logging"]),
+                        "search",
+                        side_effect=AssertionError("Cleanup reached record search"),
+                    ) as search,
+                    self.assertRaises(ValidationError),
+                ):
+                    self.rule._clean()
+                search.assert_not_called()
+
+    def test_stored_date_keeps_retention_threshold(self):
+        """Select only the old fixture; never execute a deletion in this test."""
+        now = fields.Datetime.now()
+        logs = self.env["ir.logging"].create(
+            [
+                {
+                    "name": "Retention date test",
+                    "type": "server",
+                    "dbname": self.env.cr.dbname,
+                    "level": "INFO",
+                    "message": "Retention date test",
+                    "path": __name__,
+                    "func": "test_stored_date_keeps_retention_threshold",
+                    "line": "0",
+                }
+                for _index in range(2)
+            ]
+        )
+        for log, days in zip(logs, (60, 1), strict=True):
+            # Set fixture timestamps through the ORM field; write() protects them.
+            log._fields["create_date"].write(log, now - timedelta(days=days))
+        self.rule.domain = repr([("id", "in", logs.ids)])
+
+        matching = self.env["ir.logging"].search(self.rule._get_domain())
+
+        self.assertEqual(matching, logs[0])
+        self.assertEqual(logs.exists(), logs)


### PR DESCRIPTION
Using a non-stored field such as `queue.job.__last_update` as the retention date makes Odoo discard the age condition, allowing recent records that match the remaining filters to be selected for deletion (Bugsink ODOO-11).

Validate that the selected field belongs to the target model and is a stored Date/Datetime before record search begins. Apply the same stored-field restriction to the selector and add the Turkish validation message. Existing invalid rules stop until a valid field is selected; this change does not migrate rules or run a cleanup.

Validation:

- 2 Odoo tests passed on the installed `16test2` stack using this isolated branch: invalid-field rejection before search and retention-threshold selection using temporary fixtures. No deletion was executed.
- Full `pre-commit run -a` and `git diff --check` passed.
