### PR TITLE
[ADD] Hepsiburada order webhooks and Turkish translations

### DIFF
--- a/hepsiburada_integration/README.rst
+++ b/hepsiburada_integration/README.rst
@@ -58,6 +58,40 @@ Configuration
 4. Set up cargo provider mappings in the **Cargo Mapping** tab
 5. Verify the connection with **Test Connection**
 
+Order webhooks
+--------------
+
+Upgrade the module, then open the backend's **Webhooks** tab as a Hepsiburada
+manager. Generate dedicated webhook credentials and share the **Webhook Base
+URL**, username and password with Hepsiburada through their integration onboarding
+process. First complete their test-environment checks, then arrange production
+registration and enable webhooks on the corresponding backend. Generating new
+credentials replaces the previous credentials; the outbound API credentials are
+separate.
+
+The base URL is ``https://your-odoo-host/hb/wh/<backend_id>``. It must reach the
+correct Odoo database. Hepsiburada calls these paths beneath it using Basic Auth:
+
+* ``POST /orders`` and ``POST /packages`` return HTTP 201.
+* ``PUT /packages/<package_number>/intransit``, ``/deliver``, ``/undeliver`` and
+  ``/unpack`` return HTTP 204.
+* ``PUT /lineitems/<line_item_id>/cancel`` returns HTTP 204.
+* ``PUT /orders/<order_number>/shippingaddress`` returns HTTP 204.
+
+Notifications enqueue a refresh of the current Hepsiburada API data. Pending
+refresh jobs are coalesced per backend; the request body and credentials are not
+stored in job arguments. Replayed notifications fetch current state instead of
+applying old snapshots. Unpacked packages retain their history but release their
+active line mappings so replacement packages can be created. Monitor failures in
+the job queue and the backend's synchronization error field.
+
+Keep the existing 15-minute polling enabled as a fallback. Hepsiburada does not
+echo actions performed through its API back as webhooks. Enabling the receiver
+does not register it with Hepsiburada automatically.
+
+Official contract: `Siparis Webhook Modeli
+<https://developers.hepsiburada.com/tr/companies/hepsiburada?guide=siparis-webhook-modeli&product=siparis-olusturma-entegrasyonu&view=guide>`_.
+
 Authors
 -------
 

--- a/hepsiburada_integration/__manifest__.py
+++ b/hepsiburada_integration/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Hepsiburada Marketplace Integration",
-    "version": "16.0.1.1.2",
+    "version": "16.0.1.2.0",
     "category": "Sales/Sales",
     "summary": "Integrate Odoo with Hepsiburada marketplace (orders, invoices, status)",
     "author": "Ahmet Yigit Budak, Altinkaya Enclosures",

--- a/hepsiburada_integration/controllers/__init__.py
+++ b/hepsiburada_integration/controllers/__init__.py
@@ -1,5 +1,4 @@
 # Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
-from . import models
-from . import controllers
+from . import webhook

--- a/hepsiburada_integration/controllers/webhook.py
+++ b/hepsiburada_integration/controllers/webhook.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+import logging
+import secrets
+
+from werkzeug.exceptions import BadRequest
+
+from odoo import _, http
+from odoo.http import request
+
+_logger = logging.getLogger(__name__)
+
+
+class HepsiburadaWebhookController(http.Controller):
+    """Receive Hepsiburada notifications and refresh orders through the API."""
+
+    @http.route(
+        "/hb/wh/<int:backend_id>/orders",
+        type="http",
+        auth="none",
+        methods=["POST"],
+        csrf=False,
+        save_session=False,
+    )
+    def create_orders(self, backend_id, **_kwargs):
+        """Accept the Create Order contract."""
+        return self._receive(backend_id, "orders")
+
+    @http.route(
+        "/hb/wh/<int:backend_id>/packages",
+        type="http",
+        auth="none",
+        methods=["POST"],
+        csrf=False,
+        save_session=False,
+    )
+    def create_packages(self, backend_id, **_kwargs):
+        """Accept the Create Packages contract."""
+        return self._receive(backend_id, "packages")
+
+    @http.route(
+        "/hb/wh/<int:backend_id>/packages/<string:package_number>/<string:event>",
+        type="http",
+        auth="none",
+        methods=["PUT"],
+        csrf=False,
+        save_session=False,
+    )
+    def package_event(self, backend_id, package_number, event, **_kwargs):
+        """Accept package shipment, delivery, failure and unpack notifications."""
+        if event not in ("intransit", "deliver", "undeliver", "unpack"):
+            return request.make_response("", status=404)
+        return self._receive(backend_id, event, package_number)
+
+    @http.route(
+        "/hb/wh/<int:backend_id>/lineitems/<string:line_item_id>/cancel",
+        type="http",
+        auth="none",
+        methods=["PUT"],
+        csrf=False,
+        save_session=False,
+    )
+    def cancel_line(self, backend_id, line_item_id, **_kwargs):
+        """Accept the Order Cancel contract."""
+        return self._receive(backend_id, "cancel", line_item_id)
+
+    @http.route(
+        "/hb/wh/<int:backend_id>/orders/<string:order_number>/shippingaddress",
+        type="http",
+        auth="none",
+        methods=["PUT"],
+        csrf=False,
+        save_session=False,
+    )
+    def shipping_address(self, backend_id, order_number, **_kwargs):
+        """Accept the Change Shipping Address Order contract."""
+        return self._receive(backend_id, "shippingaddress", order_number)
+
+    def _receive(self, backend_id, event, resource_id=None):
+        """Authenticate before reading data and acknowledge only durable jobs."""
+        backend = request.env["hepsiburada.backend"].sudo().browse(backend_id).exists()
+        auth = request.httprequest.authorization
+        if not self._authorized(backend, auth):
+            return request.make_response(
+                "",
+                status=401,
+                headers=[("WWW-Authenticate", 'Basic realm="Hepsiburada"')],
+            )
+
+        try:
+            data = request.get_json_data()
+            if not self._valid_payload(backend, event, resource_id, data):
+                return request.make_json_response(
+                    {"error": _("Invalid payload")}, status=400
+                )
+        except (BadRequest, TypeError, ValueError):
+            return request.make_json_response({"error": _("Invalid JSON")}, status=400)
+
+        # Webhooks can arrive late or more than once. Fetch current API state
+        # rather than applying their potentially stale order/address snapshots.
+        backend.with_company(backend.company_id)._queue_webhook_sync()
+        _logger.info("Accepted HB %s webhook for backend %s", event, backend.id)
+        return request.make_response(
+            "", status=201 if event in ("orders", "packages") else 204
+        )
+
+    @staticmethod
+    def _authorized(backend, auth):
+        """Require enabled, per-backend Basic Auth credentials."""
+        if (
+            not backend
+            or not backend.active
+            or not backend.webhook_enabled
+            or not backend.webhook_username
+            or not backend.webhook_password
+            or not auth
+            or auth.type.lower() != "basic"
+        ):
+            return False
+        username_ok = secrets.compare_digest(
+            (auth.username or "").encode(), backend.webhook_username.encode()
+        )
+        password_ok = secrets.compare_digest(
+            (auth.password or "").encode(), backend.webhook_password.encode()
+        )
+        return username_ok and password_ok
+
+    @staticmethod
+    def _valid_payload(backend, event, resource_id, data):
+        """Check contract identifiers and prevent cross-merchant notifications."""
+        if not isinstance(data, dict):
+            return False
+        if "merchantId" in data and str(data["merchantId"]) != backend.merchant_id:
+            return False
+        if event == "shippingaddress":
+            return (
+                bool(data.get("addressId"))
+                and str(data.get("orderNumber") or "") == resource_id
+            )
+        if event == "orders":
+            items = data.get("items")
+            return (
+                bool(items)
+                and isinstance(items, list)
+                and all(
+                    isinstance(item, dict)
+                    and item.get("id")
+                    and item.get("orderNumber")
+                    and str(item.get("merchantId") or "") == backend.merchant_id
+                    for item in items
+                )
+            )
+        if str(data.get("merchantId") or "") != backend.merchant_id:
+            return False
+        if event == "packages":
+            items = data.get("items")
+            return (
+                bool(data.get("packageNumber"))
+                and isinstance(items, list)
+                and bool(items)
+                and all(
+                    isinstance(item, dict)
+                    and item.get("lineItemId")
+                    and item.get("orderNumber")
+                    for item in items
+                )
+            )
+        key = "id" if event == "cancel" else "packageNumber"
+        return str(data.get(key) or "") == resource_id

--- a/hepsiburada_integration/i18n/hepsiburada_integration.pot
+++ b/hepsiburada_integration/i18n/hepsiburada_integration.pot
@@ -3920,3 +3920,82 @@ msgstr ""
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_order__hb_status__cancelled
 msgid "İptal Edildi"
 msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_enabled
+msgid "Enable Webhooks"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Generate Webhook Credentials"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Hepsiburada webhook refresh failed; retrying."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid JSON"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid payload"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Notifications trigger an immediate refresh from the\n"
+"                                Hepsiburada API. Scheduled polling remains available\n"
+"                                independently as a fallback."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Refresh Hepsiburada orders after webhook: %s"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Share this base URL and the dedicated webhook credentials\n"
+"                                with Hepsiburada. Complete their test-environment onboarding\n"
+"                                before enabling production notifications."
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__unpacked
+msgid "Unpacked"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_url
+msgid "Webhook Base URL"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_password
+msgid "Webhook Password"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_username
+msgid "Webhook Username"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Webhooks"
+msgstr ""

--- a/hepsiburada_integration/i18n/hepsiburada_integration.pot
+++ b/hepsiburada_integration/i18n/hepsiburada_integration.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 11:25+0000\n"
-"PO-Revision-Date: 2026-08-20 11:25+0000\n"
+"POT-Creation-Date: 2026-09-08 12:53+0000\n"
+"PO-Revision-Date: 2026-09-08 12:53+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -40,6 +40,14 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__newproductwillbesent
 msgid "A new product will be sent"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid "A payment was posted before Hepsiburada marked the transaction Paid."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -86,6 +94,11 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__access_warning
 msgid "Access warning"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model,name:hepsiburada_integration.model_account_auto_reconcile
+msgid "Account Auto Reconcile"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -457,6 +470,8 @@ msgid "Change"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__changeset_change_ids
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__changeset_change_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__changeset_change_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__changeset_change_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__changeset_change_ids
@@ -474,6 +489,8 @@ msgid "Changeset Changes"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__changeset_ids
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__changeset_ids
@@ -488,6 +505,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_sale_order_line__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_stock_picking__changeset_ids
 msgid "Changesets"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Check the commission amount, currency, partner and journal."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -522,6 +547,14 @@ msgstr ""
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Claim accepted in Hepsiburada."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Claim import exceeded 100,000 records"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -575,13 +608,61 @@ msgid "Commission Amount"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Commission Matching"
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_payment_id
 msgid "Commission Payment"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Pending"
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_rate
 msgid "Commission Rate"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__commission_refund
+msgid "Commission Refund"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Review"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Commission data changed; the existing payment was preserved."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -644,6 +725,8 @@ msgid "Conversations updated."
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__count_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__count_changesets
@@ -661,6 +744,8 @@ msgid "Count Changesets"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__count_pending_changeset_changes
@@ -678,6 +763,8 @@ msgid "Count Pending Changeset Changes"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__count_pending_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__count_pending_changesets
@@ -1021,6 +1108,11 @@ msgid "Effective Date"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_enabled
+msgid "Enable Webhooks"
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__environment
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_search
 msgid "Environment"
@@ -1093,6 +1185,14 @@ msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#, python-format
+msgid "Failed to refresh question status: %s"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
@@ -1102,12 +1202,7 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
-#, python-format
-msgid "Failed to refresh question status: %s"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
@@ -1195,6 +1290,11 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__hb_full_address
 msgid "Full Address"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Generate Webhook Credentials"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -1373,6 +1473,11 @@ msgid "Hepsiburada Claim"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__hepsiburada_commission_settlement_ids
+msgid "Hepsiburada Commission Settlement"
+msgstr ""
+
+#. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
@@ -1439,6 +1544,7 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Hepsiburada Payment Journal not configured on backend."
 msgstr ""
@@ -1466,19 +1572,14 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Hepsiburada created the package but returned no package number."
 msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Hepsiburada has not paid this transaction yet."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Hepsiburada import exceeded 100,000 records."
@@ -1487,12 +1588,14 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Hepsiburada no longer reports this question as answerable."
 msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Hepsiburada order not found for order number: %s"
@@ -1506,6 +1609,13 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__hb_missing_invoice
 msgid "Hepsiburada reports this package as missing invoice"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Hepsiburada webhook refresh failed; retrying."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -1761,6 +1871,20 @@ msgid ""
 msgstr ""
 
 #. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid JSON"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid payload"
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__odoo_invoice_id
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_form
 msgid "Invoice"
@@ -1768,6 +1892,7 @@ msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Invoice %s is already paid by another transaction."
@@ -1781,6 +1906,11 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__invoice_count
 msgid "Invoice Count"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__invoice_date
+msgid "Invoice Date"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -1854,6 +1984,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__message_is_follower
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__message_is_follower
 msgid "Is Follower"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__is_hepsiburada_commission
+msgid "Is Hepsiburada Commission"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -2017,6 +2152,17 @@ msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid ""
+"Legacy commission payment has no matched supplier invoice and must be "
+"reviewed."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Legacy settlement payments require manual review."
@@ -2073,6 +2219,11 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__cargo_mapping_ids
 msgid "Map Hepsiburada cargo providers to Odoo delivery carriers"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Match Commission Invoice"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -2171,8 +2322,17 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Missing-invoice claims must be accepted from the Hepsiburada portal."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Multiple posted customer documents require review."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -2301,6 +2461,7 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "No posted invoice or credit note found for sale order %s"
 msgstr ""
@@ -2316,6 +2477,14 @@ msgstr ""
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "No valid line item IDs found in order detail."
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Notifications trigger an immediate refresh from the\n"
+"                                Hepsiburada API. Scheduled polling remains available\n"
+"                                independently as a fallback."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -2431,13 +2600,7 @@ msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Only paid sale and return transactions can be reconciled."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Only questions waiting for an answer can be answered."
@@ -2575,6 +2738,7 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Package %(package)s is already linked to order %(order)s."
 msgstr ""
@@ -2711,6 +2875,7 @@ msgid "Payment Terms"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model,name:hepsiburada_integration.model_account_payment
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__payment_ids
 msgid "Payments"
 msgstr ""
@@ -2871,8 +3036,17 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Question Status Updated"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Question import exceeded %s pages"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -2925,10 +3099,19 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__state__reconciled
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
 #, python-format
 msgid "Reconciled"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Reconciliation Failed"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -2939,6 +3122,13 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_form
 msgid "Refresh Conversations"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Refresh Hepsiburada orders after webhook: %s"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -3124,6 +3314,7 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Select Refund or Change before accepting this claim."
 msgstr ""
@@ -3169,12 +3360,14 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Settlement could not be reconciled."
 msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid ""
@@ -3185,6 +3378,7 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid ""
 "Settlement group amount %(settlement).2f does not match invoice residual "
@@ -3194,8 +3388,17 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Settlement group has been reconciled successfully."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Settlement import exceeded 100,000 records for %(window)s"
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -3208,6 +3411,7 @@ msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid ""
@@ -3232,6 +3436,14 @@ msgstr ""
 msgid ""
 "Settlements are imported from Hepsiburada's finance API and used\n"
 "                to reconcile invoices with marketplace payments."
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Share this base URL and the dedicated webhook credentials\n"
+"                                with Hepsiburada. Complete their test-environment onboarding\n"
+"                                before enabling production notifications."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -3265,6 +3477,8 @@ msgid "Sku"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__smart_search
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__smart_search
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__smart_search
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__smart_search
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__smart_search
@@ -3473,6 +3687,14 @@ msgid "Test Connection"
 msgstr ""
 
 #. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The Hepsiburada payment status is unknown."
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__country_code
 msgid ""
 "The ISO country code in two chars. \n"
@@ -3482,8 +3704,17 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "The answer cannot be longer than 2,000 characters."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The commission direction, amount or currency is invalid."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -3492,6 +3723,8 @@ msgid "The internal user in charge of this contact."
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__count_pending_changeset_changes
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changeset_changes
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_claim__count_pending_changeset_changes
@@ -3509,6 +3742,8 @@ msgid "The number of pending changes of this record"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__count_pending_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_claim__count_pending_changesets
@@ -3526,6 +3761,8 @@ msgid "The number of pending changesets of this record"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__count_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_claim__count_changesets
@@ -3548,6 +3785,14 @@ msgid "The payment communication of this sale order."
 msgstr ""
 
 #. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The payment covers incompatible commission types."
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__payment_currency_id
 msgid "The payment's currency."
 msgstr ""
@@ -3565,6 +3810,14 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__fedex_shipment_purpose
 msgid "The purpose of the shipment (FedEx)"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The settlement amount has an invalid sign."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -3596,12 +3849,14 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "This question has already been answered on Hepsiburada."
 msgstr ""
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid ""
@@ -3612,9 +3867,18 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid ""
 "This question was rejected on Hepsiburada and can no longer be answered."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "This transaction type is not supported for automatic reconciliation."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -3687,6 +3951,7 @@ msgstr ""
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Tracking could not be fetched: %s"
 msgstr ""
@@ -3697,6 +3962,14 @@ msgstr ""
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Tracking info has been fetched from Hepsiburada."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Transaction %s has no key for historical refresh."
 msgstr ""
 
 #. module: hepsiburada_integration
@@ -3810,6 +4083,11 @@ msgid "Unknown"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__unpacked
+msgid "Unpacked"
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__amount_untaxed
 msgid "Untaxed Amount"
 msgstr ""
@@ -3825,6 +4103,8 @@ msgid "User"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__user_can_see_changeset
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__user_can_see_changeset
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__user_can_see_changeset
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__user_can_see_changeset
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__user_can_see_changeset
@@ -3883,6 +4163,26 @@ msgid "Warehouses to use for order fulfillment"
 msgstr ""
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_url
+msgid "Webhook Base URL"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_password
+msgid "Webhook Password"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_username
+msgid "Webhook Username"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Webhooks"
+msgstr ""
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__website_message_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__website_message_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__website_message_ids
@@ -3919,255 +4219,4 @@ msgstr ""
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_order__hb_status__cancelled
 msgid "İptal Edildi"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
