### PR TITLE
[FIX] Trendyol: prevent customer reuse from incomplete order data

### DIFF
--- a/trendyol_integration/i18n/tr.po
+++ b/trendyol_integration/i18n/tr.po
@@ -7174,3 +7174,10 @@ msgstr "Yanıtsız"
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
 msgid "Waiting Fraud Check"
 msgstr "Fraud Kontrolü Bekliyor"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_order.py:0
+#, python-format
+msgid "Trendyol customer information is not available yet. Retry the import later."
+msgstr "Trendyol müşteri bilgileri henüz hazır değil. İçe aktarmayı daha sonra tekrar deneyin."

--- a/trendyol_integration/i18n/trendyol_integration.pot
+++ b/trendyol_integration/i18n/trendyol_integration.pot
@@ -6971,3 +6971,10 @@ msgstr ""
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
 msgid "Waiting Fraud Check"
 msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_order.py:0
+#, python-format
+msgid "Trendyol customer information is not available yet. Retry the import later."
+msgstr ""

--- a/trendyol_integration/models/trendyol_order.py
+++ b/trendyol_integration/models/trendyol_order.py
@@ -154,6 +154,10 @@ class TrendyolOrder(models.Model):
         Returns:
             trendyol.order record
         """
+        # Awaiting packages have not passed payment checks and can omit buyer data.
+        if self._map_status(order_data.get("status")) == "awaiting":
+            return False
+
         package_value = order_data.get("shipmentPackageId") or order_data.get("id")
         order_number_value = order_data.get("orderNumber")
 
@@ -196,7 +200,9 @@ class TrendyolOrder(models.Model):
                     "backend_id": backend.id,
                     "trendyol_order_number": order_number,
                     "trendyol_package_id": package_id,
-                    "trendyol_customer_id": str(order_data.get("customerId", "")),
+                    "trendyol_customer_id": self._normalize_customer_id(
+                        order_data.get("customerId")
+                    ),
                     "trendyol_status": self._map_status(order_data.get("status"))
                     or "created",
                     "cargo_provider_name": order_data.get("cargoProviderName"),
@@ -237,9 +243,17 @@ class TrendyolOrder(models.Model):
     def _update_from_trendyol_data(self, order_data):
         """Refresh mutable package data on an existing binding."""
         self.ensure_one()
+        new_status = self._map_status(order_data.get("status"))
+        if new_status == "awaiting":
+            return self
+
         vals = {
             "raw_data": json.dumps(order_data, indent=2, ensure_ascii=False),
         }
+        customer_id = self._normalize_customer_id(order_data.get("customerId"))
+        if customer_id and not self._normalize_customer_id(self.trendyol_customer_id):
+            vals["trendyol_customer_id"] = customer_id
+
         field_map = {
             "cargoProviderName": "cargo_provider_name",
             "cargoProviderId": "cargo_provider_id",
@@ -253,7 +267,6 @@ class TrendyolOrder(models.Model):
             if value:
                 vals[odoo_field] = value
 
-        new_status = self._map_status(order_data.get("status"))
         if new_status:
             vals["trendyol_status"] = new_status
 
@@ -290,6 +303,14 @@ class TrendyolOrder(models.Model):
             "AtCollectionPoint": "at_collection_point",
         }
         return status_map.get(trendyol_status)
+
+    @api.model
+    def _normalize_customer_id(self, customer_id):
+        """Return a positive Trendyol customer ID, or False for missing identity."""
+        customer_id = str(customer_id or "").strip()
+        if not customer_id.isdecimal() or int(customer_id) <= 0:
+            return False
+        return str(int(customer_id))
 
     @api.model
     def _partner_vat_digits(self, vat):
@@ -371,8 +392,12 @@ class TrendyolOrder(models.Model):
                     domain.append(("company_id", "in", [False, company_id]))
                 existing = Partner.search(domain, limit=1)
                 if existing:
-                    customer_id = partner_vals.get("trendyol_customer_id")
-                    if customer_id and not existing.trendyol_customer_id:
+                    customer_id = self._normalize_customer_id(
+                        partner_vals.get("trendyol_customer_id")
+                    )
+                    if customer_id and not self._normalize_customer_id(
+                        existing.trendyol_customer_id
+                    ):
                         existing.trendyol_customer_id = customer_id
                     _logger.warning(
                         "Reusing partner %s for Trendyol VAT %s after create error: %s",
@@ -424,7 +449,14 @@ class TrendyolOrder(models.Model):
         """
         Partner = self.env["res.partner"]
 
