### PR TITLE
[FIX] delivery_integration_base: isolate tracking updates

### DIFF
--- a/delivery_integration_base/models/delivery_carrier.py
+++ b/delivery_integration_base/models/delivery_carrier.py
@@ -181,9 +181,10 @@ class DeliveryCarrier(models.Model):
 
         for picking in pickings:
             try:
-                method = f"{picking.delivery_type}_tracking_state_update"
-                if hasattr(picking.carrier_id, method):
-                    getattr(picking.carrier_id, method)(picking)
+                with self.env.cr.savepoint():
+                    method = f"{picking.delivery_type}_tracking_state_update"
+                    if hasattr(picking.carrier_id, method):
+                        getattr(picking.carrier_id, method)(picking)
             except Exception as exc:
                 _logger.error("Error updating picking %s state: %s", picking.name, exc)
 

--- a/delivery_integration_base/tests/__init__.py
+++ b/delivery_integration_base/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 Yiğit Budak (https://github.com/yibudak)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from . import test_delivery_tracking

--- a/delivery_integration_base/tests/test_delivery_tracking.py
+++ b/delivery_integration_base/tests/test_delivery_tracking.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Yiğit Budak (https://github.com/yibudak)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from unittest.mock import patch
+
+from odoo import _
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+from odoo.tools import mute_logger
+
+
+@tagged("post_install", "-at_install")
+class TestDeliveryTracking(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        product = cls.env["product.product"].create(
+            {"name": "Tracking test delivery", "type": "service"}
+        )
+        cls.carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Tracking test carrier",
+                "delivery_type": "fixed",
+                "product_id": product.id,
+                "currency_id": cls.env.company.currency_id.id,
+            }
+        )
+        warehouse = cls.env["stock.warehouse"].search(
+            [("company_id", "=", cls.env.company.id)], limit=1
+        )
+        cls.pickings = cls.env["stock.picking"].create(
+            [
+                {
+                    "name": f"Tracking test {index}",
+                    "picking_type_id": warehouse.out_type_id.id,
+                    "location_id": warehouse.lot_stock_id.id,
+                    "location_dest_id": cls.env.ref(
+                        "stock.stock_location_customers"
+                    ).id,
+                    "carrier_id": cls.carrier.id,
+                }
+                for index in range(3)
+            ]
+        )
+
+    def test_tracking_database_error_is_isolated(self):
+        self._assert_failed_picking_is_isolated(database_error=True)
+
+    def test_tracking_provider_error_rolls_back_partial_update(self):
+        self._assert_failed_picking_is_isolated(database_error=False)
+
+    def _assert_failed_picking_is_isolated(self, database_error):
+        """Keep successful updates around a failed tracking operation."""
+        visited = []
+        failed_id = self.pickings[1].id
+
+        def update_tracking(carrier, picking):
+            visited.append(picking.id)
+            picking.carrier_shipping_cost = 42
+            picking.flush_recordset(["carrier_shipping_cost"])
+            if picking.id == failed_id:
+                if database_error:
+                    # Trigger a real PostgreSQL error without changing business data.
+                    self.env.cr.execute("SELECT 1 / 0")
+                raise UserError(_("Carrier unavailable"))
+
+        with (
+            patch.object(type(self.pickings), "search", return_value=self.pickings),
+            patch.object(
+                type(self.carrier),
+                "fixed_tracking_state_update",
+                update_tracking,
+                create=True,
+            ),
+            mute_logger(
+                "odoo.sql_db",
+                "odoo.addons.delivery_integration_base.models.delivery_carrier",
+            ),
+        ):
+            self.carrier._update_all_picking_status()
+
+        self.env.flush_all()
+        self.pickings.invalidate_recordset(["carrier_shipping_cost"])
+        self.assertEqual(visited, self.pickings.ids)
+        self.assertEqual(self.pickings.mapped("carrier_shipping_cost"), [42, 0, 42])


### PR DESCRIPTION
A SQL error during a carrier tracking update leaves the cron transaction aborted, so subsequent pickings and the final cron flush fail too (Bugsink ODOO-24/ODOO-18). Provider errors can also leave partial writes on the failed picking.

Wrap each picking update in an Odoo savepoint so failed writes roll back while successful updates before and after the failure survive. The original carrier error remains logged.

Validation:

- 2 Odoo tests passed on the installed `16test2` stack using this isolated branch, covering a real PostgreSQL error and a provider error between two successful updates.
- Full `pre-commit run -a` and `git diff --check` passed.