-#, python-format
-msgid "A payment was posted before Hepsiburada marked the transaction Paid."
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model,name:hepsiburada_integration.model_account_auto_reconcile
-msgid "Account Auto Reconcile"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Check the commission amount, currency, partner and journal."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Claim import exceeded 100,000 records"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_id
-msgid "Commission Invoice"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_number
-msgid "Commission Invoice Number"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_note
-msgid "Commission Match Note"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_state
-msgid "Commission Match State"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
-msgid "Commission Matching"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
-msgid "Commission Pending"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__commission_refund
-msgid "Commission Refund"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
-msgid "Commission Review"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Commission data changed; the existing payment was preserved."
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__hepsiburada_commission_settlement_ids
-msgid "Hepsiburada Commission Settlement"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__invoice_date
-msgid "Invoice Date"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__is_hepsiburada_commission
-msgid "Is Hepsiburada Commission"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
-#, python-format
-msgid ""
-"Legacy commission payment has no matched supplier invoice and must be "
-"reviewed."
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
-msgid "Match Commission Invoice"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Multiple posted customer documents require review."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Question import exceeded %s pages"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Reconciliation Failed"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Settlement import exceeded 100,000 records for %(window)s"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The Hepsiburada payment status is unknown."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The commission direction, amount or currency is invalid."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The payment covers incompatible commission types."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The settlement amount has an invalid sign."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "This transaction type is not supported for automatic reconciliation."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Transaction %s has no key for historical refresh."
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_enabled
-msgid "Enable Webhooks"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid "Generate Webhook Credentials"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Hepsiburada webhook refresh failed; retrying."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/controllers/webhook.py:0
-#, python-format
-msgid "Invalid JSON"
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/controllers/webhook.py:0
-#, python-format
-msgid "Invalid payload"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid ""
-"Notifications trigger an immediate refresh from the\n"
-"                                Hepsiburada API. Scheduled polling remains available\n"
-"                                independently as a fallback."
-msgstr ""
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Refresh Hepsiburada orders after webhook: %s"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid ""
-"Share this base URL and the dedicated webhook credentials\n"
-"                                with Hepsiburada. Complete their test-environment onboarding\n"
-"                                before enabling production notifications."
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__unpacked
-msgid "Unpacked"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_url
-msgid "Webhook Base URL"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_password
-msgid "Webhook Password"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_username
-msgid "Webhook Username"
-msgstr ""
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid "Webhooks"
 msgstr ""

--- a/hepsiburada_integration/i18n/tr.po
+++ b/hepsiburada_integration/i18n/tr.po
@@ -3954,3 +3954,87 @@ msgstr "İptal Edildi"
 
 #~ msgid "Waiting Customer"
 #~ msgstr "Müşteri Bekleniyor"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_enabled
+msgid "Enable Webhooks"
+msgstr "Webhook'ları Etkinleştir"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Generate Webhook Credentials"
+msgstr "Webhook Erişim Bilgilerini Oluştur"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Hepsiburada webhook refresh failed; retrying."
+msgstr "Hepsiburada webhook yenilemesi başarısız oldu; yeniden denenecek."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid JSON"
+msgstr "Geçersiz JSON"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid payload"
+msgstr "Geçersiz bildirim verisi"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Notifications trigger an immediate refresh from the\n"
+"                                Hepsiburada API. Scheduled polling remains available\n"
+"                                independently as a fallback."
+msgstr ""
+"Bildirimler, Hepsiburada API üzerinden hemen yenileme başlatır. Zamanlanmış "
+"sorgulama, yedek olarak bağımsız şekilde kullanılmaya devam eder."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Refresh Hepsiburada orders after webhook: %s"
+msgstr "Webhook sonrası Hepsiburada siparişlerini yenile: %s"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Share this base URL and the dedicated webhook credentials\n"
+"                                with Hepsiburada. Complete their test-environment onboarding\n"
+"                                before enabling production notifications."
+msgstr ""
+"Bu temel adresi ve webhook için oluşturulan erişim bilgilerini Hepsiburada "
+"ile paylaşın. Canlı ortam bildirimlerini etkinleştirmeden önce Hepsiburada "
+"test ortamındaki kurulum sürecini tamamlayın."
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__unpacked
+msgid "Unpacked"
+msgstr "Paketi Bozuldu"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_url
+msgid "Webhook Base URL"
+msgstr "Webhook Temel Adresi"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_password
+msgid "Webhook Password"
+msgstr "Webhook Parolası"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_username
+msgid "Webhook Username"
+msgstr "Webhook Kullanıcı Adı"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Webhooks"
+msgstr "Webhook'lar"

--- a/hepsiburada_integration/i18n/tr.po
+++ b/hepsiburada_integration/i18n/tr.po
@@ -6,15 +6,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 11:25+0000\n"
-"PO-Revision-Date: 2026-04-27 07:17+0000\n"
+"POT-Creation-Date: 2026-09-08 12:53+0000\n"
+"PO-Revision-Date: 2026-09-08 13:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_settlement__currency_code
@@ -30,20 +30,16 @@ msgstr "<span class=\"o_stat_text\">Hepsiburada</span>"
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid ""
 "<span class=\"text-muted\">\n"
-"                                <b>Known Hepsiburada Cargo Providers:</b><br/"
-">\n"
-"                                Aras Kargo, Borusan Lojistik, Ceva "
-"Lojistik,\n"
+"                                <b>Known Hepsiburada Cargo Providers:</b><br/>\n"
+"                                Aras Kargo, Borusan Lojistik, Ceva Lojistik,\n"
 "                                DHL E-commerce, HepsiJet, hepsiJET XL,\n"
 "                                Horoz Lojistik, Kolay Gelsin, MNG Kargo,\n"
 "                                PTT Kargo, Sürat Kargo, UPS, Yurtiçi Kargo\n"
 "                            </span>"
 msgstr ""
 "<span class=\"text-muted\">\n"
-"                                <b>Bilinen Hepsiburada Kargo Sağlayıcıları:</"
-"b><br/>\n"
-"                                Aras Kargo, Borusan Lojistik, Ceva "
-"Lojistik,\n"
+"                                <b>Hepsiburada Kargo Firmaları:</b><br/>\n"
+"                                Aras Kargo, Borusan Lojistik, Ceva Lojistik,\n"
 "                                DHL E-commerce, HepsiJet, hepsiJET XL,\n"
 "                                Horoz Lojistik, Kolay Gelsin, MNG Kargo,\n"
 "                                PTT Kargo, Sürat Kargo, UPS, Yurtiçi Kargo\n"
@@ -55,14 +51,22 @@ msgid "A new product will be sent"
 msgstr "Yeni bir ürün gönderilecek"
 
 #. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid "A payment was posted before Hepsiburada marked the transaction Paid."
+msgstr "Hepsiburada işlemi ödendi olarak bildirmeden önce ödeme onaylanmış."
+
+#. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "API Configuration"
-msgstr "API Yapılandırması"
+msgstr "API Ayarları"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__api_password
 msgid "API Password"
-msgstr "API Şifresi"
+msgstr "API Parolası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__api_username
@@ -101,6 +105,11 @@ msgid "Access warning"
 msgstr "Erişim uyarısı"
 
 #. module: hepsiburada_integration
+#: model:ir.model,name:hepsiburada_integration.model_account_auto_reconcile
+msgid "Account Auto Reconcile"
+msgstr "Otomatik Hesap Uzlaştırma"
+
+#. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Accounting"
 msgstr "Muhasebe"
@@ -108,7 +117,7 @@ msgstr "Muhasebe"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__action_expire_date
 msgid "Action Expire Date"
-msgstr "İşlem Son Tarihi"
+msgstr "Son İşlem Tarihi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__message_needaction
@@ -134,7 +143,7 @@ msgstr "Aktiviteler"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__activity_exception_decoration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr "Aktivite İstisna Gösterimi"
+msgstr "Aktivite Uyarı Görünümü"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__activity_state
@@ -157,7 +166,8 @@ msgstr "Adres"
 #: model:ir.model.fields,help:hepsiburada_integration.field_res_partner__hb_address_id
 #: model:ir.model.fields,help:hepsiburada_integration.field_res_users__hb_address_id
 msgid "Address ID from Hepsiburada for delivery address matching"
-msgstr "Teslimat adresi eşleştirmesi için Hepsiburada adres kimliği"
+msgstr ""
+"Teslimat adresini eşleştirmek için kullanılan Hepsiburada adres kimliği."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__amount
@@ -182,7 +192,7 @@ msgstr "Şirket Para Biriminde Toplam Tutar"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__sale_order_amount_in_words
 msgid "Amount to Text"
-msgstr "Tutarın Yazılı Hali"
+msgstr "Tutarı Yazıya Çevir"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__analytic_account_id
@@ -192,33 +202,32 @@ msgstr "Analitik Hesap"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__answer_text
 msgid "Answer"
-msgstr "Yanıt"
+msgstr "Cevap"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__expire_date
-#, fuzzy
 msgid "Answer Deadline"
-msgstr "Yanıtlandı"
+msgstr "Cevap Son Tarihi"
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Answer sent to Hepsiburada successfully."
-msgstr "Yanıt Hepsiburada'ya başarıyla gönderildi."
+msgstr "Cevap Hepsiburada'ya gönderildi."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_question__hb_status__answered
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_search
-#, fuzzy
 msgid "Answered"
-msgstr "Yanıt"
+msgstr "Cevaplandı"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_search
 msgid "Archived"
-msgstr "Arşivlenmiş"
+msgstr "Arşivlendi"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_form
@@ -245,34 +254,33 @@ msgstr "Ek Sayısı"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__authorized_transaction_ids
 msgid "Authorized Transactions"
-msgstr "Onaylı İşlemler"
+msgstr "Yetkilendirilmiş İşlemler"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_question__hb_status__auto_closed
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_search
-#, fuzzy
 msgid "Auto Closed"
-msgstr "Kapatıldı"
+msgstr "Otomatik Kapatıldı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__auto_import_claims
 msgid "Auto Import Claims"
-msgstr "İade Taleplerini Otomatik İçe Aktar"
+msgstr "Talepleri Otomatik Aktar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__auto_import_orders
 msgid "Auto Import Orders"
-msgstr "Siparişleri Otomatik İçe Aktar"
+msgstr "Siparişleri Otomatik Aktar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__auto_import_questions
 msgid "Auto Import Questions"
-msgstr "Soruları Otomatik İçe Aktar"
+msgstr "Soruları Otomatik Aktar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__auto_import_settlements
 msgid "Auto Import Settlements"
-msgstr "Hesaplaşmaları Otomatik İçe Aktar"
+msgstr "Hesaplaşmaları Otomatik Aktar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__auto_reconcile_settlements
@@ -287,12 +295,12 @@ msgstr "Faturayı Otomatik Gönder"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Auto Sync"
-msgstr "Otomatik Senkronizasyon"
+msgstr "Otomatik Eşitleme"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__auto_sync_tracking
 msgid "Auto Sync Tracking"
-msgstr "Takibi Otomatik Senkronize Et"
+msgstr "Kargo Takibini Otomatik Eşitle"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__auto_confirm_orders
@@ -302,39 +310,37 @@ msgstr "Siparişleri Otomatik Onayla"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_confirm_orders
 msgid "Automatically confirm imported orders"
-msgstr "İçe aktarılan siparişleri otomatik olarak onayla"
+msgstr "İçe aktarılan siparişleri otomatik onaylar."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_import_claims
 msgid "Automatically import customer claims via scheduled job"
-msgstr ""
-"Müşteri iade taleplerini zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Müşteri taleplerini zamanlanmış görevle içe aktarır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_import_questions
 msgid "Automatically import customer questions via scheduled job"
-msgstr "Müşteri sorularını zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Müşteri sorularını zamanlanmış görevle içe aktarır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_import_settlements
 msgid "Automatically import financial settlements via scheduled job"
-msgstr ""
-"Finansal hesaplaşmaları zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Hesaplaşmaları zamanlanmış görevle içe aktarır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_import_orders
 msgid "Automatically import orders via scheduled job"
-msgstr "Siparişleri zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Siparişleri zamanlanmış görevle içe aktarır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_reconcile_settlements
 msgid "Automatically reconcile imported settlements with invoices"
-msgstr "İçe aktarılan hesaplaşmaları faturalarla otomatik olarak uzlaştır"
+msgstr "İçe aktarılan hesaplaşmaları faturalarla otomatik uzlaştırır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_sync_tracking
 msgid "Automatically send tracking numbers when delivery is done"
-msgstr "Teslimat tamamlandığında takip numaralarını otomatik olarak gönder"
+msgstr "Teslimat tamamlanınca takip numaralarını otomatik gönderir."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__hb_status__awaiting_action
@@ -344,9 +350,8 @@ msgstr "İşlem Bekliyor"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__hb_status__awaiting_pre_approval
-#, fuzzy
 msgid "Awaiting Pre-Approval"
-msgstr "İşlem Bekliyor"
+msgstr "Ön Onay Bekliyor"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__backend_id
@@ -360,17 +365,17 @@ msgstr "İşlem Bekliyor"
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_search
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
 msgid "Backend"
-msgstr "Arka Uç"
+msgstr "Entegrasyon"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Backend Name"
-msgstr "Backend Adı"
+msgstr "Entegrasyon Adı"
 
 #. module: hepsiburada_integration
 #: model:ir.ui.menu,name:hepsiburada_integration.menu_hepsiburada_backends
 msgid "Backends"
-msgstr "Backend'ler"
+msgstr "Entegrasyonlar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__block_autoinvoicing
@@ -380,12 +385,12 @@ msgstr "Otomatik Faturalamayı Engelle"
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__boxisemptywithreport
 msgid "Box is empty with a report"
-msgstr "Kutu boş ve tutanak mevcut"
+msgstr "Kutu boş, tutanak var"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__boxisemptywithoutreport
 msgid "Box is empty without a report"
-msgstr "Kutu boş ve tutanak yok"
+msgstr "Kutu boş, tutanak yok"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__campaign_id
@@ -394,6 +399,7 @@ msgstr "Kampanya"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Cancel Queued"
@@ -406,6 +412,7 @@ msgstr "Hepsiburada'da İptal Et"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Cancel order: %s"
@@ -421,12 +428,14 @@ msgstr "İptal Edildi"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Cannot fetch tracking: no package number on this order."
-msgstr "Takip bilgisi alınamıyor: bu siparişte paket numarası yok."
+msgstr "Siparişte paket numarası olmadığı için takip bilgisi alınamıyor."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Cannot send invoice for cancelled orders."
@@ -452,25 +461,26 @@ msgstr "Kargo Eşleştirmeleri"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__cargo_provider_name
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_package__cargo_provider_name
 msgid "Cargo Provider"
-msgstr "Kargo Sağlayıcı"
+msgstr "Kargo Firması"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__hepsiburada_cargo_provider_name
 msgid "Cargo provider name from Hepsiburada API"
-msgstr "Hepsiburada API'sinden kargo sağlayıcı adı"
+msgstr "Hepsiburada API'sindeki kargo firması adı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__carrier_payment_type
 msgid "Carrier Payment Type"
-msgstr "Taşıyıcı Ödeme Türü"
+msgstr "Kargo Ödeme Türü"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__finalized_with__change
-#, fuzzy
 msgid "Change"
-msgstr "Değişiklikler"
+msgstr "Değişim"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__changeset_change_ids
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__changeset_change_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__changeset_change_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__changeset_change_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__changeset_change_ids
@@ -485,9 +495,11 @@ msgstr "Değişiklikler"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_sale_order_line__changeset_change_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_stock_picking__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Changeset Değişiklikleri"
+msgstr "Değişiklik Kayıtları"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__changeset_ids
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__changeset_ids
@@ -502,28 +514,37 @@ msgstr "Changeset Değişiklikleri"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_sale_order_line__changeset_ids
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_stock_picking__changeset_ids
 msgid "Changesets"
-msgstr "Değişiklikler"
+msgstr "Değişiklik Grupları"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Check the commission amount, currency, partner and journal."
+msgstr ""
+"Komisyon tutarını, para birimini, cari hesabı ve yevmiyeyi kontrol edin."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__crm_claim_count
 msgid "Claim Count"
-msgstr "İade Talebi Sayısı"
+msgstr "Talep Sayısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__claim_date
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_search
 msgid "Claim Date"
-msgstr "İade Talebi Tarihi"
+msgstr "Talep Tarihi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__hb_claim_id
 msgid "Claim ID"
-msgstr "Talep ID"
+msgstr "Talep Kimliği"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_form
 msgid "Claim Info"
-msgstr "İade Talebi Bilgisi"
+msgstr "Talep Bilgileri"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__hb_claim_number
@@ -533,6 +554,7 @@ msgstr "Talep Numarası"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Claim accepted in Hepsiburada."
 msgstr "Talep Hepsiburada'da kabul edildi."
@@ -540,17 +562,27 @@ msgstr "Talep Hepsiburada'da kabul edildi."
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Claim import exceeded 100,000 records"
+msgstr "Talep aktarımı 100.000 kaydı aştı"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Claim import has been queued."
-msgstr "Talep içe aktarma kuyruğa alındı."
+msgstr "Talep aktarımı kuyruğa alındı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.constraint,message:hepsiburada_integration.constraint_hepsiburada_claim_unique_claim_per_backend
 msgid "Claim number must be unique per backend."
-msgstr "Talep numarası arka uç başına benzersiz olmalıdır."
+msgstr "Talep numarası her entegrasyonda benzersiz olmalıdır."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Claim rejected in Hepsiburada."
@@ -559,10 +591,11 @@ msgstr "Talep Hepsiburada'da reddedildi."
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__claimedcomponentisnotpartoftheproduct
 msgid "Claimed component is not part of the product"