-        customer_id = str(order_data.get("customerId", ""))
+        customer_id = self._normalize_customer_id(order_data.get("customerId"))
+        if not customer_id:
+            raise UserError(
+                _(
+                    "Trendyol customer information is not available yet. "
+                    "Retry the import later."
+                )
+            )
         invoice_address = order_data.get("invoiceAddress", {})
         raw_tax = (invoice_address.get("taxNumber") or "").strip()
         vat = self._sanitize_partner_vat(raw_tax)
@@ -445,7 +477,7 @@ class TrendyolOrder(models.Model):
             )
             if partner:
                 # Update trendyol_customer_id if missing
-                if customer_id and not partner.trendyol_customer_id:
+                if not self._normalize_customer_id(partner.trendyol_customer_id):
                     partner.trendyol_customer_id = customer_id
                 return partner
 

--- a/trendyol_integration/tests/test_trendyol_order.py
+++ b/trendyol_integration/tests/test_trendyol_order.py
@@ -4,15 +4,103 @@
 import json
 from datetime import timedelta
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from odoo import fields
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 from .common import TrendyolTestCase
 
 
 class TestTrendyolOrder(TrendyolTestCase):
+    def test_missing_customer_identity_never_reuses_a_placeholder_partner(self):
+        Partner = self.env["res.partner"]
+        for customer_id in (0, "0", None, False, "", " ", "None", "False", -1):
+            with self.subTest(customer_id=customer_id):
+                placeholder = Partner.create(
+                    {
+                        "name": "Placeholder Customer",
+                        "trendyol_customer_id": str(customer_id),
+                    }
+                )
+                partner_count = Partner.search_count([])
+                with self.assertRaises(UserError):
+                    self.env["trendyol.order"]._get_or_create_main_partner(
+                        self.backend,
+                        {
+                            "customerId": customer_id,
+                            "invoiceAddress": {"fullName": "Different Customer"},
+                        },
+                    )
+                self.assertEqual(Partner.search_count([]), partner_count)
+                self.assertEqual(placeholder.trendyol_customer_id, str(customer_id))
+
+    def test_valid_customer_identity_reuses_the_matching_customer(self):
+        partner = self.env["res.partner"].create(
+            {"name": "Known Customer", "trendyol_customer_id": "987654321"}
+        )
+        for customer_id in (987654321, "987654321"):
+            with self.subTest(customer_id=customer_id):
+                imported = self.env["trendyol.order"]._get_or_create_main_partner(
+                    self.backend, {"customerId": customer_id}
+                )
+                self.assertEqual(imported, partner)
+
+    def test_vat_match_replaces_placeholder_customer_identity(self):
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Known Company",
+                "vat": "8001234007",
+                "trendyol_customer_id": "0",
+            }
+        )
+        imported = self.env["trendyol.order"]._get_or_create_main_partner(
+            self.backend,
+            {
+                "customerId": 987654321,
+                "invoiceAddress": {"taxNumber": partner.vat},
+            },
+        )
+        self.assertEqual(imported, partner)
+        self.assertEqual(partner.trendyol_customer_id, "987654321")
+
+    def test_customer_identity_refresh_preserves_corrected_order_partners(self):
+        sale, order = self._create_sale_and_order(package_id="CUSTOMER-REFRESH")
+        order.trendyol_customer_id = "0"
+        partners = (sale.partner_id, sale.partner_invoice_id, sale.partner_shipping_id)
+
+        order._update_from_trendyol_data({"status": "Created", "customerId": 987654321})
+        order._update_from_trendyol_data({"status": "Created", "customerId": 0})
+
+        self.assertEqual(order.trendyol_customer_id, "987654321")
+        self.assertEqual(
+            (sale.partner_id, sale.partner_invoice_id, sale.partner_shipping_id),
+            partners,
+        )
+
+    def test_missing_identity_keeps_polling_cursor_and_creates_no_order(self):
+        old_cursor = fields.Datetime.now() - timedelta(hours=1)
+        self.backend.last_order_sync = old_cursor
+        data = {
+            "shipmentPackageId": "MISSING-CUSTOMER",
+            "orderNumber": "MISSING-CUSTOMER",
+            "status": "Created",
+            "customerId": 0,
+            "invoiceAddress": {"fullName": "Different Customer"},
+        }
+        client = SimpleNamespace(
+            get_orders=lambda **_kwargs: {"content": [data], "totalPages": 1}
+        )
+        partner_count = self.env["res.partner"].search_count([])
+        order_count = self.env["sale.order"].search_count([])
+
+        with patch.object(type(self.backend), "_get_api_client", return_value=client):
+            self.backend._import_orders()
+
+        self.assertEqual(self.backend.last_order_sync, old_cursor)
+        self.assertEqual(self.env["res.partner"].search_count([]), partner_count)
+        self.assertEqual(self.env["sale.order"].search_count([]), order_count)
+
     def test_existing_order_refreshes_cargo_without_status_change(self):
         _sale, order = self._create_sale_and_order(status="created")
 
