### PR TITLE
[FIX] hepsiburada_integration: parse settlement ISO dates

### DIFF
--- a/hepsiburada_integration/models/hepsiburada_settlement.py
+++ b/hepsiburada_integration/models/hepsiburada_settlement.py
@@ -7,6 +7,8 @@ import logging
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
+from .hepsiburada_backend import _parse_hb_datetime
+
 _logger = logging.getLogger(__name__)
 
 TRANSACTION_TYPE_MAP = {
@@ -172,6 +174,7 @@ class HepsiburadaSettlement(models.Model):
             currency_code = amount_data.get("currencyCode") or currency_code
 
         try:
+            # Reject invalid dates instead of silently importing them as empty.
             vals = {
                 "backend_id": backend.id,
                 "hb_transaction_id": transaction_id,
@@ -179,7 +182,8 @@ class HepsiburadaSettlement(models.Model):
                 "hb_transaction_type": hb_transaction_type,
                 "is_income": is_income,
                 "is_invoice": data.get("isInvoice") is True,
-                "transaction_date": data.get("recordDate"),
+                "transaction_date": _parse_hb_datetime(data.get("recordDate"))
+                or fields.Datetime.to_datetime(data.get("recordDate")),
                 "order_number": order_number,
                 "package_number": str(data.get("packageNumber") or ""),
                 "sku": data.get("sku", ""),
@@ -194,7 +198,8 @@ class HepsiburadaSettlement(models.Model):
                 "tax_amount": self._numeric_value(data.get("taxAmount", 0.0)),
                 "quantity": self._numeric_value(data.get("quantity", 0.0)),
                 "currency_code": str(currency_code or "949"),
-                "payment_date": data.get("paymentDate"),
+                "payment_date": _parse_hb_datetime(data.get("paymentDate"))
+                or fields.Datetime.to_datetime(data.get("paymentDate")),
                 "payment_status": data.get("status", ""),
                 "invoice_number": data.get("invoiceNumber", ""),
                 "hb_order_id": hb_order.id if hb_order else False,

--- a/hepsiburada_integration/tests/test_hepsiburada_settlement.py
+++ b/hepsiburada_integration/tests/test_hepsiburada_settlement.py
@@ -1,12 +1,64 @@
 # Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
+from datetime import datetime
+
 from odoo import fields
+from odoo.tools import mute_logger
 
 from .common import HepsiburadaCommon
 
 
 class TestHepsiburadaSettlement(HepsiburadaCommon):
+    def test_import_settlement_parses_iso_dates(self):
+        settlement = self.env["hepsiburada.settlement"]._import_settlement(
+            self.backend,
+            {
+                "id": "iso-dates",
+                "recordDate": "2026-09-01T00:00:00",
+                "paymentDate": "2026-09-02T10:30:00.123",
+            },
+        )
+
+        self.assertEqual(settlement.transaction_date, datetime(2026, 9, 1))
+        self.assertEqual(
+            settlement.payment_date, datetime(2026, 9, 2, 10, 30, 0, 123000)
+        )
+
+    def test_import_settlement_updates_dates_in_utc(self):
+        settlement_model = self.env["hepsiburada.settlement"]
+        settlement = settlement_model._import_settlement(
+            self.backend, {"id": "updated-dates"}
+        )
+
+        updated = settlement_model._import_settlement(
+            self.backend,
+            {
+                "id": "updated-dates",
+                "recordDate": "2026-09-01T01:00:00+03:00",
+                "paymentDate": "2026-09-02T10:30:00Z",
+            },
+        )
+
+        self.assertEqual(updated, settlement)
+        self.assertEqual(updated.transaction_date, datetime(2026, 8, 31, 22))
+        self.assertEqual(updated.payment_date, datetime(2026, 9, 2, 10, 30))
+
+    def test_import_settlement_rejects_invalid_dates(self):
+        for field_name in ("recordDate", "paymentDate"):
+            with (
+                self.subTest(field_name=field_name),
+                mute_logger(
+                    "odoo.addons.hepsiburada_integration.models.hepsiburada_settlement"
+                ),
+                self.assertRaises(ValueError),
+                self.env.cr.savepoint(),
+            ):
+                self.env["hepsiburada.settlement"]._import_settlement(
+                    self.backend,
+                    {"id": f"invalid-{field_name}", field_name: "invalid-date"},
+                )
+
     def test_import_settlement_extracts_nested_amount(self):
         settlement = self.env["hepsiburada.settlement"]._import_settlement(
             self.backend,
@@ -20,6 +72,8 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
 
         self.assertEqual(settlement.amount, -408.0)
         self.assertEqual(settlement.currency_code, "949")
+        self.assertFalse(settlement.transaction_date)
+        self.assertFalse(settlement.payment_date)
 
     def test_will_be_paid_transaction_is_not_reconciled(self):
         settlement = self.env["hepsiburada.settlement"].create(


### PR DESCRIPTION
Hepsiburada settlement imports pass ISO `recordDate` and `paymentDate` strings directly to Odoo Datetime fields, causing create/update failures for timestamps such as `2026-09-01T00:00:00` (Bugsink ODOO-87).

Reuse the integration's existing datetime parser for both fields, normalizing timezone-aware values to UTC and preserving its naive-date convention. Empty dates remain supported; invalid nonempty dates are rejected instead of silently cleared.

Validation:

- 7 Odoo settlement tests passed on the installed `16test2` stack using this isolated branch, including ISO/fractional dates, UTC conversion, create/update, invalid/empty dates and existing reconciliation behavior.
- Full `pre-commit run -a` and `git diff --check` passed.