-msgstr "Talep edilen parça ürünün bir parçası değil"
+msgstr "Talep edilen parça bu ürüne ait değil"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__claim_count
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__crm_claim_ids
@@ -570,7 +603,7 @@ msgstr "Talep edilen parça ürünün bir parçası değil"
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 #, python-format
 msgid "Claims"
-msgstr "İade Talepleri"
+msgstr "Talepler"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__commission
@@ -585,14 +618,62 @@ msgid "Commission Amount"
 msgstr "Komisyon Tutarı"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr "Komisyon Faturası"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr "Komisyon Fatura No."
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr "Komisyon Uzlaştırma Notu"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr "Komisyon Uzlaştırma Durumu"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Commission Matching"
+msgstr "Komisyon Uzlaştırma"
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_payment_id
 msgid "Commission Payment"
 msgstr "Komisyon Ödemesi"
 
 #. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Pending"
+msgstr "Komisyon Bekliyor"
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_rate
 msgid "Commission Rate"
 msgstr "Komisyon Oranı"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__commission_refund
+msgid "Commission Refund"
+msgstr "Komisyon İadesi"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Review"
+msgstr "Komisyon İncelemesi"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Commission data changed; the existing payment was preserved."
+msgstr "Komisyon bilgileri değişti; mevcut ödeme korundu."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
@@ -615,7 +696,7 @@ msgstr "Şirket Para Birimi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__effective_date
 msgid "Completion date of the first delivery order."
-msgstr "İlk teslimat emrinin tamamlanma tarihi."
+msgstr "İlk teslimatın tamamlandığı tarih."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__hb_full_address
@@ -625,7 +706,7 @@ msgstr "Kolay arama için birleştirilmiş adres"
 #. module: hepsiburada_integration
 #: model:ir.ui.menu,name:hepsiburada_integration.menu_hepsiburada_config
 msgid "Configuration"
-msgstr "Yapılandırma"
+msgstr "Ayarlar"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.actions.act_window,help:hepsiburada_integration.action_hepsiburada_backend
@@ -633,13 +714,12 @@ msgid ""
 "Configure API credentials and sync settings to connect\n"
 "                your Odoo instance with Hepsiburada marketplace."
 msgstr ""
-"Odoo kurulumunuzu Hepsiburada pazar yeri ile bağlamak için\n"
-"                API bilgilerini ve senkronizasyon ayarlarını yapılandırın."
+"Hepsiburada bağlantısı için API bilgilerini ve eşitleme ayarlarını girin."
 
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_res_partner
 msgid "Contact"
-msgstr "İletişim"
+msgstr "İlgili Kişi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__conversation_ids
@@ -650,11 +730,14 @@ msgstr "Konuşmalar"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Conversations updated."
 msgstr "Konuşmalar güncellendi."
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__count_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__count_changesets
@@ -669,9 +752,11 @@ msgstr "Konuşmalar güncellendi."
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_sale_order_line__count_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_stock_picking__count_changesets
 msgid "Count Changesets"
-msgstr "Sayım Değişiklik Setleri"
+msgstr "Değişiklik Grubu Sayısı"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__count_pending_changeset_changes
@@ -686,9 +771,11 @@ msgstr "Sayım Değişiklik Setleri"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_sale_order_line__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_stock_picking__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
+msgstr "Bekleyen Değişiklik Sayısı"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__count_pending_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__count_pending_changesets
@@ -703,12 +790,12 @@ msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_sale_order_line__count_pending_changesets
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_stock_picking__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Bekleyen Değişiklik Setlerini Say"
+msgstr "Bekleyen Değişiklik Grubu Sayısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__mrp_production_count
 msgid "Count of MO generated"
-msgstr "Oluşturulan Üretim Emri Sayısı"
+msgstr "Üretim Emri Sayısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__country_code
@@ -728,6 +815,7 @@ msgstr "Paket Oluştur"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Create package: %s"
 msgstr "Paket oluştur: %s"
@@ -735,7 +823,7 @@ msgstr "Paket oluştur: %s"
 #. module: hepsiburada_integration
 #: model_terms:ir.actions.act_window,help:hepsiburada_integration.action_hepsiburada_backend
 msgid "Create your first Hepsiburada backend"
-msgstr "İlk Hepsiburada arka ucunuzu oluşturun"
+msgstr "İlk Hepsiburada entegrasyonunu oluşturun"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__create_uid
@@ -761,7 +849,7 @@ msgstr "Oluşturan"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question_message__create_date
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__create_date
 msgid "Created on"
-msgstr "Oluşturma Tarihi"
+msgstr "Oluşturulma Tarihi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__date_order
@@ -769,8 +857,8 @@ msgid ""
 "Creation date of draft/sent orders,\n"
 "Confirmation date of confirmed orders."
 msgstr ""
-"Taslak/gönderilmiş siparişlerin oluşturulma tarihi,\n"
-"Onaylanmış siparişlerin onay tarihi."
+"Taslak ve gönderilen tekliflerde oluşturulma tarihi; onaylı siparişlerde "
+"onay tarihi."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__currency_id
@@ -813,7 +901,7 @@ msgstr "Müşteri Açıklaması"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__hb_customer_id
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__customer_id
 msgid "Customer ID"
-msgstr "Müşteri ID"
+msgstr "Müşteri No."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__customer_name
@@ -825,7 +913,7 @@ msgstr "Müşteri Adı"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__access_url
 msgid "Customer Portal URL"
-msgstr "Müşteri Portal URL"
+msgstr "Müşteri Portalı Adresi"
 
 #. module: hepsiburada_integration
 #: model:ir.actions.act_window,name:hepsiburada_integration.action_hepsiburada_question
@@ -843,14 +931,14 @@ msgid ""
 "Customer claims (returns, missing items, etc.) will appear\n"
 "                here when imported from Hepsiburada."
 msgstr ""
-"Müşteri talepleri (iadeler, eksik ürünler vb.) Hepsiburada'dan\n"
-"                içe aktarıldığında burada görünecektir."
+"Hepsiburada'dan aktarılan iade, eksik ürün ve diğer müşteri talepleri burada"
+" görünür."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_res_partner__hb_customer_id
 #: model:ir.model.fields,help:hepsiburada_integration.field_res_users__hb_customer_id
 msgid "Customer identifier from Hepsiburada marketplace"
-msgstr "Hepsiburada pazar yerinden müşteri tanımlayıcısı"
+msgstr "Hepsiburada'daki müşteri kimliği."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__customerproblemsolved
@@ -863,9 +951,8 @@ msgid ""
 "Customer questions will appear here when imported from\n"
 "                Hepsiburada. Configure auto-import in backend settings."
 msgstr ""
-"Müşteri soruları Hepsiburada'dan içe aktarıldığında burada\n"
-"                görünecektir. Arka uç ayarlarında otomatik içe aktarmayı "
-"yapılandırın."
+"Hepsiburada'dan aktarılan sorular burada görünür. Entegrasyon ayarlarından "
+"otomatik aktarımı açabilirsiniz."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__customerreturnedwrongitem
@@ -875,7 +962,7 @@ msgstr "Müşteri yanlış ürünü iade etti"
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__claim_type__damaged_with_report
 msgid "Damaged With Report"
-msgstr "Raporlu Hasarlı"
+msgstr "Tutanaklı Hasar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question_message__message_date
@@ -905,12 +992,12 @@ msgstr "Vergisi olmayan ürünler için varsayılan KDV oranı"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__default_cargo_company_id
 msgid "Default delivery carrier for Hepsiburada orders"
-msgstr "Hepsiburada siparişleri için varsayılan teslimat taşıyıcısı"
+msgstr "Hepsiburada siparişlerinde kullanılacak varsayılan kargo firması."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__fiscal_position_id
 msgid "Default fiscal position for Hepsiburada orders"
-msgstr "Hepsiburada siparişleri için varsayılan mali durum"
+msgstr "Hepsiburada siparişlerinde kullanılacak varsayılan mali koşul."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__label_printer_id
@@ -918,8 +1005,8 @@ msgid ""
 "Default printer for Hepsiburada shipping labels (Ortak Barkod). Used when "
 "the delivery carrier has no printer configured."
 msgstr ""
-"Hepsiburada kargo etiketleri (Ortak Barkod) için varsayılan yazıcı. Teslimat "
-"taşıyıcısında yazıcı yapılandırılmadığında kullanılır."
+"Kargo firması için yazıcı seçilmemişse Hepsiburada etiketleri (Ortak Barkod)"
+" bu yazıcıdan basılır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__sales_team_id
@@ -940,7 +1027,7 @@ msgstr "Teslimat Adresi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__carrier_id
 msgid "Delivery Carrier"
-msgstr "Teslimat Taşıyıcısı"
+msgstr "Kargo Firması"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__commitment_date
@@ -960,22 +1047,22 @@ msgstr "Teslimat Yöntemi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__delivery_count
 msgid "Delivery Orders"
-msgstr "Teslimat Emirleri"
+msgstr "Teslimatlar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__delivery_price_try
 msgid "Delivery Price (TRY)"
-msgstr "Teslimat Fiyatı (TRY)"
+msgstr "Kargo Ücreti (TL)"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__delivery_rating_success
 msgid "Delivery Rating Success"
-msgstr "Teslimat Değerlendirme Başarısı"
+msgstr "Kargo Ücreti Hesaplandı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__delivery_set
 msgid "Delivery Set"
-msgstr "Teslimat Seti"
+msgstr "Kargo Satırı Eklendi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__delivery_status
@@ -990,7 +1077,7 @@ msgstr "Teslimat Türü"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__recompute_delivery_price
 msgid "Delivery cost should be recomputed"
-msgstr "Teslimat maliyeti yeniden hesaplanmalı"
+msgstr "Kargo ücreti yeniden hesaplanmalı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__expected_date
@@ -1000,10 +1087,8 @@ msgid ""
 "shipping, the shipping policy of the order will be taken into account to "
 "either use the minimum or maximum lead time of the order lines."
 msgstr ""
-"Müşteriye vaat edebileceğiniz teslimat tarihi; hizmet ürünlerinde sipariş "
-"kalemlerinin minimum temin süresinden hesaplanır. Sevkiyat durumunda, "
-"sipariş kalemlerinin minimum veya maksimum temin süresini kullanmak için "
-"siparişin sevkiyat politikası dikkate alınır."
+"Taahhüt edilebilir teslimat tarihi. Hizmetlerde en kısa süre kullanılır; "
+"sevkiyatta teslimat politikasına göre en kısa veya en uzun süre esas alınır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__description
@@ -1026,12 +1111,12 @@ msgstr "Varış limanı"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question_message__display_name
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__display_name
 msgid "Display Name"
-msgstr "Görüntülenen Ad"
+msgstr "Görünüm Adı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__visible_project
 msgid "Display project"
-msgstr "Projeyi göster"
+msgstr "Proje görüntüle"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__due_date
@@ -1042,6 +1127,11 @@ msgstr "Vade Tarihi"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__effective_date
 msgid "Effective Date"
 msgstr "Geçerlilik Tarihi"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_enabled
+msgid "Enable Webhooks"
+msgstr "Webhook'ları Etkinleştir"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__environment
@@ -1087,18 +1177,17 @@ msgstr "Gider"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__validity_date
 msgid "Expiration"
-msgstr "Son Kullanma"
+msgstr "Geçerlilik Sonu"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__claim_type__extra_product
 msgid "Extra Product"
-msgstr "Ekstra Ürün"
+msgstr "Fazladan Ürün"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__extraproducthasbeenreturned
-#, fuzzy
 msgid "Extra product was returned"
-msgstr "Ekstra Ürün"
+msgstr "Fazladan ürün iade edildi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__failed_message_ids
@@ -1110,12 +1199,22 @@ msgstr "Başarısız Mesajlar"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Failed to accept claim: %s"
 msgstr "Talep kabul edilemedi: %s"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#, python-format
+msgid "Failed to refresh question status: %s"
+msgstr "Soru durumu yenilenemedi: %s"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Failed to reject claim: %s"
@@ -1124,16 +1223,14 @@ msgstr "Talep reddedilemedi: %s"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
-#, python-format
-msgid "Failed to refresh question status: %s"
-msgstr "Soru durumu yenilenemedi: %s"
-
-#. module: hepsiburada_integration
-#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Failed to send answer: %s"
-msgstr "Yanıt gönderilemedi: %s"
+msgstr "Cevap gönderilemedi: %s"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__default_product_id
@@ -1141,8 +1238,8 @@ msgid ""
 "Fallback product for unmapped items. If not set, unmapped items will be "
 "created as note lines."
 msgstr ""
-"Eşleştirilmemiş ürünler için yedek ürün. Ayarlanmazsa eşleştirilmemiş "
-"kalemler not satırı olarak oluşturulur."
+"Eşleşmeyen kalemlerde kullanılacak ürün. Seçilmezse bu kalemler not satırı "
+"olarak eklenir."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__account_move_line_ids
@@ -1157,13 +1254,12 @@ msgstr "FedEx Gönderi Amacı"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_form
 msgid "Fetch Tracking"
-msgstr "Takip Bilgisi Getir"
+msgstr "Takip Bilgisini Getir"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__carrier_id
 msgid "Fill this field if you plan to invoice the shipping based on picking."
-msgstr ""
-"Sevkiyatı toplama bazında faturalamayı planlıyorsanız bu alanı doldurun."
+msgstr "Sevkiyata göre kargo ücreti faturalandırılacaksa doldurun."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__finalized_with
@@ -1173,7 +1269,7 @@ msgstr "Sonuçlandırma"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
 msgid "Financial"
-msgstr "Finans"
+msgstr "Finansal"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__first_reminder_mail_sent
@@ -1190,11 +1286,11 @@ msgstr "Mali Koşul"
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__fiscal_position_id
 msgid ""
 "Fiscal positions are used to adapt taxes and accounts for particular "
-"customers or sales orders/invoices.The default value comes from the customer."
+"customers or sales orders/invoices.The default value comes from the "
+"customer."
 msgstr ""
-"Mali durumlar, belirli müşteriler veya satış siparişleri/faturaları için "
-"vergileri ve hesapları uyarlamak için kullanılır. Varsayılan değer "
-"müşteriden gelir."
+"Vergi ve hesapları müşteriye veya siparişe göre uyarlar. Varsayılan değer "
+"müşteri kaydından gelir."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__message_follower_ids
@@ -1222,6 +1318,11 @@ msgid "Full Address"
 msgstr "Tam Adres"
 
 #. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Generate Webhook Credentials"
+msgstr "Webhook Erişimi Oluştur"
+
+#. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_search
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_search
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_search
@@ -1233,19 +1334,20 @@ msgstr "Grupla"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "HB Commission - Order %s"
-msgstr "HB Komisyon - Sipariş %s"
+msgstr "HB Komisyonu - Sipariş %s"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__customer_id
 msgid "HB Customer ID"
-msgstr "HB Müşteri ID"
+msgstr "HB Müşteri Kimliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order_line__hb_line_item_id
 msgid "HB Line Item ID"
-msgstr "HB Kalem ID"
+msgstr "HB Kalem Kimliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__hb_line_item_ids
@@ -1256,7 +1358,7 @@ msgstr "HB Kalemleri"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question_message__hb_message_id
 msgid "HB Message ID"
-msgstr "HB Mesaj ID"
+msgstr "HB Mesaj Kimliği"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_search
@@ -1283,9 +1385,10 @@ msgstr "HB SKU"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "HB Settlement - Order %s"
-msgstr "HB Hesap Kesimi - Sipariş %s"
+msgstr "HB Hesaplaşması - Sipariş %s"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__hepsiburada_status
@@ -1295,9 +1398,8 @@ msgstr "HB Durumu"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__hb_transaction_type
-#, fuzzy
 msgid "HB Transaction Type"
-msgstr "İşlem Türü"
+msgstr "HB İşlem Türü"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order_line__hb_sku
@@ -1307,7 +1409,7 @@ msgstr "HBSKU"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__show_update_fpos
 msgid "Has Fiscal Position Changed"
-msgstr "Mali Durum Değişti mi"
+msgstr "Mali Koşul Değişti mi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__has_message
@@ -1319,7 +1421,7 @@ msgstr "Mesaj Var"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__has_old_revisions
 msgid "Has Old Revisions"
-msgstr "Eski Revizyonları Var"
+msgstr "Eski Revizyonlar Var"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__show_update_pricelist
@@ -1329,7 +1431,7 @@ msgstr "Fiyat Listesi Değişti mi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__show_json_popover
 msgid "Has late picking"
-msgstr "Gecikmiş toplama var"
+msgstr "Gecikmiş transfer var"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__hb_missing_invoice
@@ -1351,6 +1453,8 @@ msgstr "HB Durumu"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: model:ir.ui.menu,name:hepsiburada_integration.menu_hepsiburada_root
 #, python-format
@@ -1361,32 +1465,32 @@ msgstr "Hepsiburada"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_res_partner__hb_address_id
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_res_users__hb_address_id
 msgid "Hepsiburada Address ID"
-msgstr "Hepsiburada Adres ID"
+msgstr "Hepsiburada Adres Kimliği"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Hepsiburada Backend"
-msgstr "Hepsiburada Arka Uç"
+msgstr "Hepsiburada Entegrasyonu"
 
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_hepsiburada_backend
 msgid "Hepsiburada Backend Configuration"
-msgstr "Hepsiburada Arka Uç Yapılandırması"
+msgstr "Hepsiburada Entegrasyon Ayarları"
 
 #. module: hepsiburada_integration
 #: model:ir.actions.act_window,name:hepsiburada_integration.action_hepsiburada_backend
 msgid "Hepsiburada Backends"
-msgstr "Hepsiburada Arka Uçları"
+msgstr "Hepsiburada Entegrasyonları"
 
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_hepsiburada_cargo_mapping
 msgid "Hepsiburada Cargo Provider Mapping"
-msgstr "Hepsiburada Kargo Sağlayıcı Eşleştirmesi"
+msgstr "Hepsiburada Kargo Eşleştirmesi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__hepsiburada_cargo_provider_name
 msgid "Hepsiburada Cargo Provider Name"