@@ -146,7 +234,7 @@ class TestTrendyolOrder(TrendyolTestCase):
         partner = self.env["trendyol.order"]._get_or_create_main_partner(
             self.backend,
             {
-                "customerId": "ty-cust-invalid-vat",
+                "customerId": 987654321,
                 "invoiceAddress": {
                     "company": "WARMER INNOVATION",
                     "taxNumber": "80012349540",
@@ -161,7 +249,7 @@ class TestTrendyolOrder(TrendyolTestCase):
         self.assertEqual(partner.name, "WARMER INNOVATION")
         self.assertFalse(partner.vat)
         self.assertEqual(partner.company_type, "company")
-        self.assertEqual(partner.trendyol_customer_id, "ty-cust-invalid-vat")
+        self.assertEqual(partner.trendyol_customer_id, "987654321")
 
     def test_create_main_partner_drops_vat_on_validation_error(self):
         Partner = self.env["res.partner"]
@@ -193,8 +281,9 @@ class TestTrendyolOrder(TrendyolTestCase):
         existing = Partner.create(
             {
                 "name": "Same Company VAT",
-                "vat": "11111111110",
+                "vat": "8001234007",
                 "company_id": self.env.company.id,
+                "trendyol_customer_id": "0",
             }
         )
         with self._patch_create_failing_on_vat(
@@ -204,16 +293,16 @@ class TestTrendyolOrder(TrendyolTestCase):
                 Partner,
                 {
                     "name": "New Import",
-                    "vat": "11111111110",
+                    "vat": "8001234007",
                     "company_id": self.env.company.id,
-                    "trendyol_customer_id": "ty-reuse-1",
+                    "trendyol_customer_id": "987654321",
                     "company_type": "company",
                     "country_id": self.env.ref("base.tr").id,
                 },
             )
 
         self.assertEqual(reused, existing)
-        self.assertEqual(existing.trendyol_customer_id, "ty-reuse-1")
+        self.assertEqual(existing.trendyol_customer_id, "987654321")
 
     def test_create_main_partner_does_not_reuse_other_company_on_duplicate_vat(self):
         Partner = self.env["res.partner"]
@@ -221,7 +310,7 @@ class TestTrendyolOrder(TrendyolTestCase):
         other = Partner.create(
             {
                 "name": "Other Company VAT",
-                "vat": "11111111110",
+                "vat": "8001234007",
                 "company_id": other_company.id,
             }
         )
@@ -232,7 +321,7 @@ class TestTrendyolOrder(TrendyolTestCase):
                 Partner,
                 {
                     "name": "This Company Import",
-                    "vat": "11111111110",
+                    "vat": "8001234007",
                     "company_id": self.env.company.id,
                     "trendyol_customer_id": "ty-other-co",
                     "company_type": "company",
@@ -249,16 +338,13 @@ class TestTrendyolOrder(TrendyolTestCase):
     def test_create_main_partner_does_not_reuse_on_invalid_vat_error(self):
         Partner = self.env["res.partner"]
         decoy = Partner.create({"name": "Decoy VAT Partner"})
-        PartnerClass = type(Partner)
-        with (
-            self._patch_create_failing_on_vat(
-                Partner,
-                "The VAT number [%s] for partner [X] does not seem to be valid.",
-            ),
-            patch.object(PartnerClass, "search", return_value=decoy) as search_mock,
+        search_mock = Mock(return_value=decoy)
+        with self._patch_create_failing_on_vat(
+            Partner,
+            "The VAT number [%s] for partner [X] does not seem to be valid.",
         ):
             created = self.env["trendyol.order"]._create_main_partner(
-                Partner,
+                SimpleNamespace(create=Partner.create, search=search_mock),
                 {
                     "name": "Invalid VAT Import",
                     "vat": "80012349540",

--- a/trendyol_integration/tests/test_trendyol_webhook.py
+++ b/trendyol_integration/tests/test_trendyol_webhook.py
@@ -30,6 +30,98 @@ class FakeRequest:
 
 
 class TestTrendyolWebhook(TrendyolTestCase):
+    def _customer_package(self, package_id, customer_id, status="Created"):
+        """Build a package with separate invoice and shipping addresses."""
+        return {
+            "shipmentPackageId": package_id,
+            "orderNumber": f"ORDER-{package_id}",
+            "status": status,
+            "customerId": customer_id,
+            "invoiceAddress": {
+                "id": package_id * 10,
+                "fullName": f"Customer {package_id}",
+                "address1": "Invoice Street 1",
+                "city": "Ankara",
+                "countryCode": "TR",
+            },
+            "shipmentAddress": {
+                "id": package_id * 10 + 1,
+                "fullName": f"Recipient {package_id}",
+                "address1": "Shipping Street 2",
+                "city": "Ankara",
+                "countryCode": "TR",
+            },
+            "lines": [],
+        }
+
+    def test_awaiting_then_created_imports_distinct_customers_once(self):
+        self.backend.auto_confirm_orders = False
+        placeholder = self.env["res.partner"].create(
+            {"name": "Unrelated Company", "trendyol_customer_id": "0"}
+        )
+        Order = self.env["trendyol.order"]
+        partner_count = self.env["res.partner"].search_count([])
+        sale_count = self.env["sale.order"].search_count([])
+
+        self.backend._process_webhook_data(
+            {
+                "content": [
+                    self._customer_package(901, 0, status="Awaiting"),
+                    self._customer_package(902, 0, status="Awaiting"),
+                ]
+            }
+        )
+
+        self.assertEqual(self.env["res.partner"].search_count([]), partner_count)
+        self.assertEqual(self.env["sale.order"].search_count([]), sale_count)
+        payload = {
+            "content": [
+                self._customer_package(901, 987654321),
+                self._customer_package(902, 987654322),
+            ]
+        }
+        self.backend._process_webhook_data(payload)
+        self.backend._process_webhook_data(payload)
+
+        orders = Order.search([("backend_id", "=", self.backend.id)])
+        self.assertEqual(len(orders), 2)
+        self.assertEqual(len(orders.partner_id), 2)
+        self.assertEqual(self.env["sale.order"].search_count([]), sale_count + 2)
+        self.assertNotIn(placeholder, orders.partner_id)
+        self.assertEqual(placeholder.trendyol_customer_id, "0")
+        for order in orders:
+            with self.subTest(package_id=order.trendyol_package_id):
+                self.assertEqual(order.trendyol_status, "created")
+                self.assertEqual(
+                    order.trendyol_customer_id, order.partner_id.trendyol_customer_id
+                )
+                self.assertEqual(order.partner_invoice_id, order.partner_id)
+                self.assertNotEqual(order.partner_shipping_id, order.partner_id)
+                self.assertEqual(order.partner_shipping_id.parent_id, order.partner_id)
+
+    def test_late_awaiting_keeps_existing_customer_data_and_status(self):
+        sale, order = self._create_sale_and_order(status="created")
+        data = self._customer_package(123, 987654321)
+        order.write(
+            {
+                "trendyol_customer_id": "987654321",
+                "raw_data": json.dumps(data),
+                "cargo_tracking_number": "VALID-TRACKING",
+            }
+        )
+        original_data = order.raw_data
+        original_partner = sale.partner_id
+
+        self.backend._process_webhook_data(
+            {"content": [self._customer_package(123, 0, status="Awaiting")]}
+        )
+
+        self.assertEqual(order.trendyol_status, "created")
+        self.assertEqual(order.trendyol_customer_id, "987654321")
+        self.assertEqual(order.raw_data, original_data)
+        self.assertEqual(order.cargo_tracking_number, "VALID-TRACKING")
+        self.assertEqual(sale.partner_id, original_partner)
+
     def test_plain_json_payload_is_authenticated_and_queued(self):
         controller = TrendyolWebhookController()
         payload = {"content": [{"shipmentPackageId": 123}]}


### PR DESCRIPTION
An `Awaiting` webhook can contain `customerId=0`. Converting that value to the nonempty string `"0"` made unrelated buyers reuse the same customer card. The later `Created` event updated the raw payload while leaving the original customer assignment in place.

Defer sales-order creation until the package leaves `Awaiting`, as required by [Trendyol’s order-status guidance](https://developers.trendyol.com/tr/docs/sipari%C5%9F-paketlerini-%C3%A7ekme-getshipmentpackages). Ignore delayed `Awaiting` updates so they cannot replace complete buyer data or regress an existing order’s status. Match customers only by a valid positive customer ID; incomplete new imports fail before creating records, and polling retains its cursor for retry. Valid subsequent data can replace placeholder IDs on bindings and VAT-matched customers while preserving existing sales-order customer, invoice and delivery assignments.

Validation:
- 22 Odoo order/webhook tests passed on local `16test2`, with all test data rolled back. The runner temporarily enabled the optional MTS/MTO global route inside the test transaction for the existing company fixture.
- The same suite against the original importer produced 15 failed assertions, including placeholder-ID subtests, with no test errors.
- `pre-commit run -a` and `git diff --check` passed.
- Turkish translation added for the incomplete-customer error.

This change does not bulk-reassign historical orders or invoices. Production deployment has not been performed.