-msgstr "Hepsiburada Kargo Sağlayıcı Adı"
+msgstr "Hepsiburada Kargo Firması"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_form
@@ -1394,7 +1498,13 @@ msgid "Hepsiburada Claim"
 msgstr "Hepsiburada Talebi"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__hepsiburada_commission_settlement_ids
+msgid "Hepsiburada Commission Settlement"
+msgstr "Hepsiburada Komisyon Hesaplaşması"
+
+#. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Hepsiburada Customer"
@@ -1409,7 +1519,7 @@ msgstr "Hepsiburada Müşteri Talebi"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_res_partner__hb_customer_id
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_res_users__hb_customer_id
 msgid "Hepsiburada Customer ID"
-msgstr "Hepsiburada Müşteri ID"
+msgstr "Hepsiburada Müşteri Kimliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_hepsiburada_question
@@ -1443,26 +1553,26 @@ msgstr "Hepsiburada Siparişleri"
 
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_hepsiburada_package
-#, fuzzy
 msgid "Hepsiburada Package"
-msgstr "Hepsiburada Arka Uç"
+msgstr "Hepsiburada Paketi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__hb_partner_id
 msgid "Hepsiburada Partner"
-msgstr "Hepsiburada İş Ortağı"
+msgstr "Hepsiburada Cari Hesabı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__settlement_journal_id
 msgid "Hepsiburada Payment Journal"
-msgstr "Hepsiburada Ödeme Günlüğü"
+msgstr "Hepsiburada Ödeme Yevmiyesi"
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, fuzzy, python-format
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
 msgid "Hepsiburada Payment Journal not configured on backend."
-msgstr "Hepsiburada Ödeme Günlüğü"
+msgstr "Entegrasyon ayarlarında Hepsiburada ödeme yevmiyesi seçilmemiş."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_form
@@ -1472,20 +1582,21 @@ msgstr "Hepsiburada Sorusu"
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_hepsiburada_question_message
 msgid "Hepsiburada Question Conversation Message"
-msgstr "Hepsiburada Soru Konuşma Mesajı"
+msgstr "Hepsiburada Soru Mesajı"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
 msgid "Hepsiburada Settlement"
-msgstr "Hepsiburada Hesap Kesimi"
+msgstr "Hepsiburada Hesaplaşması"
 
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_hepsiburada_settlement
 msgid "Hepsiburada Settlement Transaction"
-msgstr "Hepsiburada Hesap Kesimi İşlemi"
+msgstr "Hepsiburada Hesaplaşma İşlemi"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Hepsiburada created the package but returned no package number."
@@ -1493,41 +1604,44 @@ msgstr "Hepsiburada paketi oluşturdu ancak paket numarası döndürmedi."
 
 #. module: hepsiburada_integration
 #. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, fuzzy, python-format
-msgid "Hepsiburada has not paid this transaction yet."
-msgstr "Hepsiburada Hesap Kesimi İşlemi"
-
-#. module: hepsiburada_integration
-#. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, fuzzy, python-format
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
 msgid "Hepsiburada import exceeded 100,000 records."
-msgstr "Hepsiburada: Siparişleri İçe Aktar"
+msgstr "Hepsiburada aktarımı 100.000 kaydı aştı."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Hepsiburada no longer reports this question as answerable."
-msgstr "Hepsiburada bu soruyu artık yanıtlanabilir olarak bildirmiyor."
+msgstr "Bu soru Hepsiburada'da artık cevaplanamıyor."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Hepsiburada order not found for order number: %s"
-msgstr "Sipariş numarası için Hepsiburada siparişi bulunamadı: %s"
+msgstr "Hepsiburada siparişi bulunamadı: %s"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__hb_order_id
 msgid "Hepsiburada orderId GUID"
-msgstr "Hepsiburada sipariş GUID'i"
+msgstr "Hepsiburada sipariş kimliği (orderId GUID)."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__hb_missing_invoice
 msgid "Hepsiburada reports this package as missing invoice"
-msgstr "Hepsiburada bu paketi eksik fatura olarak bildiriyor"
+msgstr "Hepsiburada'da bu paketin faturası eksik görünüyor."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Hepsiburada webhook refresh failed; retrying."
+msgstr "Hepsiburada webhook eşitlemesi başarısız. Yeniden denenecek."
 
 #. module: hepsiburada_integration
 #: model:ir.actions.server,name:hepsiburada_integration.cron_import_claims_ir_actions_server
@@ -1551,7 +1665,7 @@ msgstr "Hepsiburada: Soruları İçe Aktar"
 #: model:ir.actions.server,name:hepsiburada_integration.cron_import_settlements_ir_actions_server
 #: model:ir.cron,cron_name:hepsiburada_integration.cron_import_settlements
 msgid "Hepsiburada: Import Settlements"
-msgstr "Hepsiburada: Hesap Kesimlerini İçe Aktar"
+msgstr "Hepsiburada: Hesaplaşmaları İçe Aktar"
 
 #. module: hepsiburada_integration
 #: model:ir.actions.server,name:hepsiburada_integration.cron_send_invoices_ir_actions_server
@@ -1582,14 +1696,14 @@ msgstr "Simge"
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__activity_exception_icon
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr "İstisna aktivitesini belirten simge."
+msgstr "Aktivite uyarısını gösteren simge."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__message_needaction
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__message_needaction
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_settlement__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr "İşaretliyse yeni mesajlar ilginizi gerektiriyor."
+msgstr "İşlem bekleyen yeni mesajlar var."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__message_has_error
@@ -1599,13 +1713,12 @@ msgstr "İşaretliyse yeni mesajlar ilginizi gerektiriyor."
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_settlement__message_has_error
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_settlement__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
-msgstr "İşaretliyse bazı mesajlarda teslim hatası var."
+msgstr "Gönderilemeyen mesajlar var."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__pricelist_id
 msgid "If you change the pricelist, only newly added lines will be affected."
-msgstr ""
-"Fiyat listesini değiştirirseniz sadece yeni eklenen kalemler etkilenir."
+msgstr "Fiyat listesi değişikliği yalnızca yeni eklenen satırları etkiler."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__picking_policy
@@ -1614,8 +1727,8 @@ msgid ""
 "based on the greatest product lead time. Otherwise, it will be based on the "
 "shortest."
 msgstr ""
-"Tüm ürünleri tek seferde teslim ederseniz teslimat emri en uzun temin "
-"süresine göre planlanır. Aksi halde en kısa süreye göre planlanır."
+"Tek seferde teslimatta en uzun ürün teslim süresi, parçalı teslimatta en "
+"kısa süre esas alınır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__ignore_exception
@@ -1630,7 +1743,7 @@ msgstr "İçe Aktar"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Import Claims"
-msgstr "İade Taleplerini İçe Aktar"
+msgstr "Talepleri İçe Aktar"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_search
@@ -1641,12 +1754,18 @@ msgstr "İçe Aktarma Tarihi"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Import Hepsiburada claims: %s"
 msgstr "Hepsiburada taleplerini içe aktar: %s"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Import Hepsiburada orders: %s"
@@ -1655,6 +1774,9 @@ msgstr "Hepsiburada siparişlerini içe aktar: %s"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Import Hepsiburada questions: %s"
 msgstr "Hepsiburada sorularını içe aktar: %s"
@@ -1662,9 +1784,12 @@ msgstr "Hepsiburada sorularını içe aktar: %s"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Import Hepsiburada settlements: %s"
-msgstr "Hepsiburada hesap kesimlerini içe aktar: %s"
+msgstr "Hepsiburada hesaplaşmalarını içe aktar: %s"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
@@ -1684,6 +1809,13 @@ msgstr "Hesaplaşmaları İçe Aktar"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Import Started"
 msgstr "İçe Aktarma Başladı"
@@ -1697,19 +1829,18 @@ msgstr "İçe Aktarıldı"
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__hb_status__in_dispute
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_search
 msgid "In Dispute"
-msgstr "İhtilaf"
+msgstr "İhtilaflı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__in_transit
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_search
 msgid "In Transit"
-msgstr "Transfer Halinde"
+msgstr "Kargoda"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__income
-#, fuzzy
 msgid "Income"
-msgstr "Teslim Şekli"
+msgstr "Gelir"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__incoterm
@@ -1719,27 +1850,27 @@ msgstr "Teslim Şekli"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__incoterm_address_id
 msgid "Incoterm Address"
-msgstr "Incoterm Adresi"
+msgstr "Teslim Şekli Adresi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__incoterm_location
 msgid "Incoterm Location"
-msgstr "Incoterm Konumu"
+msgstr "Teslim Şekli Konumu"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__first_reminder_mail_sent
 msgid "Indicates if the first quotation reminder has been sent."
-msgstr "İlk teklif hatırlatmasının gönderilip gönderilmediğini belirtir."
+msgstr "İlk teklif hatırlatması gönderildi."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__packed
 msgid "Indicates if the sale order has been packed."
-msgstr "Satış siparişinin paketlenip paketlenmediğini belirtir."
+msgstr "Sipariş paketlendi."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__second_reminder_mail_sent
 msgid "Indicates if the second quotation reminder has been sent."
-msgstr "İkinci teklif hatırlatmasının gönderilip gönderilmediğini belirtir."
+msgstr "İkinci teklif hatırlatması gönderildi."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__settlement_journal_id
@@ -1747,27 +1878,40 @@ msgid ""
 "Intermediary bank-type journal for Hepsiburada payments. When a real bank "
 "transfer arrives, reconcile against this journal."
 msgstr ""
-"Hepsiburada ödemeleri için ara banka tipi günlük. Gerçek banka transferi "
-"geldiğinde bu günlükle mutabakat yapın."
+"Hepsiburada ödemelerinin izlendiği, banka türündeki ara yevmiye. Bankaya "
+"gelen transferleri bu yevmiyeyle uzlaştırın."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__internal_note
 msgid "Internal Note"
-msgstr "Dahili Not"
+msgstr "İç Not"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__internal_note
-msgid "Internal note for the order. This field is not visible to the customer."
-msgstr "Sipariş için dahili not. Bu alan müşteriye görünmez."
+msgid ""
+"Internal note for the order. This field is not visible to the customer."
+msgstr "Müşteriye gösterilmeyen sipariş notu."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__incoterm
 msgid ""
 "International Commercial Terms are a series of predefined commercial terms "
 "used in international transactions."
-msgstr ""
-"Uluslararası Ticari Terimler, uluslararası işlemlerde kullanılan önceden "
-"tanımlanmış ticari terimler dizisidir."
+msgstr "Uluslararası ticarette kullanılan standart teslim koşulları."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid JSON"
+msgstr "Geçersiz JSON"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/controllers/webhook.py:0
+#, python-format
+msgid "Invalid payload"
+msgstr "Geçersiz bildirim verisi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__odoo_invoice_id
@@ -1777,6 +1921,7 @@ msgstr "Fatura"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Invoice %s is already paid by another transaction."
@@ -1793,10 +1938,15 @@ msgid "Invoice Count"
 msgstr "Fatura Sayısı"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__invoice_date
+msgid "Invoice Date"
+msgstr "Fatura Tarihi"
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__invoice_link_sent
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_package__invoice_link_sent
 msgid "Invoice Link Sent"
-msgstr "Fatura Linki Gönderildi"
+msgstr "Fatura Bağlantısı Gönderildi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__invoice_number
@@ -1805,6 +1955,7 @@ msgstr "Fatura Numarası"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Invoice Send Queued"
@@ -1824,9 +1975,10 @@ msgstr "Fatura Durumu"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Invoice link already sent."
-msgstr "Fatura linki zaten gönderildi."
+msgstr "Fatura bağlantısı zaten gönderilmiş."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__invoicereplaceswarranty
@@ -1835,6 +1987,7 @@ msgstr "Fatura garanti belgesi yerine geçer"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Invoice sending has been queued."
@@ -1848,19 +2001,24 @@ msgstr "Faturalar"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__is_answered
 msgid "Is Answered"
-msgstr "Yanıtlandı"
+msgstr "Cevaplandı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__is_expired
 msgid "Is Expired"
-msgstr "Süresi Doldu"
+msgstr "Süresi Dolmuş"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__message_is_follower
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__message_is_follower
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__message_is_follower
 msgid "Is Follower"
-msgstr "Takipçi mi"
+msgstr "Takipçi"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__is_hepsiburada_commission
+msgid "Is Hepsiburada Commission"
+msgstr "Hepsiburada Komisyonu"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__is_income
@@ -1869,7 +2027,6 @@ msgstr "Gelir mi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__is_invoice
-#, fuzzy
 msgid "Is Invoice"
 msgstr "Fatura"
 
@@ -1881,27 +2038,27 @@ msgstr "Gecikmiş mi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__is_product_milestone
 msgid "Is Product Milestone"
-msgstr "Ürün Kilometre Taşı mı"
+msgstr "Aşamaya Göre Faturalanan Ürün"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__hb_issue_id
 msgid "Issue ID"
-msgstr "Sorun ID"
+msgstr "Soru Kimliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__hb_issue_number
 msgid "Issue Number"
-msgstr "Sorun Numarası"
+msgstr "Soru Numarası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.constraint,message:hepsiburada_integration.constraint_hepsiburada_question_unique_issue_per_backend
 msgid "Issue number must be unique per backend."
-msgstr "Sorun numarası arka uç başına benzersiz olmalıdır."
+msgstr "Soru numarası her entegrasyonda benzersiz olmalıdır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__json_popover
 msgid "JSON data for the popover widget"
-msgstr "Açılır pencere bileşeni için JSON verisi"
+msgstr "Açılır bileşen için JSON verisi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_order__hb_status__in_transit
@@ -1911,18 +2068,17 @@ msgstr "Kargoda"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__label_printer_id
 msgid "Label Printer"
-msgstr "Etiket Yazıcı"
+msgstr "Etiket Yazıcısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_claim_sync
 msgid "Last Claim Sync"
-msgstr "Son İade Talebi Senkronizasyonu"
+msgstr "Son Talep Eşitlemesi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_claim_sync_error
-#, fuzzy
 msgid "Last Claim Sync Error"
-msgstr "Son İade Talebi Senkronizasyonu"
+msgstr "Son Talep Eşitleme Hatası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__sale_last_deci
@@ -1931,9 +2087,8 @@ msgstr "Son Onaylanan Desi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__last_modified_date
-#, fuzzy
 msgid "Last Modified Date"
-msgstr "Son Değiştirilme Tarihi"
+msgstr "Son Değişiklik Tarihi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend____last_update
@@ -1946,40 +2101,37 @@ msgstr "Son Değiştirilme Tarihi"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question_message____last_update
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement____last_update
 msgid "Last Modified on"
-msgstr "Son Değiştirilme Tarihi"
+msgstr "Son Değiştirme Tarihi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_order_sync
 msgid "Last Order Sync"
-msgstr "Son Sipariş Senkronizasyonu"
+msgstr "Son Sipariş Eşitlemesi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_order_sync_error
-#, fuzzy
 msgid "Last Order Sync Error"
-msgstr "Son Sipariş Senkronizasyonu"
+msgstr "Son Sipariş Eşitleme Hatası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_question_sync
 msgid "Last Question Sync"
-msgstr "Son Soru Senkronizasyonu"
+msgstr "Son Soru Eşitlemesi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_question_sync_error
-#, fuzzy
 msgid "Last Question Sync Error"
-msgstr "Son Soru Senkronizasyonu"
+msgstr "Son Soru Eşitleme Hatası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_settlement_sync
 msgid "Last Settlement Sync"
-msgstr "Son Hesaplaşma Senkronizasyonu"
+msgstr "Son Hesaplaşma Eşitlemesi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__last_settlement_sync_error
-#, fuzzy
 msgid "Last Settlement Sync Error"
-msgstr "Son Hesaplaşma Senkronizasyonu"
+msgstr "Son Hesaplaşma Eşitleme Hatası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__last_status_refresh
@@ -1989,7 +2141,7 @@ msgstr "Son Durum Yenileme"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Last Sync Times"
-msgstr "Son Senkronizasyon Zamanları"
+msgstr "Son Eşitleme Zamanları"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__write_uid
@@ -2025,32 +2177,42 @@ msgstr "Son sevk tarihi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__rejection_reason
 msgid "Legacy Rejection Note"
-msgstr "Eski Red Notu"
+msgstr "Eski Ret Notu"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid ""
+"Legacy commission payment has no matched supplier invoice and must be "
+"reviewed."
+msgstr ""
+"Eski komisyon ödemesi bir tedarikçi faturasıyla eşleşmemiş. İncelenmelidir."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "Legacy settlement payments require manual review."
-msgstr "Eski mutabakat ödemeleri manuel inceleme gerektiriyor."
+msgstr "Eski hesaplaşma ödemeleri elle incelenmelidir."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__hb_line_item_id
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__line_item_id
-#, fuzzy
 msgid "Line Item ID"
-msgstr "HB Kalem ID"
+msgstr "Kalem Kimliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_package__line_ids
-#, fuzzy
 msgid "Line Items"
-msgstr "HB Kalemleri"
+msgstr "Sipariş Kalemleri"
 
 #. module: hepsiburada_integration
 #: model:ir.model.constraint,message:hepsiburada_integration.constraint_hepsiburada_order_line_line_item_id_order_uniq
 msgid "Line item ID must be unique per order!"
-msgstr "Kalem ID'si sipariş başına benzersiz olmalıdır!"
+msgstr "Kalem kimliği her siparişte benzersiz olmalıdır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__message_main_attachment_id
@@ -2067,7 +2229,7 @@ msgstr "Ana İstisna"
 #. module: hepsiburada_integration
 #: model:ir.module.category,description:hepsiburada_integration.module_category_hepsiburada
 msgid "Manage Hepsiburada marketplace integration"
-msgstr "Hepsiburada pazar yeri entegrasyonunu yönetin"
+msgstr "Hepsiburada entegrasyonunu yönetin"
 
 #. module: hepsiburada_integration
 #: model:res.groups,name:hepsiburada_integration.group_hepsiburada_manager
@@ -2082,18 +2244,22 @@ msgstr "Manuel İşlemler"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__mrp_production_ids
 msgid "Manufacturing orders associated with this sales order."
-msgstr "Bu satış siparişi ile ilişkili üretim emirleri."
+msgstr "Bu satış siparişiyle ilişkili üretim emirleri."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__cargo_mapping_ids
 msgid "Map Hepsiburada cargo providers to Odoo delivery carriers"
-msgstr ""
-"Hepsiburada kargo sağlayıcılarını Odoo teslimat taşıyıcılarıyla eşleştirin"
+msgstr "Hepsiburada kargo firmalarını Odoo'dakilerle eşleştirin"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Match Commission Invoice"
+msgstr "Komisyonu Uzlaştır"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__medium_id
 msgid "Medium"
-msgstr "Ortam"
+msgstr "Araç"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_question_message__sender__merchant
@@ -2103,18 +2269,18 @@ msgstr "Satıcı"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__merchant_id
 msgid "Merchant ID"
-msgstr "Satıcı ID"
+msgstr "Satıcı Kimliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__merchant_sku
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__merchant_sku
 msgid "Merchant SKU"
-msgstr "Satıcı SKU"
+msgstr "Satıcı Stok Kodu"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order_line__merchant_sku
 msgid "Merchant Sku"
-msgstr "Satıcı SKU"
+msgstr "Satıcı Stok Kodu"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__merchant_statement
@@ -2131,7 +2297,7 @@ msgstr "Mesaj"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__message_has_error
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__message_has_error
 msgid "Message Delivery error"
-msgstr "Mesaj Teslim Hatası"
+msgstr "Mesaj Gönderim Hatası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__message_ids
@@ -2143,7 +2309,7 @@ msgstr "Mesajlar"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__milestone_count
 msgid "Milestone Count"
-msgstr "Kilometre Taşı Sayısı"
+msgstr "Aşama Sayısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__claim_type__missing_invoice
@@ -2163,14 +2329,15 @@ msgstr "Eksik Parça"
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__claim_type__missing_warranty
 msgid "Missing Warranty"
-msgstr "Eksik Garanti"
+msgstr "Garanti Belgesi Eksik"
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Missing invoice sync has been queued."
-msgstr "Eksik fatura senkronizasyonu kuyruğa alındı."
+msgstr "Eksik faturaları eşitleme işi kuyruğa alındı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__missingitemorpartcannotbesupplied
@@ -2185,9 +2352,19 @@ msgstr "Parçalı sevkiyattaki eksik paket teslim edilecek"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
-#, fuzzy, python-format
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#, python-format
 msgid "Missing-invoice claims must be accepted from the Hepsiburada portal."
-msgstr "Takip bilgisi Hepsiburada'dan alındı."
+msgstr ""
+"Eksik fatura talepleri Hepsiburada satıcı panelinden kabul edilmelidir."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Multiple posted customer documents require review."
+msgstr "Birden fazla onaylı müşteri belgesi var. İncelenmelidir."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__my_activity_date_deadline
@@ -2208,6 +2385,7 @@ msgstr "Müşteri Satış Temsilcisi"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "N/A"
 msgstr "Yok"
@@ -2219,9 +2397,8 @@ msgstr "Ad"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__net_amount
-#, fuzzy
 msgid "Net Amount"
-msgstr "KDV Tutarı"
+msgstr "Net Tutar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__sale_volume
@@ -2243,7 +2420,7 @@ msgstr "Yeni Talep"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__activity_calendar_event_id
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__activity_calendar_event_id
 msgid "Next Activity Calendar Event"
-msgstr "Sonraki Aktivite Takvim Etkinliği"
+msgstr "Sonraki Takvim Etkinliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__activity_date_deadline
@@ -2291,6 +2468,7 @@ msgstr "Henüz müşteri sorusu yok"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "No line items found to cancel."
 msgstr "İptal edilecek kalem bulunamadı."
@@ -2298,24 +2476,26 @@ msgstr "İptal edilecek kalem bulunamadı."
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "No line items returned from order detail API."
-msgstr "Sipariş detay API'sinden kalem dönmedi."
+msgstr "Sipariş ayrıntıları API'si kalem bilgisi döndürmedi."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "No posted invoice found for this order."
-msgstr "Bu sipariş için onaylanmış fatura bulunamadı."
+msgstr "Bu sipariş için onaylı fatura bulunamadı."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid "No posted invoice or credit note found for sale order %s"
-msgstr ""
-"%s satış siparişi için onaylanmış fatura veya iade faturası bulunamadı."
+msgstr "%s siparişine ait onaylı fatura veya iade faturası bulunamadı."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.actions.act_window,help:hepsiburada_integration.action_hepsiburada_settlement
@@ -2325,9 +2505,20 @@ msgstr "Henüz hesaplaşma içe aktarılmadı"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "No valid line item IDs found in order detail."
-msgstr "Sipariş detayında geçerli kalem ID'si bulunamadı."
+msgstr "Sipariş ayrıntılarında geçerli kalem kimliği bulunamadı."
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Notifications trigger an immediate refresh from the\n"
+"                                Hepsiburada API. Scheduled polling remains available\n"
+"                                independently as a fallback."
+msgstr ""
+"Bildirim gelince Hepsiburada API'sinden güncel bilgiler alınır. Zamanlanmış "
+"sorgulama da yedek olarak çalışmaya devam eder."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__message_needaction_counter
@@ -2344,7 +2535,7 @@ msgstr "Proje Sayısı"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__purchase_order_count
 msgid "Number of Purchase Order Generated"
-msgstr "Oluşturulan Satın Alma Siparişi Sayısı"
+msgstr "Oluşturulan Satınalma Siparişi Sayısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__message_has_error_counter
@@ -2365,12 +2556,12 @@ msgstr "İşlem gerektiren mesaj sayısı"
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__message_has_error_counter
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_settlement__message_has_error_counter
 msgid "Number of messages with delivery error"
-msgstr "Teslim hatası olan mesaj sayısı"
+msgstr "Gönderilemeyen mesaj sayısı."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Odoo Configuration"
-msgstr "Odoo Yapılandırması"
+msgstr "Odoo Ayarları"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
@@ -2386,7 +2577,7 @@ msgstr "Odoo Siparişi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__carrier_id
 msgid "Odoo delivery carrier to assign for this cargo provider"
-msgstr "Bu kargo sağlayıcısı için atanacak Odoo teslimat taşıyıcısı"
+msgstr "Bu kargo firmasıyla eşleşen Odoo kargo kaydı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__sale_line_history
@@ -2401,29 +2592,33 @@ msgstr "Eski revizyonlar"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__require_payment
 msgid "Online Payment"
-msgstr "Çevrimiçi Ödeme"
+msgstr "Online Ödeme"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__require_signature
 msgid "Online Signature"
-msgstr "Çevrimiçi İmza"
+msgstr "Online İmza"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Only claims with status New/Awaiting/Dispute can be accepted."
-msgstr "Sadece Yeni/Beklemede/İhtilaf durumundaki talepler kabul edilebilir."
+msgstr ""
+"Yalnızca yeni, işlem bekleyen veya ihtilaflı talepler kabul edilebilir."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Only claims with status New/Awaiting/Dispute can be rejected."
-msgstr "Sadece Yeni/Beklemede/İhtilaf durumundaki talepler reddedilebilir."
+msgstr "Yalnızca yeni, işlem bekleyen veya ihtilaflı talepler reddedilebilir."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Only orders with 'Open' status can be cancelled in Hepsiburada."
@@ -2432,19 +2627,14 @@ msgstr "Sadece 'Açık' durumundaki siparişler Hepsiburada'da iptal edilebilir.
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Only orders with 'Open' status can be packaged."
 msgstr "Sadece 'Açık' durumundaki siparişler paketlenebilir."
 
 #. module: hepsiburada_integration
 #. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Only paid sale and return transactions can be reconciled."
-msgstr "Yalnızca ödenmiş satış ve iade işlemleri uzlaştırılabilir."
-
-#. module: hepsiburada_integration
-#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Only questions waiting for an answer can be answered."
@@ -2463,7 +2653,7 @@ msgstr "Fırsat"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__sale_order_option_ids
 msgid "Optional Products Lines"
-msgstr "Opsiyonel Ürün Kalemleri"
+msgstr "Opsiyonel Ürün Satırları"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_form
@@ -2478,7 +2668,7 @@ msgstr "Sipariş Tarihi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__hb_order_id
 msgid "Order ID"
-msgstr "Sipariş ID"
+msgstr "Sipariş Kimliği"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_form
@@ -2488,7 +2678,7 @@ msgstr "Sipariş Bilgisi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__order_line
 msgid "Order Lines"
-msgstr "Sipariş Kalemleri"
+msgstr "Sipariş Satırları"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__hb_order_number
@@ -2516,6 +2706,7 @@ msgstr "Sipariş Durumu"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Order cancellation has been queued."
 msgstr "Sipariş iptali kuyruğa alındı."
@@ -2523,17 +2714,19 @@ msgstr "Sipariş iptali kuyruğa alındı."
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Order import has been queued."
-msgstr "Sipariş içe aktarma kuyruğa alındı."
+msgstr "Sipariş içe aktarımı kuyruğa alındı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.constraint,message:hepsiburada_integration.constraint_hepsiburada_order_order_number_backend_uniq
 msgid "Order number must be unique per backend!"
-msgstr "Sipariş numarası arka uç başına benzersiz olmalıdır!"
+msgstr "Sipariş numarası her entegrasyonda benzersiz olmalıdır."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__order_count
 #: model:ir.ui.menu,name:hepsiburada_integration.menu_hepsiburada_orders
@@ -2549,15 +2742,14 @@ msgid ""
 "                Configure auto-import in backend settings or click\n"
 "                \"Import Orders\" manually."
 msgstr ""
-"Hepsiburada'dan içe aktarıldığında siparişler burada görünecektir.\n"
-"                Arka uç ayarlarında otomatik içe aktarmayı yapılandırın "
-"veya\n"
-"                \"Siparişleri İçe Aktar\" butonuna tıklayın."
+"Hepsiburada'dan aktarılan siparişler burada görünür. Entegrasyon "
+"ayarlarından otomatik aktarımı açın veya \"Siparişleri İçe Aktar\" düğmesini"
+" kullanın."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__raw_data
 msgid "Original JSON data from Hepsiburada"
-msgstr "Hepsiburada'dan gelen orijinal JSON verisi"
+msgstr "Hepsiburada'dan gelen özgün JSON verisi."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__unrevisioned_name
@@ -2577,12 +2769,12 @@ msgstr "Gecikmiş"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order_line__package_id
-#, fuzzy
 msgid "Package"
-msgstr "Paketlendi"
+msgstr "Paket"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Package %(package)s is already linked to order %(order)s."
@@ -2590,16 +2782,16 @@ msgstr "%(package)s paketi zaten %(order)s siparişine bağlı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__package_count
-#, fuzzy
 msgid "Package Count"
-msgstr "Paket Numarası"
+msgstr "Paket Sayısı"
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Package Creation Queued"
-msgstr "Paket Oluşturma Kuyruğa Alındı"
+msgstr "Paketleme Kuyruğa Alındı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__package_mapping_incomplete
@@ -2616,6 +2808,7 @@ msgstr "Paket Numarası"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Package already created for this order."
 msgstr "Bu sipariş için paket zaten oluşturuldu."
@@ -2623,15 +2816,15 @@ msgstr "Bu sipariş için paket zaten oluşturuldu."
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Package creation has been queued."
 msgstr "Paket oluşturma kuyruğa alındı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.constraint,message:hepsiburada_integration.constraint_hepsiburada_package_package_number_backend_uniq
-#, fuzzy
 msgid "Package number must be unique per backend."
-msgstr "Sorun numarası arka uç başına benzersiz olmalıdır."
+msgstr "Paket numarası her entegrasyonda benzersiz olmalıdır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__packaged
@@ -2642,9 +2835,8 @@ msgstr "Paketlendi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__package_ids
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_form
-#, fuzzy
 msgid "Packages"
-msgstr "Paketlendi"
+msgstr "Paketler"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__packed
@@ -2669,7 +2861,7 @@ msgstr "Paketlenecek"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__partner_credit_warning
 msgid "Partner Credit Warning"
-msgstr "İş Ortağı Kredi Uyarısı"
+msgstr "Cari Hesap Kredi Uyarısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__hb_partner_id
@@ -2677,8 +2869,7 @@ msgid ""
 "Partner record for Hepsiburada. Used for commission settlement payments and "
 "for reporting purposes."
 msgstr ""
-"Hepsiburada için iş ortağı kaydı. Komisyon hesap kesimi ödemeleri ve "
-"raporlama amacıyla kullanılır."
+"Komisyon ödemelerinde ve raporlarda kullanılacak Hepsiburada cari hesabı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__somepartsorsomeaccessoriesorsomepapersaremissing
@@ -2708,7 +2899,7 @@ msgstr "Ödeme Bilgisi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__reference
 msgid "Payment Ref."
-msgstr "Ödeme Ref."
+msgstr "Ödeme Açıklaması"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__payment_status
@@ -2722,6 +2913,7 @@ msgid "Payment Terms"
 msgstr "Ödeme Koşulları"
 
 #. module: hepsiburada_integration
+#: model:ir.model,name:hepsiburada_integration.model_account_payment
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__payment_ids
 msgid "Payments"
 msgstr "Ödemeler"
@@ -2729,26 +2921,28 @@ msgstr "Ödemeler"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Please enter a rejection reason before rejecting."
-msgstr "Reddetmeden önce lütfen bir ret nedeni girin."
+msgstr "Talebi reddetmeden önce ret nedenini girin."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Please enter an answer before sending."
-msgstr "Göndermeden önce lütfen bir yanıt girin."
+msgstr "Göndermeden önce cevabınızı yazın."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__access_url
 msgid "Portal Access URL"
-msgstr "Portal Erişim URL"
+msgstr "Portal Adresi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__revision_count
 msgid "Previous versions count"
-msgstr "Önceki sürüm sayısı"
+msgstr "Önceki Sürüm Sayısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__pricelist_id
@@ -2759,7 +2953,7 @@ msgstr "Fiyat Listesi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__pricelist_id
 msgid "Pricelist to use for Hepsiburada prices (must be in TRY)"
-msgstr "Hepsiburada fiyatları için kullanılacak fiyat listesi (TRY olmalı)"
+msgstr "Hepsiburada fiyatları için kullanılacak TL (TRY) fiyat listesi."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
@@ -2779,7 +2973,7 @@ msgstr "Ürün"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__product_image_url
 msgid "Product Image URL"
-msgstr "Ürün Resmi URL"
+msgstr "Ürün Görseli Adresi"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_form
@@ -2795,23 +2989,22 @@ msgstr "Ürün Adı"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question__product_url
 msgid "Product URL"
-msgstr "Ürün URL"
+msgstr "Ürün Bağlantısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__returnedproducthasaccountorpassword
 msgid "Product has an account or password"
-msgstr "Üründe hesap veya şifre mevcut"
+msgstr "Üründe hesap veya parola var"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__productisdamaged
-#, fuzzy
 msgid "Product is damaged"
-msgstr "Ürün Adı"
+msgstr "Ürün hasarlı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__nosuchaccessory
 msgid "Product is used or not resalable"
-msgstr "Ürün kullanılmış veya yeniden satılabilir değil"
+msgstr "Ürün kullanılmış veya tekrar satılamaz"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__productsentcomplete
@@ -2821,12 +3014,12 @@ msgstr "Ürün eksiksiz gönderildi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__markedasserviceprocess
 msgid "Product will enter service analysis"
-msgstr "Ürün servis analizine alınacak"
+msgstr "Ürün serviste incelenecek"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_backend__environment__prod
 msgid "Production"
-msgstr "Üretim"
+msgstr "Canlı Ortam"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__production_ids
@@ -2881,6 +3074,7 @@ msgstr "Soru Bilgisi"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Question Status Updated"
 msgstr "Soru Durumu Güncellendi"
@@ -2888,12 +3082,22 @@ msgstr "Soru Durumu Güncellendi"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
-msgid "Question import has been queued."
-msgstr "Soru içe aktarma kuyruğa alındı."
+msgid "Question import exceeded %s pages"
+msgstr "Soru aktarımı %s sayfayı aştı"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Question import has been queued."
+msgstr "Soru içe aktarımı kuyruğa alındı."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__question_count
 #: model:ir.ui.menu,name:hepsiburada_integration.menu_hepsiburada_questions
@@ -2933,11 +3137,20 @@ msgstr "Uzlaştır"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__state__reconciled
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
 #, python-format
 msgid "Reconciled"
 msgstr "Uzlaştırıldı"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Reconciliation Failed"
+msgstr "Uzlaştırma Başarısız"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__origin
@@ -2950,10 +3163,16 @@ msgid "Refresh Conversations"
 msgstr "Konuşmaları Yenile"
 
 #. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Refresh Hepsiburada orders after webhook: %s"
+msgstr "Webhook sonrası Hepsiburada siparişlerini yenile: %s"
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__finalized_with__refund
-#, fuzzy
 msgid "Refund"
-msgstr "İade Edildi"
+msgstr "Para İadesi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__refund_amount
@@ -2991,9 +3210,8 @@ msgstr "Ret Nedeni"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__claim_type__renew_product
-#, fuzzy
 msgid "Renew Product"
-msgstr "Hizmet Ürünü"
+msgstr "Ürün Yenileme"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__require_signature
@@ -3001,8 +3219,8 @@ msgid ""
 "Request a online signature and/or payment to the customer in order to "
 "confirm orders automatically."
 msgstr ""
-"Siparişleri otomatik onaylamak için müşteriden çevrimiçi imza ve/veya ödeme "
-"talep edin."
+"Siparişi otomatik onaylamak için müşteriden çevrim içi imza ve/veya ödeme "
+"ister."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__requires_manual_review
@@ -3012,12 +3230,12 @@ msgstr "Manuel İnceleme Gerekli"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__req_destination_port
 msgid "Requires destination port"
-msgstr "Varış limanı gerekli"
+msgstr "Varış limanı gerektirir"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__req_transport_type
 msgid "Requires transport type"
-msgstr "Taşıma türü gerekli"
+msgstr "Taşıma türü gerektirir"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__activity_user_id
@@ -3033,12 +3251,12 @@ msgstr "İade"
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__returnedproductisnotdelivered
 msgid "Returned product was not delivered"
-msgstr "İade edilen ürün teslim edilmedi"
+msgstr "İade ürünü teslim alınmadı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__missingquantity
 msgid "Returned quantity is missing"
-msgstr "İade edilen adet eksik"
+msgstr "İade edilen ürün adedi eksik"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
@@ -3047,9 +3265,8 @@ msgstr "İadeler"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__review_reason
-#, fuzzy
 msgid "Review Reason"
-msgstr "Ret Nedeni"
+msgstr "İnceleme Nedeni"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__revision_number
@@ -3061,7 +3278,7 @@ msgstr "Revizyon"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__message_has_sms_error
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__message_has_sms_error
 msgid "SMS Delivery error"
-msgstr "SMS Teslim Hatası"
+msgstr "SMS Gönderim Hatası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__sale_deci
@@ -3102,27 +3319,27 @@ msgstr "Satış Temsilcisi"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_search
 msgid "Search Backends"
-msgstr "Arka Uç Ara"
+msgstr "Entegrasyonlarda Ara"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_claim_search
 msgid "Search Claims"
-msgstr "İade Taleplerinde Ara"
+msgstr "Taleplerde Ara"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_search
 msgid "Search Orders"
-msgstr "Sipariş Ara"
+msgstr "Siparişlerde Ara"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_search
 msgid "Search Questions"
-msgstr "Soru Ara"
+msgstr "Sorularda Ara"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
 msgid "Search Settlements"
-msgstr "Hesap Kesimi Ara"
+msgstr "Hesaplaşmalarda Ara"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__second_reminder_mail_sent
@@ -3137,19 +3354,20 @@ msgstr "Güvenlik Anahtarı"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
 #, python-format
 msgid "Select Refund or Change before accepting this claim."
-msgstr "Bu talebi kabul etmeden önce İade veya Değişim seçin."
+msgstr "Talebi kabul etmeden önce Para İadesi veya Değişim seçin."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__project_id
 msgid "Select a non billable project on which tasks can be created."
-msgstr "Görevlerin oluşturulabileceği faturalandırılmayan bir proje seçin."
+msgstr "Görev açılacak, faturalandırılmayan projeyi seçin."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_form
 msgid "Send Answer"
-msgstr "Yanıt Gönder"
+msgstr "Cevabı Gönder"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_form
@@ -3159,10 +3377,11 @@ msgstr "Fatura Gönder"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__auto_send_invoice
 msgid "Send invoice links to Hepsiburada via nightly batch cron"
-msgstr "Gece toplu iş ile Hepsiburada'ya fatura bağlantılarını gönder"
+msgstr "Fatura bağlantılarını her gece toplu olarak Hepsiburada'ya gönderir."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Send invoice: %s"
@@ -3171,7 +3390,7 @@ msgstr "Fatura gönder: %s"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_question_message__sender
 msgid "Sender"
-msgstr "Gönderen"
+msgstr "Gönderici"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__is_all_service
@@ -3181,41 +3400,54 @@ msgstr "Hizmet Ürünü"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, fuzzy, python-format
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
 msgid "Settlement could not be reconciled."
-msgstr "Hesaplaşma içe aktarımı kuyruğa alındı."
+msgstr "Hesaplaşma uzlaştırılamadı."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid ""
 "Settlement currency %(settlement)s does not match invoice currency "
 "%(invoice)s."
 msgstr ""
-"Mutabakat para birimi %(settlement)s, fatura para birimi %(invoice)s ile "
-"eşleşmiyor."
+"Hesaplaşmanın para birimi (%(settlement)s), faturanın para birimiyle "
+"(%(invoice)s) eşleşmiyor."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid ""
 "Settlement group amount %(settlement).2f does not match invoice residual "
 "%(invoice).2f."
 msgstr ""
-"Mutabakat grubu tutarı %(settlement).2f, faturanın kalan tutarı "
-"%(invoice).2f ile eşleşmiyor."
+"Hesaplaşma toplamı (%(settlement).2f), faturanın kalan tutarıyla "
+"(%(invoice).2f) eşleşmiyor."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, fuzzy, python-format
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
 msgid "Settlement group has been reconciled successfully."
-msgstr "Hesaplaşma içe aktarımı kuyruğa alındı."
+msgstr "Hesaplaşma grubu uzlaştırıldı."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Settlement import exceeded 100,000 records for %(window)s"
+msgstr "%(window)s aralığındaki hesaplaşma aktarımı 100.000 kaydı aştı"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Settlement import has been queued."
@@ -3224,16 +3456,18 @@ msgstr "Hesaplaşma içe aktarımı kuyruğa alındı."
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
 #, python-format
 msgid ""
 "Settlement journal currency %(journal)s does not match invoice currency "
 "%(invoice)s."
 msgstr ""
-"Mutabakat günlüğü para birimi %(journal)s, fatura para birimi %(invoice)s "
-"ile eşleşmiyor."
+"Ödeme yevmiyesinin para birimi (%(journal)s), faturanın para birimiyle "
+"(%(invoice)s) eşleşmiyor."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #: model:ir.actions.act_window,name:hepsiburada_integration.action_hepsiburada_settlement
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__settlement_count
@@ -3249,19 +3483,28 @@ msgid ""
 "Settlements are imported from Hepsiburada's finance API and used\n"
 "                to reconcile invoices with marketplace payments."
 msgstr ""
-"Hesap kesimleri Hepsiburada'nın finans API'sinden içe aktarılır ve\n"
-"                faturaların pazar yeri ödemeleri ile mutabakatı için "
-"kullanılır."
+"Hepsiburada'nın finans API'sinden aktarılan hesaplaşmalar, faturaları "
+"pazaryeri ödemeleriyle uzlaştırmak için kullanılır."
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid ""
+"Share this base URL and the dedicated webhook credentials\n"
+"                                with Hepsiburada. Complete their test-environment onboarding\n"
+"                                before enabling production notifications."
+msgstr ""
+"Bu adresi ve webhook erişim bilgilerini Hepsiburada'ya iletin. Canlı "
+"bildirimleri açmadan önce test kurulumunu tamamlayın."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_order_form
 msgid "Shipping"
-msgstr "Sevkiyat"
+msgstr "Nakliye"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__picking_policy
 msgid "Shipping Policy"
-msgstr "Sevkiyat Politikası"
+msgstr "Teslimat Politikası"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__signature
@@ -3284,6 +3527,8 @@ msgid "Sku"
 msgstr "SKU"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__smart_search
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__smart_search
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__smart_search
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__smart_search
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__smart_search
@@ -3348,10 +3593,9 @@ msgid ""
 "Today: Activity date is today\n"
 "Planned: Future activities."
 msgstr ""
-"Aktivitelere dayalı durum\n"
-"Gecikmiş: Son tarih geçmiş\n"
-"Bugün: Aktivite tarihi bugün\n"
-"Planlanmış: Gelecek aktiviteler."
+"Gecikmiş: Son tarih geçti.\n"
+"Bugün: Aktivitenin tarihi bugün.\n"
+"Planlanmış: Aktivitenin tarihi ileride."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__rejection_code__stockproblem
@@ -3371,6 +3615,12 @@ msgstr "Konu"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_claim.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "Success"
@@ -3384,12 +3634,12 @@ msgstr "Anket Sayısı"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__survey_url
 msgid "Survey URL"
-msgstr "Anket URL"
+msgstr "Anket Adresi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__survey_url_qr
 msgid "Survey URL QR"
-msgstr "Anket URL QR"
+msgstr "Anket QR Kodu"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__survey_ids
@@ -3399,31 +3649,35 @@ msgstr "Anketler"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Sync Missing Invoices"
-msgstr "Eksik Faturaları Senkronize Et"
+msgstr "Eksik Faturaları Eşitle"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Sync Settings"
-msgstr "Senkronizasyon Ayarları"
+msgstr "Eşitleme Ayarları"
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Sync Started"
-msgstr "Senkronizasyon Başlatıldı"
+msgstr "Eşitleme Başlatıldı"
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
 msgid "Sync Status"
-msgstr "Senkronizasyon Durumu"
+msgstr "Eşitleme Durumu"
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
 #, python-format
 msgid "Sync missing invoices: %s"
-msgstr "Eksik faturaları senkronize et: %s"
+msgstr "Eksik faturaları eşitle: %s"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__tag_ids
@@ -3442,9 +3696,8 @@ msgstr "Bu satışla ilişkili görevler"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__tax_amount
-#, fuzzy
 msgid "Tax Amount"
-msgstr "KDV Tutarı"
+msgstr "Vergi Tutarı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__tax_country_id
@@ -3464,7 +3717,7 @@ msgstr "Vergiler"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__terms_type
 msgid "Terms & Conditions format"
-msgstr "Şartlar ve Koşullar biçimi"
+msgstr "Şartlar ve Koşullar formatı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__note
@@ -3487,27 +3740,46 @@ msgid "Test Connection"
 msgstr "Bağlantıyı Test Et"
 
 #. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The Hepsiburada payment status is unknown."
+msgstr "Hepsiburada ödeme durumu bilinmiyor."
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__country_code
 msgid ""
 "The ISO country code in two chars. \n"
 "You can use this field for quick search."
 msgstr ""
-"İki karakterlik ISO ülke kodu.\n"
-"Hızlı arama için bu alanı kullanabilirsiniz."
+"İki karakterlik ISO ülke kodu. \n"
+"Bu alanı hızlı arama için kullanabilirsiniz."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "The answer cannot be longer than 2,000 characters."
 msgstr "Cevap 2.000 karakterden uzun olamaz."
 
 #. module: hepsiburada_integration
-#: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__partner_user_id
-msgid "The internal user in charge of this contact."
-msgstr "Bu kontakla ilgilenen dahili kullanıcı."
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The commission direction, amount or currency is invalid."
+msgstr "Komisyonun yönü, tutarı veya para birimi geçersiz."
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__partner_user_id
+msgid "The internal user in charge of this contact."
+msgstr "Bu kişiden sorumlu iç kullanıcı."
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__count_pending_changeset_changes
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changeset_changes
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_claim__count_pending_changeset_changes
@@ -3522,9 +3794,11 @@ msgstr "Bu kontakla ilgilenen dahili kullanıcı."
 #: model:ir.model.fields,help:hepsiburada_integration.field_sale_order_line__count_pending_changeset_changes
 #: model:ir.model.fields,help:hepsiburada_integration.field_stock_picking__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "Bu kaydın bekleyen değişiklik sayısı"
+msgstr "Bu kayıtta bekleyen değişiklik sayısı."
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__count_pending_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_pending_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_claim__count_pending_changesets
@@ -3539,9 +3813,11 @@ msgstr "Bu kaydın bekleyen değişiklik sayısı"
 #: model:ir.model.fields,help:hepsiburada_integration.field_sale_order_line__count_pending_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_stock_picking__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
+msgstr "Bu kayıtta bekleyen değişiklik grubu sayısı."
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,help:hepsiburada_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__count_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_cargo_mapping__count_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_claim__count_changesets
@@ -3556,12 +3832,20 @@ msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
 #: model:ir.model.fields,help:hepsiburada_integration.field_sale_order_line__count_changesets
 #: model:ir.model.fields,help:hepsiburada_integration.field_stock_picking__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Bu kaydın toplam değişiklik seti sayısı"
+msgstr "Bu kaydın toplam değişiklik grubu sayısı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__reference
 msgid "The payment communication of this sale order."
-msgstr "Bu satış siparişinin ödeme iletişimi."
+msgstr "Bu siparişin ödeme açıklaması."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The payment covers incompatible commission types."
+msgstr "Ödeme, birbiriyle uyumsuz komisyon türleri içeriyor."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__payment_currency_id
@@ -3584,13 +3868,20 @@ msgid "The purpose of the shipment (FedEx)"
 msgstr "Gönderinin amacı (FedEx)"
 
 #. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The settlement amount has an invalid sign."
+msgstr "Hesaplaşma tutarının işareti işlem yönüyle uyuşmuyor."
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__campaign_id
 msgid ""
-"This is a name that helps you keep track of your different campaign efforts, "
-"e.g. Fall_Drive, Christmas_Special"
+"This is a name that helps you keep track of your different campaign efforts,"
+" e.g. Fall_Drive, Christmas_Special"
 msgstr ""
-"Bu, farklı kampanya çalışmalarınızı takip etmenize yardımcı olan bir "
-"isimdir, ör. Sonbahar_Kampanyası, Yılbaşı_Özel"
+"Kampanyaları ayırt etmek için kullanılan ad. Örnek: Sonbahar Kampanyası."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__commitment_date
@@ -3598,13 +3889,13 @@ msgid ""
 "This is the delivery date promised to the customer. If set, the delivery "
 "order will be scheduled based on this date rather than product lead times."
 msgstr ""
-"Bu müşteriye vaat edilen teslimat tarihidir. Ayarlanırsa teslimat emri ürün "
-"temin süreleri yerine bu tarihe göre planlanır."
+"Müşteriye taahhüt edilen teslimat tarihi. Girilirse sevkiyat, ürün teslim "
+"süreleri yerine bu tarihe göre planlanır."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__medium_id
 msgid "This is the method of delivery, e.g. Postcard, Email, or Banner Ad"
-msgstr "Bu teslimat yöntemidir, ör. Kartpostal, E-posta veya Banner Reklam"
+msgstr "Pazarlama kanalı. Örnek: e-posta, kartpostal veya banner reklam."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__source_id
@@ -3612,44 +3903,53 @@ msgid ""
 "This is the source of the link, e.g. Search Engine, another domain, or name "
 "of email list"
 msgstr ""
-"Bu bağlantının kaynağıdır, ör. Arama Motoru, başka bir alan adı veya e-posta "
-"listesi adı"
+"Bağlantının geldiği kaynak. Örnek: arama motoru, başka bir site veya e-posta"
+" listesi."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid "This question has already been answered on Hepsiburada."
-msgstr "Bu soru Hepsiburada'da zaten yanıtlanmış."
+msgstr "Bu soru Hepsiburada'da zaten cevaplanmış."
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid ""
 "This question was automatically closed by Hepsiburada and can no longer be "
 "answered."
-msgstr ""
-"Bu soru Hepsiburada tarafından otomatik olarak kapatıldı ve artık "
-"yanıtlanamaz."
+msgstr "Hepsiburada soruyu otomatik kapattı. Artık cevaplanamaz."
 
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_question.py:0
 #, python-format
 msgid ""
 "This question was rejected on Hepsiburada and can no longer be answered."
-msgstr "Bu soru Hepsiburada'da reddedildi ve artık yanıtlanamaz."
+msgstr "Soru Hepsiburada'da reddedildi. Artık cevaplanamaz."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "This transaction type is not supported for automatic reconciliation."
+msgstr "Bu işlem türü otomatik uzlaştırma için desteklenmiyor."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__timesheet_encode_uom_id
 msgid "Timesheet Encoding Unit"
-msgstr "Zaman Çizelgesi Kodlama Birimi"
+msgstr "Zaman Çizelgesi Süre Birimi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__timesheet_total_duration
 msgid "Timesheet Total Duration"
-msgstr "Zaman Çizelgesi Toplam Süresi"
+msgstr "Toplam Çalışma Süresi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__timesheet_count
@@ -3679,21 +3979,20 @@ msgstr "Toplam Fiyat"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__commission_amount
 msgid "Total commission amount for the sale order."
-msgstr "Satış siparişi için toplam komisyon tutarı."
+msgstr "Siparişin toplam komisyon tutarı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__timesheet_total_duration
 msgid ""
 "Total recorded duration, expressed in the encoding UoM, and rounded to the "
 "unit"
-msgstr ""
-"Kodlama birimiyle ifade edilen ve birime yuvarlanmış toplam kayıtlı süre"
+msgstr "Seçili süre birimine çevrilmiş ve yuvarlanmış toplam kayıtlı süre."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__cargo_tracking_link
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_package__cargo_tracking_link
 msgid "Tracking Link"
-msgstr "Takip Linki"
+msgstr "Takip Bağlantısı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__cargo_tracking_number
@@ -3704,12 +4003,14 @@ msgstr "Takip Numarası"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Tracking Updated"
 msgstr "Takip Güncellendi"
 
 #. module: hepsiburada_integration
 #. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Tracking could not be fetched: %s"
@@ -3718,9 +4019,18 @@ msgstr "Takip bilgisi alınamadı: %s"
 #. module: hepsiburada_integration
 #. odoo-python
 #: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_order.py:0
 #, python-format
 msgid "Tracking info has been fetched from Hepsiburada."
 msgstr "Takip bilgisi Hepsiburada'dan alındı."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Transaction %s has no key for historical refresh."
+msgstr "%s işlemini geçmişten yenilemek için gerekli kimlik bilgileri eksik."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__transaction_date
@@ -3730,12 +4040,12 @@ msgstr "İşlem Tarihi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__hb_transaction_id
 msgid "Transaction ID"
-msgstr "İşlem ID"
+msgstr "İşlem Kimliği"
 
 #. module: hepsiburada_integration
 #: model:ir.model.constraint,message:hepsiburada_integration.constraint_hepsiburada_settlement_transaction_uniq
 msgid "Transaction ID must be unique per backend!"
-msgstr "İşlem ID'si arka uç başına benzersiz olmalıdır!"
+msgstr "İşlem kimliği her entegrasyonda benzersiz olmalıdır."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
@@ -3756,7 +4066,7 @@ msgstr "İşlemler"
 #. module: hepsiburada_integration
 #: model:ir.model,name:hepsiburada_integration.model_stock_picking
 msgid "Transfer"
-msgstr "Teslimat"
+msgstr "Stok Transferi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__picking_ids
@@ -3783,12 +4093,12 @@ msgstr "Tür Adı"
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__activity_exception_decoration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr "Kayıttaki istisna aktivitesinin türü."
+msgstr "Kayıttaki aktivite uyarısının türü."
 
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_form
 msgid "Type your answer here..."
-msgstr "Yanıtınızı buraya yazın..."
+msgstr "Cevabınızı yazın..."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__currency_id_usd
@@ -3798,7 +4108,7 @@ msgstr "USD Para Birimi"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__source_id
 msgid "UTM source to set on Hepsiburada orders"
-msgstr "Hepsiburada siparişlerinde ayarlanacak UTM kaynağı"
+msgstr "Hepsiburada siparişlerine atanacak UTM kaynağı."
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_order_line__hb_line_item_id
@@ -3808,13 +4118,12 @@ msgstr "HB items[].id alanından UUID"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_search
 msgid "Unanswered"
-msgstr "Yanıtsız"
+msgstr "Cevaplanmadı"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__undelivered
-#, fuzzy
 msgid "Undelivered"
-msgstr "Teslim Edildi"
+msgstr "Teslim Edilemedi"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_claim__claim_type__undelivered_product
@@ -3834,6 +4143,11 @@ msgid "Unknown"
 msgstr "Bilinmiyor"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__unpacked
+msgid "Unpacked"
+msgstr "Paket Bozuldu"
+
+#. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__amount_untaxed
 msgid "Untaxed Amount"
 msgstr "Vergisiz Tutar"
@@ -3849,6 +4163,8 @@ msgid "User"
 msgstr "Kullanıcı"
 
 #. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_auto_reconcile__user_can_see_changeset
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__user_can_see_changeset
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__user_can_see_changeset
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_cargo_mapping__user_can_see_changeset
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_claim__user_can_see_changeset
@@ -3863,7 +4179,7 @@ msgstr "Kullanıcı"
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_sale_order_line__user_can_see_changeset
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_stock_picking__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "Kullanıcı Değişiklikleri Görebilir"
+msgstr "Değişiklikleri Görebilir"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__user_agent
@@ -3889,7 +4205,7 @@ msgstr "KDV Oranı"
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_question__hb_status__waiting_merchant
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_search
 msgid "Waiting Merchant"
-msgstr "Satıcı Bekleniyor"
+msgstr "Satıcı Cevabı Bekleniyor"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_order__warehouse_id
@@ -3904,7 +4220,27 @@ msgstr "Depolar"
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__warehouse_ids
 msgid "Warehouses to use for order fulfillment"
-msgstr "Sipariş karşılama için kullanılacak depolar"
+msgstr "Siparişlerin hazırlanacağı depolar."
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_url
+msgid "Webhook Base URL"
+msgstr "Webhook Adresi"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_password
+msgid "Webhook Password"
+msgstr "Webhook Parolası"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_username
+msgid "Webhook Username"
+msgstr "Webhook Kullanıcı Adı"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
+msgid "Webhooks"
+msgstr "Webhook'lar"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__website_message_ids
@@ -3928,7 +4264,7 @@ msgstr "Yanlış Ürün"
 #. module: hepsiburada_integration
 #: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_question_form
 msgid "Your Answer"
-msgstr "Yanıtınız"
+msgstr "Cevabınız"
 
 #. module: hepsiburada_integration
 #: model:ir.model.fields,help:hepsiburada_integration.field_hepsiburada_backend__merchant_id
@@ -3944,274 +4280,3 @@ msgstr "Ödeme Bekliyor"
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_order__hb_status__cancelled
 msgid "İptal Edildi"
 msgstr "İptal Edildi"
-
-#, python-format
-#~ msgid "Notify HB intransit: %s"
-#~ msgstr "HB transit bildirimi: %s"
-
-#~ msgid "Sale"
-#~ msgstr "Satış"
-
-#~ msgid "Waiting Customer"
-#~ msgstr "Müşteri Bekleniyor"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
-#, python-format
-msgid "A payment was posted before Hepsiburada marked the transaction Paid."
-msgstr ""
-"Hepsiburada işlemi ödendi olarak işaretlemeden önce ödeme kaydı "
-"oluşturulmuş."
-
-#. module: hepsiburada_integration
-#: model:ir.model,name:hepsiburada_integration.model_account_auto_reconcile
-msgid "Account Auto Reconcile"
-msgstr "Otomatik Hesap Uzlaştırma"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Check the commission amount, currency, partner and journal."
-msgstr ""
-"Komisyon tutarını, para birimini, iş ortağını ve yevmiyeyi kontrol edin."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Claim import exceeded 100,000 records"
-msgstr "Talep aktarımı 100.000 kaydı aştı"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_id
-msgid "Commission Invoice"
-msgstr "Komisyon Faturası"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_number
-msgid "Commission Invoice Number"
-msgstr "Komisyon Fatura No."
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_note
-msgid "Commission Match Note"
-msgstr "Komisyon Uzlaştırma Notu"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_state
-msgid "Commission Match State"
-msgstr "Komisyon Uzlaştırma Durumu"
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
-msgid "Commission Matching"
-msgstr "Komisyon Uzlaştırma"
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
-msgid "Commission Pending"
-msgstr "Komisyon Bekliyor"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__commission_refund
-msgid "Commission Refund"
-msgstr "Komisyon İadesi"
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
-msgid "Commission Review"
-msgstr "Komisyon İncelemesi"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Commission data changed; the existing payment was preserved."
-msgstr "Komisyon bilgileri değişti; mevcut ödeme korundu."
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__hepsiburada_commission_settlement_ids
-msgid "Hepsiburada Commission Settlement"
-msgstr "Hepsiburada Komisyon Hesaplaşması"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__invoice_date
-msgid "Invoice Date"
-msgstr "Fatura Tarihi"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__is_hepsiburada_commission
-msgid "Is Hepsiburada Commission"
-msgstr "Hepsiburada Komisyonu"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
-#, python-format
-msgid ""
-"Legacy commission payment has no matched supplier invoice and must be "
-"reviewed."
-msgstr ""
-"Eski komisyon ödemesinin eşleşen tedarikçi faturası yok; incelenmesi "
-"gerekiyor."
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
-msgid "Match Commission Invoice"
-msgstr "Komisyonu Uzlaştır"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Multiple posted customer documents require review."
-msgstr "Birden fazla onaylanmış müşteri belgesi var; incelenmesi gerekiyor."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Question import exceeded %s pages"
-msgstr "Soru aktarımı %s sayfayı aştı"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "Reconciliation Failed"
-msgstr "Uzlaştırma Başarısız"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Settlement import exceeded 100,000 records for %(window)s"
-msgstr "%(window)s aralığındaki hesaplaşma aktarımı 100.000 kaydı aştı"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The Hepsiburada payment status is unknown."
-msgstr "Hepsiburada ödeme durumu bilinmiyor."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The commission direction, amount or currency is invalid."
-msgstr "Komisyonun yönü, tutarı veya para birimi geçersiz."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The payment covers incompatible commission types."
-msgstr "Ödeme, birbiriyle uyumsuz komisyon türleri içeriyor."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "The settlement amount has an invalid sign."
-msgstr "Hesaplaşma tutarının işareti işlem yönüyle uyuşmuyor."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
-#, python-format
-msgid "This transaction type is not supported for automatic reconciliation."
-msgstr "Bu işlem türü otomatik uzlaştırma için desteklenmiyor."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Transaction %s has no key for historical refresh."
-msgstr "%s işlemini geçmişten yenilemek için gerekli bilgiler bulunamadı."
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_enabled
-msgid "Enable Webhooks"
-msgstr "Webhook'ları Etkinleştir"
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid "Generate Webhook Credentials"
-msgstr "Webhook Erişim Bilgilerini Oluştur"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Hepsiburada webhook refresh failed; retrying."
-msgstr "Hepsiburada webhook yenilemesi başarısız oldu; yeniden denenecek."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/controllers/webhook.py:0
-#, python-format
-msgid "Invalid JSON"
-msgstr "Geçersiz JSON"
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/controllers/webhook.py:0
-#, python-format
-msgid "Invalid payload"
-msgstr "Geçersiz bildirim verisi"
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid ""
-"Notifications trigger an immediate refresh from the\n"
-"                                Hepsiburada API. Scheduled polling remains available\n"
-"                                independently as a fallback."
-msgstr ""
-"Bildirimler, Hepsiburada API üzerinden hemen yenileme başlatır. Zamanlanmış "
-"sorgulama, yedek olarak bağımsız şekilde kullanılmaya devam eder."
-
-#. module: hepsiburada_integration
-#. odoo-python
-#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
-#, python-format
-msgid "Refresh Hepsiburada orders after webhook: %s"
-msgstr "Webhook sonrası Hepsiburada siparişlerini yenile: %s"
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid ""
-"Share this base URL and the dedicated webhook credentials\n"
-"                                with Hepsiburada. Complete their test-environment onboarding\n"
-"                                before enabling production notifications."
-msgstr ""
-"Bu temel adresi ve webhook için oluşturulan erişim bilgilerini Hepsiburada "
-"ile paylaşın. Canlı ortam bildirimlerini etkinleştirmeden önce Hepsiburada "
-"test ortamındaki kurulum sürecini tamamlayın."
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_package__hb_status__unpacked
-msgid "Unpacked"
-msgstr "Paketi Bozuldu"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_url
-msgid "Webhook Base URL"
-msgstr "Webhook Temel Adresi"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_password
-msgid "Webhook Password"
-msgstr "Webhook Parolası"
-
-#. module: hepsiburada_integration
-#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_backend__webhook_username
-msgid "Webhook Username"
-msgstr "Webhook Kullanıcı Adı"
-
-#. module: hepsiburada_integration
-#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_backend_form
-msgid "Webhooks"
-msgstr "Webhook'lar"

--- a/hepsiburada_integration/models/hepsiburada_backend.py
+++ b/hepsiburada_integration/models/hepsiburada_backend.py
@@ -2,12 +2,15 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 import logging
+import secrets
 from datetime import timedelta
 
 from dateutil import parser as dateutil_parser
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+
+from odoo.addons.queue_job.exception import RetryableJobError
 
 from .hepsiburada_request import HepsiburadaAPIError, HepsiburadaRequest
 
@@ -74,6 +77,25 @@ class HepsiburadaBackend(models.Model):
         default="stage",
         required=True,
         tracking=True,
+    )
+
+    webhook_enabled = fields.Boolean(
+        string="Enable Webhooks",
+        groups="hepsiburada_integration.group_hepsiburada_manager",
+        copy=False,
+    )
+    webhook_url = fields.Char(
+        string="Webhook Base URL",
+        compute="_compute_webhook_url",
+        groups="hepsiburada_integration.group_hepsiburada_manager",
+    )
+    webhook_username = fields.Char(
+        groups="hepsiburada_integration.group_hepsiburada_manager",
+        copy=False,
+    )
+    webhook_password = fields.Char(
+        groups="hepsiburada_integration.group_hepsiburada_manager",
+        copy=False,
     )
 
     # Odoo Mappings
@@ -246,6 +268,64 @@ class HepsiburadaBackend(models.Model):
             environment=backend.environment,
             user_agent=backend.user_agent,
         )
+
+    def _compute_webhook_url(self):
+        """Expose the base URL under which Hepsiburada's routes are served."""
+        base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+        for backend in self:
+            backend.webhook_url = (
+                f"{base_url.rstrip('/')}/hb/wh/{backend.id}"
+                if base_url and backend.id
+                else False
+            )
+
+    def action_generate_webhook_credentials(self):
+        """Generate dedicated inbound credentials for Hepsiburada onboarding."""
+        self.ensure_one()
+        self.write(
+            {
+                "webhook_username": f"hepsiburada-{self.id}",
+                "webhook_password": secrets.token_urlsafe(32),
+            }
+        )
+
+    def _queue_webhook_sync(self):
+        """Coalesce notifications into a refresh of authoritative API data."""
+        self.ensure_one()
+        self.with_delay(
+            channel=self._marketplace_queue_channel(),
+            identity_key=f"hepsiburada-webhook-sync-{self.id}",
+            description=_("Refresh Hepsiburada orders after webhook: %s") % self.name,
+        )._sync_webhook_orders()
+
+    def _sync_webhook_orders(self):
+        """Run the shared import and retry incomplete API reads."""
+        self.ensure_one()
+        if not self.active or not self.webhook_enabled:
+            return
+        if not self._import_orders():
+            raise RetryableJobError(
+                _("Hepsiburada webhook refresh failed; retrying."), seconds=60
+            )
+
+    def _sync_unpacked_packages(self, client):
+        """Reconcile unpacked package history for polling and webhooks alike."""
+        self.ensure_one()
+        packages = self._fetch_all_packages(client.get_unpacked_packages, limit=10)
+        Package = self.env["hepsiburada.package"]
+        for data in packages:
+            package_number = data.get("packageNumber")
+            if not package_number:
+                continue
+            package = Package.search(
+                [
+                    ("backend_id", "=", self.id),
+                    ("hb_package_number", "=", str(package_number)),
+                ],
+                limit=1,
+            )
+            if package:
+                package._mark_unpacked()
 
     # ==================== Order Import ====================
 
@@ -561,6 +641,7 @@ class HepsiburadaBackend(models.Model):
         - /packages/delivered (teslim edildi)
         - /packages/undelivered (teslim edilemedi)
         - /packages/cancelled (iptal edildi)
+        - /packages/status/unpacked (paketi bozuldu)
         """
         self.ensure_one()
         Order = self.env["hepsiburada.order"]
@@ -580,6 +661,12 @@ class HepsiburadaBackend(models.Model):
         fetch_errors = []
         record_errors = []
         client = self._get_api_client()
+        try:
+            with self.env.cr.savepoint():
+                self._sync_unpacked_packages(client)
+        except Exception as error:
+            fetch_errors.append(f"unpacked: {error}")
+            _logger.exception("Failed to synchronize unpacked HB packages")
         payloads = self._current_order_payloads(client, fetch_errors)
         payloads.extend(
             self._transition_order_payloads(
@@ -602,6 +689,7 @@ class HepsiburadaBackend(models.Model):
             self.name,
             len(errors),
         )
+        return not fetch_errors
 
     # ==================== Settlement Import ====================
 

--- a/hepsiburada_integration/models/hepsiburada_order.py
+++ b/hepsiburada_integration/models/hepsiburada_order.py
@@ -461,7 +461,9 @@ class HepsiburadaOrder(models.Model):
 
     def _sync_from_packages(self):
         for order in self:
-            packages = order.package_ids
+            packages = order.package_ids.filtered(
+                lambda package: package.hb_status != "unpacked"
+            )
             active_packages = packages.filtered(
                 lambda package: package.hb_status != "cancelled"
             )
@@ -476,6 +478,12 @@ class HepsiburadaOrder(models.Model):
                 aggregate_status = "in_transit"
             elif statuses:
                 aggregate_status = "packaged"
+            elif order.package_ids and not packages:
+                aggregate_status = (
+                    "cancelled"
+                    if set(order.hb_line_item_ids.mapped("status")) == {"cancelled"}
+                    else "open"
+                )
             else:
                 aggregate_status = False
 
@@ -506,6 +514,14 @@ class HepsiburadaOrder(models.Model):
                         ),
                     }
                 )
+            elif order.package_ids:
+                vals.update(
+                    {
+                        "hb_missing_invoice": False,
+                        "invoice_link_sent": False,
+                        "invoice_sent_date": False,
+                    }
+                )
             if len(packages) == 1:
                 package = packages[0]
                 vals.update(
@@ -517,7 +533,7 @@ class HepsiburadaOrder(models.Model):
                         "cargo_tracking_link": package.cargo_tracking_link,
                     }
                 )
-            elif len(packages) > 1:
+            elif order.package_ids:
                 vals.update(
                     {
                         "hb_package_number": False,
@@ -974,10 +990,11 @@ class HepsiburadaOrder(models.Model):
         """Fetch every HB package independently and refresh aggregate fields."""
         self.ensure_one()
         self._ensure_package_records()
-        if not self.package_ids:
+        packages = self.package_ids.filtered(lambda item: item.hb_status != "unpacked")
+        if not packages:
             return
         errors = []
-        for package in self.package_ids:
+        for package in packages:
             try:
                 package._fetch_tracking_from_api()
             except HepsiburadaAPIError as error:
@@ -988,7 +1005,7 @@ class HepsiburadaOrder(models.Model):
                     exc_info=True,
                 )
         self._sync_from_packages()
-        if errors and len(errors) == len(self.package_ids):
+        if errors and len(errors) == len(packages):
             raise UserError(_("Tracking could not be fetched: %s") % errors[0])
 
     def _ensure_package_records(self):
@@ -1098,7 +1115,7 @@ class HepsiburadaOrder(models.Model):
         base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
         invoice_url = f"{base_url}{invoice.get_portal_url()}"
         for package in self.package_ids.filtered(
-            lambda item: not item.invoice_link_sent
+            lambda item: not item.invoice_link_sent and item.hb_status != "unpacked"
         ):
             package._send_invoice_link(invoice_url)
         self._sync_from_packages()
@@ -1114,7 +1131,7 @@ class HepsiburadaOrder(models.Model):
         """Manual button: queue package creation in Hepsiburada."""
         self.ensure_one()
         self._ensure_package_records()
-        if self.package_ids:
+        if self.package_ids.filtered(lambda item: item.hb_status != "unpacked"):
             raise UserError(_("Package already created for this order."))
         if self.hb_status != "open":
             raise UserError(_("Only orders with 'Open' status can be packaged."))

--- a/hepsiburada_integration/models/hepsiburada_package.py
+++ b/hepsiburada_integration/models/hepsiburada_package.py
@@ -17,6 +17,7 @@ PACKAGE_STATUS_SELECTION = [
     ("delivered", "Delivered"),
     ("undelivered", "Undelivered"),
     ("cancelled", "Cancelled"),
+    ("unpacked", "Unpacked"),
 ]
 
 
@@ -91,6 +92,16 @@ class HepsiburadaPackage(models.Model):
         self.write(vals)
         self.hb_order_id._sync_from_packages()
         return self
+
+    def _mark_unpacked(self):
+        """Release package mappings while preserving the package history."""
+        self.ensure_one()
+        if self.hb_status == "unpacked":
+            return
+        active_lines = self.line_ids.filtered(lambda line: line.status != "cancelled")
+        active_lines.write({"package_id": False, "status": "open"})
+        self.hb_status = "unpacked"
+        self.hb_order_id._sync_from_packages()
 
     def _fetch_tracking_from_api(self):
         self.ensure_one()

--- a/hepsiburada_integration/models/hepsiburada_request.py
+++ b/hepsiburada_integration/models/hepsiburada_request.py
@@ -166,6 +166,13 @@ class HepsiburadaRequest(MarketplaceRequest):
         params.update(self._date_range_params(begin_date, end_date))
         return self._make_request("GET", "oms", endpoint, params=params)
 
+    def get_unpacked_packages(self, offset=0, limit=10):
+        """Get packages that Hepsiburada has unpacked."""
+        endpoint = f"/packages/merchantid/{self.merchant_id}/status/unpacked"
+        return self._make_request(
+            "GET", "oms", endpoint, params={"offset": offset, "limit": min(limit, 10)}
+        )
+
     def get_delivered_packages(
         self, offset=0, limit=50, begin_date=None, end_date=None
     ):

--- a/hepsiburada_integration/tests/__init__.py
+++ b/hepsiburada_integration/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_hepsiburada_question
 from . import test_hepsiburada_request
 from . import test_hepsiburada_security
 from . import test_hepsiburada_settlement
+from . import test_hepsiburada_webhook

--- a/hepsiburada_integration/tests/test_hepsiburada_order.py
+++ b/hepsiburada_integration/tests/test_hepsiburada_order.py
@@ -157,6 +157,7 @@ class TestHepsiburadaOrder(HepsiburadaCommon):
                 "location_dest_id": self.env.ref("stock.stock_location_customers").id,
                 "partner_id": binding.odoo_id.partner_id.id,
                 "group_id": group.id,
+                "sale_id": binding.odoo_id.id,
             }
         )
 

--- a/hepsiburada_integration/tests/test_hepsiburada_webhook.py
+++ b/hepsiburada_integration/tests/test_hepsiburada_webhook.py
@@ -1,0 +1,366 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from odoo.exceptions import AccessError
+from odoo.tests import HttpCase, tagged
+
+from odoo.addons.queue_job.exception import RetryableJobError
+
+from ..models.hepsiburada_request import HepsiburadaAPIError
+from .common import HepsiburadaCommon
+
+
+@tagged("post_install", "-at_install")
+class TestHepsiburadaWebhook(HepsiburadaCommon, HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend.write(
+            {
+                "webhook_enabled": True,
+                "webhook_username": "hb-webhook-user",
+                "webhook_password": "dedicated-webhook-secret",
+            }
+        )
+
+    def _request(self, path, payload, method="POST", authorization=None, raw=False):
+        """Send a real HTTP request to the public webhook routes."""
+        token = base64.b64encode(b"hb-webhook-user:dedicated-webhook-secret").decode()
+        return self.opener.request(
+            method,
+            f"{self.base_url()}/hb/wh/{self.backend.id}/{path}",
+            data=payload if raw else json.dumps(payload),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": authorization
+                if authorization is not None
+                else f"Basic {token}",
+            },
+            timeout=15,
+        )
+
+    def _order_notification(self, merchant_id="merchant"):
+        return {
+            "items": [
+                {
+                    "id": "LINE-1",
+                    "orderNumber": "ORDER-1",
+                    "merchantId": merchant_id,
+                    "customerName": "Stale Webhook Customer",
+                }
+            ]
+        }
+
+    def _jobs(self):
+        return self.env["queue.job"].search(
+            [("identity_key", "=", f"hepsiburada-webhook-sync-{self.backend.id}")]
+        )
+
+    def _api_client(self):
+        """Supply complete API data independently of the webhook snapshot."""
+        item = {
+            "id": "LINE-1",
+            "orderNumber": "ORDER-1",
+            "customerId": "CUSTOMER-1",
+            "customerName": "Fresh API Customer",
+            "quantity": 1,
+            "unitPrice": {"amount": 100, "currency": "TRY"},
+            "totalPrice": {"amount": 100, "currency": "TRY"},
+            "vat": 0,
+            "vatRate": 0,
+            "shippingAddress": {
+                "id": "ADDRESS-1",
+                "name": "Fresh API Customer",
+                "address": "Test Street 1",
+                "city": "Ankara",
+                "countryCode": "TR",
+            },
+            "invoice": {
+                "address": {
+                    "address": "Invoice Street 1",
+                    "city": "Ankara",
+                    "countryCode": "TR",
+                }
+            },
+        }
+        client = SimpleNamespace(get_paid_orders=Mock(return_value=[item]))
+        for name in (
+            "get_unpacked_packages",
+            "get_payment_awaiting_orders",
+            "get_packages",
+            "get_cancelled_orders",
+            "get_shipped_packages",
+            "get_delivered_packages",
+            "get_undelivered_packages",
+        ):
+            setattr(client, name, Mock(return_value=[]))
+        return client
+
+    def test_order_notifications_are_accepted_and_coalesced(self):
+        payload = self._order_notification()
+        first = self._request("orders", payload)
+        second = self._request("orders", payload)
+        self.assertEqual(first.status_code, 201)
+        self.assertEqual(second.status_code, 201)
+        jobs = self._jobs()
+        self.assertEqual(len(jobs), 1)
+        self.assertEqual(jobs.method_name, "_sync_webhook_orders")
+        self.assertNotIn("dedicated-webhook-secret", jobs.func_string)
+        self.assertNotIn("Stale Webhook Customer", jobs.func_string)
+
+    def test_all_documented_notification_routes(self):
+        requests = [
+            (
+                "packages",
+                "POST",
+                {
+                    "merchantId": "merchant",
+                    "packageNumber": "PKG-1",
+                    "items": [{"lineItemId": "LINE-1", "orderNumber": "ORDER-1"}],
+                },
+                201,
+            ),
+            (
+                "lineitems/LINE-1/cancel",
+                "PUT",
+                {"merchantId": "merchant", "id": "LINE-1", "quantity": 1},
+                204,
+            ),
+            (
+                "orders/ORDER-1/shippingaddress",
+                "PUT",
+                {"orderNumber": "ORDER-1", "addressId": "ADDRESS-2"},
+                204,
+            ),
+        ]
+        for event in ("intransit", "deliver", "undeliver", "unpack"):
+            requests.append(
+                (
+                    f"packages/PKG-1/{event}",
+                    "PUT",
+                    {"merchantId": "merchant", "packageNumber": "PKG-1"},
+                    204,
+                )
+            )
+        for path, method, payload, status in requests:
+            with self.subTest(path=path):
+                response = self._request(path, payload, method=method)
+                self.assertEqual(response.status_code, status)
+                self.assertFalse(response.content)
+        self.assertEqual(len(self._jobs()), 1)
+
+    def test_wrong_or_missing_authentication_never_queues(self):
+        for authorization in ("", "Basic !!!", "Bearer token", "Basic dXNlcjpwYXNz"):
+            with self.subTest(authorization=authorization):
+                response = self._request(
+                    "orders", self._order_notification(), authorization=authorization
+                )
+                self.assertEqual(response.status_code, 401)
+                self.assertIn("Basic", response.headers["WWW-Authenticate"])
+        self.assertFalse(self._jobs())
+
+    def test_disabled_and_incomplete_configuration_fail_closed(self):
+        for values in (
+            {"webhook_enabled": False},
+            {"active": False},
+            {"webhook_username": False},
+            {"webhook_password": False},
+        ):
+            with self.subTest(values=values), self.env.cr.savepoint():
+                old = {key: self.backend[key] for key in values}
+                self.backend.write(values)
+                self.assertEqual(
+                    self._request("orders", self._order_notification()).status_code, 401
+                )
+                self.backend.write(old)
+        self.assertFalse(self._jobs())
+
+    def test_cross_merchant_and_mismatched_resource_ids_are_rejected(self):
+        requests = [
+            ("orders", "POST", self._order_notification("other-merchant")),
+            (
+                "packages/PKG-1/deliver",
+                "PUT",
+                {"merchantId": "other-merchant", "packageNumber": "PKG-1"},
+            ),
+            (
+                "packages/PKG-1/deliver",
+                "PUT",
+                {"merchantId": "merchant", "packageNumber": "PKG-2"},
+            ),
+            (
+                "lineitems/LINE-1/cancel",
+                "PUT",
+                {"merchantId": "merchant", "id": "LINE-2"},
+            ),
+            (
+                "orders/ORDER-1/shippingaddress",
+                "PUT",
+                {"orderNumber": "ORDER-2", "addressId": "ADDRESS-1"},
+            ),
+        ]
+        for path, method, payload in requests:
+            with self.subTest(path=path):
+                self.assertEqual(
+                    self._request(path, payload, method=method).status_code, 400
+                )
+        self.assertFalse(self._jobs())
+
+    def test_invalid_json_and_incomplete_payloads_are_rejected(self):
+        for payload in ("{", "[]", "null", "{}", '{"items": []}', '{"items": [null]}'):
+            with self.subTest(payload=payload):
+                self.assertEqual(
+                    self._request("orders", payload, raw=True).status_code, 400
+                )
+        self.assertFalse(self._jobs())
+
+    def test_unknown_events_and_wrong_http_methods_are_rejected(self):
+        self.assertEqual(
+            self._request("packages/PKG-1/unknown", {}, method="PUT").status_code, 404
+        )
+        self.assertEqual(
+            self._request(
+                "orders", self._order_notification(), method="PUT"
+            ).status_code,
+            405,
+        )
+        self.assertFalse(self._jobs())
+
+    def test_queue_failure_is_not_acknowledged(self):
+        with patch.object(
+            type(self.backend),
+            "_queue_webhook_sync",
+            side_effect=RuntimeError("Queue unavailable"),
+        ):
+            response = self._request("orders", self._order_notification())
+        self.assertEqual(response.status_code, 500)
+        self.assertFalse(self._jobs())
+
+    def test_refresh_uses_api_customer_and_remains_idempotent(self):
+        self.assertEqual(
+            self._request("orders", self._order_notification()).status_code, 201
+        )
+        with patch.object(
+            type(self.backend), "_get_api_client", return_value=self._api_client()
+        ):
+            self.backend._sync_webhook_orders()
+            self.backend._sync_webhook_orders()
+        orders = self.env["hepsiburada.order"].search(
+            [("backend_id", "=", self.backend.id)]
+        )
+        self.assertEqual(len(orders), 1)
+        self.assertEqual(orders.partner_id.name, "Fresh API Customer")
+        self.assertEqual(len(orders.hb_line_item_ids), 1)
+
+    def test_unpacked_packages_release_lines_without_cancelling_the_order(self):
+        client = self._api_client()
+        with patch.object(type(self.backend), "_get_api_client", return_value=client):
+            self.backend._sync_webhook_orders()
+            order = self.env["hepsiburada.order"].search(
+                [("backend_id", "=", self.backend.id)]
+            )
+            package = order._upsert_package({"packageNumber": "PKG-1"}, "packaged")
+            order.hb_line_item_ids.write(
+                {"package_id": package.id, "status": "packaged"}
+            )
+            client.get_unpacked_packages.return_value = [{"packageNumber": "PKG-1"}]
+            self.backend._sync_webhook_orders()
+            self.backend._sync_webhook_orders()
+        self.assertEqual(package.hb_status, "unpacked")
+        self.assertFalse(order.hb_line_item_ids.package_id)
+        self.assertEqual(order.hb_status, "open")
+        self.assertNotEqual(order.odoo_id.state, "cancel")
+        self.assertFalse(order.hb_package_number)
+
+    def test_credentials_are_dedicated_and_disabled_on_copy(self):
+        api_password = self.backend.api_password
+        self.backend.action_generate_webhook_credentials()
+        self.assertEqual(self.backend.api_password, api_password)
+        self.assertGreaterEqual(len(self.backend.webhook_password), 32)
+        copied = self.backend.copy({"merchant_id": "other-merchant"})
+        self.assertFalse(copied.webhook_enabled)
+        self.assertFalse(copied.webhook_password)
+        self.assertTrue(self.backend.webhook_url.endswith(f"/hb/wh/{self.backend.id}"))
+
+    def test_unpack_preserves_cancelled_order_status(self):
+        with patch.object(
+            type(self.backend), "_get_api_client", return_value=self._api_client()
+        ):
+            self.backend._sync_webhook_orders()
+        order = self.env["hepsiburada.order"].search(
+            [("backend_id", "=", self.backend.id)]
+        )
+        package = order._upsert_package({"packageNumber": "CANCELLED-PKG"}, "packaged")
+        order.hb_line_item_ids.write({"package_id": package.id, "status": "cancelled"})
+        order._sync_status_from_lines()
+        package._mark_unpacked()
+        self.assertEqual(order.hb_status, "cancelled")
+
+    def test_replacement_package_owns_tracking_and_invoice_state(self):
+        with patch.object(
+            type(self.backend), "_get_api_client", return_value=self._api_client()
+        ):
+            self.backend._sync_webhook_orders()
+        order = self.env["hepsiburada.order"].search(
+            [("backend_id", "=", self.backend.id)]
+        )
+        old = order._upsert_package(
+            {"packageNumber": "OLD-PKG", "trackingInfoCode": "OLD-TRACK"}, "packaged"
+        )
+        order.hb_line_item_ids.package_id = old
+        old.invoice_link_sent = True
+        old._mark_unpacked()
+        new = order._upsert_package(
+            {"packageNumber": "NEW-PKG", "trackingInfoCode": "NEW-TRACK"}, "packaged"
+        )
+        order.hb_line_item_ids.package_id = new
+        order._sync_from_packages()
+        self.assertEqual(len(order.package_ids), 2)
+        self.assertEqual(order.hb_package_number, "NEW-PKG")
+        self.assertEqual(order.cargo_tracking_number, "NEW-TRACK")
+        self.assertFalse(order.invoice_link_sent)
+        self.assertFalse(order.package_mapping_incomplete)
+
+    def test_api_failures_are_retryable(self):
+        client = self._api_client()
+        client.get_unpacked_packages.side_effect = HepsiburadaAPIError("Unavailable")
+        with patch.object(type(self.backend), "_get_api_client", return_value=client):
+            with self.assertRaises(RetryableJobError):
+                self.backend._sync_webhook_orders()
+        client.get_unpacked_packages.side_effect = None
+        with (
+            patch.object(type(self.backend), "_get_api_client", return_value=client),
+            patch.object(type(self.backend), "_import_orders", return_value=False),
+        ):
+            with self.assertRaises(RetryableJobError):
+                self.backend._sync_webhook_orders()
+
+    def test_webhook_credentials_are_hidden_from_regular_users(self):
+        user = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "HB Webhook User",
+                    "login": "hb-webhook-reader",
+                    "groups_id": [
+                        (
+                            6,
+                            0,
+                            self.env.ref(
+                                "hepsiburada_integration.group_hepsiburada_user"
+                            ).ids,
+                        )
+                    ],
+                }
+            )
+        )
+        with self.assertRaises(AccessError):
+            self.backend.with_user(user).read(["webhook_password"])
+        with self.assertRaises(AccessError):
+            self.backend.with_user(user).action_generate_webhook_credentials()

--- a/hepsiburada_integration/views/hepsiburada_backend_views.xml
+++ b/hepsiburada_integration/views/hepsiburada_backend_views.xml
@@ -99,6 +99,34 @@
                         </group>
                     </group>
                     <notebook>
+                        <page
+                            string="Webhooks"
+                            name="webhooks"
+                            groups="hepsiburada_integration.group_hepsiburada_manager"
+                        >
+                            <group>
+                                <field name="webhook_enabled" />
+                                <field name="webhook_url" widget="url" />
+                                <field name="webhook_username" />
+                                <field name="webhook_password" password="True" />
+                            </group>
+                            <button
+                                name="action_generate_webhook_credentials"
+                                string="Generate Webhook Credentials"
+                                type="object"
+                                class="btn-secondary"
+                            />
+                            <p class="mt-3">
+                                Share this base URL and the dedicated webhook credentials
+                                with Hepsiburada. Complete their test-environment onboarding
+                                before enabling production notifications.
+                            </p>
+                            <p>
+                                Notifications trigger an immediate refresh from the
+                                Hepsiburada API. Scheduled polling remains available
+                                independently as a fallback.
+                            </p>
+                        </page>
                         <page string="Sync Settings" name="sync_settings">
                             <group>
                                 <group string="Auto Sync">


### PR DESCRIPTION
Hepsiburada order changes currently wait for the scheduled import. Add authenticated webhook routes beneath `/hb/wh/<backend_id>` that immediately queue a refresh from the current API data. Dedicated per-backend Basic Auth credentials, merchant/resource checks, and pending-job coalescing protect the receiver; POST notifications return 201 and PUT notifications return 204.

Keep the existing 15-minute polling independent. Both paths reconcile unpacked packages while preserving their history and allowing replacement packages to own tracking and invoice state. A manager-only Webhooks tab exposes the base URL and credential generator; the receiver starts disabled.

Regenerate the Hepsiburada POT and Turkish PO through `export_translation_file.button_save_translation()`. Review all 686 current terms, correct fuzzy mismatches, and simplify 293 translations. No untranslated, fuzzy, or obsolete entries remain. Use module version `16.0.1.2.1` so this upgrade follows the existing commission migration.

Validation:
- Module upgrade and Turkish field/button readback in a disposable ERP test database.
- 49 model tests passed after full registry initialization; 15 real-HTTP webhook tests passed separately. The model-test harness loads all modules first because this ERP fixture has exception rules referring to later-loaded Trendyol fields.
- `pre-commit run -a`, `git diff --check`, and `msgfmt --check --check-format` passed.
- POT/PO source identities, placeholders, and HTML structure checked.

Deploy the code and upgrade `hepsiburada_integration` with `--i18n-overwrite` to apply the revised Turkish terms. [Hepsiburada requires test onboarding and provider-side URL/Basic Auth registration](https://developers.hepsiburada.com/tr/companies/hepsiburada?guide=siparis-webhook-modeli&product=siparis-olusturma-entegrasyonu&view=guide). Production deployment and provider onboarding are not part of this PR.
