### PR TITLE
[FIX] Refresh and match Trendyol commission invoice references

### DIFF
--- a/trendyol_integration/README.rst
+++ b/trendyol_integration/README.rst
@@ -47,7 +47,7 @@ including previously saved raw data. A later nonempty reference refreshes an
 existing settlement without rewriting its posted financial amounts.
 
 Trendyol commission payments are excluded from the generic invoice-centric
-auto-reconciler, including its single-partner wizard entry point. New commission
+auto-reconciler, including its single-partner wizard entry point. Commission
 payments remain posted and open until every charged settlement row associated
 with the payment identifies the same vendor document. Only the matching posted
 DSM bill (or vendor credit note for an inbound commission refund), in the same
@@ -71,15 +71,17 @@ This refresh also runs when automatic settlement reconciliation is disabled.
 Order webhooks do not provide these financial reference updates.
 
 When automatic settlement reconciliation is enabled, the same import retries
-open commission payments created by this new flow. A reference can arrive
+all posted, open Trendyol commission payments, including historical ones.
+A reference can arrive
 before its vendor bill: matching retries without another API refresh once the
 reference is known. Missing references or bills never fall back to matching
 the oldest open invoice.
 
-Historical payments are excluded from generic matching but are not enrolled in
-automatic invoice-specific matching. No migration removes their reconciliations
-or recreates their payments. Correcting historical allocations requires a
-separately reviewed list and accounting checks; do not bulk-unreconcile them.
+The cron does not remove existing reconciliations or recreate payments. Once
+an incorrect historical allocation is explicitly unreconciled, that same open
+payment becomes eligible for invoice-specific matching without another flag.
+Review the affected records and accounting side effects before removing an
+allocation; no migration bulk-unreconciles historical payments.
 
 The reference is documented in the `Trendyol domestic finance API
 <https://developers.trendyol.com/docs/cari-hesap-ekstresi-entegrasyonu>`_.

--- a/trendyol_integration/README.rst
+++ b/trendyol_integration/README.rst
@@ -38,6 +38,43 @@ Configuration
 4. Set up cargo provider mappings in the **Cargo Mapping** tab
 5. Verify the connection with **Test Connection**
 
+Commission invoice matching
+---------------------------
+
+Upgrade the module to ``16.0.1.2.0`` to enable invoice-specific commission
+matching. ``commissionInvoiceSerialNumber`` is extracted from the API payload,
+including previously saved raw data. A later nonempty reference refreshes an
+existing settlement without rewriting its posted financial amounts.
+
+Trendyol commission payments are excluded from the generic invoice-centric
+auto-reconciler, including its single-partner wizard entry point. New commission
+payments remain posted and open until every charged settlement row associated
+with the payment identifies the same vendor document. Only the matching posted
+DSM bill (or vendor credit note for an inbound commission refund), in the same
+company and currency, may be reconciled. Supplier, amount, payable-account and
+remaining-balance checks are required. Multiple references, duplicate documents
+or an existing reconciliation to another document require review.
+
+Customer payment reconciliation continues independently. The settlement's
+**Commission Matching** tab shows the API reference, target vendor document,
+matching state and waiting/review reason. **Match Commission Invoice** retries
+matching without creating another payment. Several order commissions may pay
+the same vendor invoice; that invoice can remain partially unpaid until all
+of its commissions are matched.
+
+When automatic settlement reconciliation is enabled, the normal import retries
+open commission payments created by this new flow. Its date window revisits
+transactions whose commission reference is still missing. Missing references
+or bills never fall back to matching the oldest open invoice.
+
+Historical payments are excluded from generic matching but are not enrolled in
+automatic invoice-specific matching. No migration removes their reconciliations
+or recreates their payments. Correcting historical allocations requires a
+separately reviewed list and accounting checks; do not bulk-unreconcile them.
+
+The reference is documented in the `Trendyol domestic finance API
+<https://developers.trendyol.com/docs/cari-hesap-ekstresi-entegrasyonu>`_.
+
 Authors
 -------
 

--- a/trendyol_integration/README.rst
+++ b/trendyol_integration/README.rst
@@ -62,10 +62,19 @@ matching without creating another payment. Several order commissions may pay
 the same vendor invoice; that invoice can remain partially unpaid until all
 of its commissions are matched.
 
-When automatic settlement reconciliation is enabled, the normal import retries
-open commission payments created by this new flow. Its date window revisits
-transactions whose commission reference is still missing. Missing references
-or bills never fall back to matching the oldest open invoice.
+The daily settlement import separately refreshes missing commission invoice
+references, including old settlements whose customer payment or commission
+payment is already reconciled and rows without a payment yet. It queries only
+the date windows containing missing references, in batches of at most 15 days,
+and only updates existing reference metadata in those historical windows.
+This refresh also runs when automatic settlement reconciliation is disabled.
+Order webhooks do not provide these financial reference updates.
+
+When automatic settlement reconciliation is enabled, the same import retries
+open commission payments created by this new flow. A reference can arrive
+before its vendor bill: matching retries without another API refresh once the
+reference is known. Missing references or bills never fall back to matching
+the oldest open invoice.
 
 Historical payments are excluded from generic matching but are not enrolled in
 automatic invoice-specific matching. No migration removes their reconciliations

--- a/trendyol_integration/__manifest__.py
+++ b/trendyol_integration/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Trendyol Marketplace Integration",
-    "version": "16.0.1.1.2",
+    "version": "16.0.1.2.0",
     "category": "Sales/Sales",
     "summary": "Integrate Odoo with Trendyol marketplace",
     "author": "Ahmet Yigit Budak, Altinkaya Enclosures",

--- a/trendyol_integration/i18n/tr.po
+++ b/trendyol_integration/i18n/tr.po
@@ -7174,3 +7174,224 @@ msgstr "Yanıtsız"
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
 msgid "Waiting Fraud Check"
 msgstr "Fraud Kontrolü Bekliyor"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr "Komisyon Faturası"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr "Komisyon Fatura Numarası"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr "Komisyon Eşleştirme Notu"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr "Komisyon Eşleştirme Durumu"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+#, python-format
+msgid "Commission Matching"
+msgstr "Komisyon Eşleştirme"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matched to the referenced vendor document."
+msgstr "Komisyon, belirtilen tedarikçi belgesiyle uzlaştırıldı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matching is pending."
+msgstr "Komisyon eşleştirmesi bekliyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Customer Payment Reconciled"
+msgstr "Müşteri Tahsilatı Uzlaştırıldı"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__trendyol_commission_auto_match
+msgid ""
+"Enabled only for commission payments created by the invoice-specific "
+"matching flow. Legacy payments require a separately reviewed correction."
+msgstr ""
+"Yalnızca faturaya özel eşleştirme akışında oluşturulan komisyon ödemeleri "
+"için etkinleştirilir. Eski ödemeler için ayrı bir inceleme ve düzeltme "
+"gerekir."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
+msgid "Is Trendyol Commission"
+msgstr "Trendyol Komisyonu"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Legacy commission payments require a separately reviewed correction. No "
+"payment reconciliation was changed."
+msgstr ""
+"Eski komisyon ödemeleri için ayrı bir inceleme ve düzeltme gerekir. Ödeme "
+"uzlaşmalarında değişiklik yapılmadı."
+
+#. module: trendyol_integration
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+msgid "Match Commission Invoice"
+msgstr "Komisyon Faturasıyla Uzlaştır"
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__matched
+msgid "Matched"
+msgstr "Uzlaştırıldı"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Multiple vendor documents have this commission invoice reference."
+msgstr ""
+"Bu komisyon fatura referansına sahip birden fazla tedarikçi belgesi var."
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__review
+msgid "Review Required"
+msgstr "İnceleme Gerekli"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment amount differs from its settlement rows."
+msgstr ""
+"Komisyon ödemesinin tutarı, hakediş satırlarının toplamıyla uyuşmuyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment and vendor document currencies differ."
+msgstr "Komisyon ödemesi ile tedarikçi belgesinin para birimleri farklı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment exceeds the referenced vendor document's remaining "
+"balance."
+msgstr ""
+"Komisyon ödemesi, belirtilen tedarikçi belgesinin kalan bakiyesini aşıyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment is already reconciled with another document. Existing"
+" reconciliations were preserved."
+msgstr ""
+"Komisyon ödemesi başka bir belgeyle uzlaştırılmış. Mevcut uzlaşmalar "
+"korundu."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment is closed without a matching vendor document."
+msgstr "Komisyon ödemesi, ilgili tedarikçi belgesine bağlanmadan kapanmış."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment partner or company does not match the Trendyol "
+"backend."
+msgstr ""
+"Komisyon ödemesinin iş ortağı veya şirketi Trendyol yapılandırmasıyla "
+"uyuşmuyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The vendor document has no compatible open payable lines."
+msgstr "Tedarikçi belgesinde uyumlu ve açık bir satıcı hesabı satırı yok."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"This payment covers multiple commission invoice references. Review is "
+"required."
+msgstr ""
+"Bu ödeme birden fazla komisyon faturası referansını kapsıyor. İnceleme "
+"gerekiyor."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_auto_match
+msgid "Trendyol Commission Auto Match"
+msgstr "Trendyol Komisyonu Otomatik Eşleştirme"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_settlement_ids
+msgid "Trendyol Commission Settlement"
+msgstr "Trendyol Komisyon Hakedişi"
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__waiting
+msgid "Waiting"
+msgstr "Bekliyor"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission invoice number from Trendyol."
+msgstr "Trendyol komisyon fatura numarası bekleniyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission payment to be posted."
+msgstr "Komisyon ödemesinin onaylanması bekleniyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Waiting for the referenced DSM vendor bill or credit note to be posted."
+msgstr ""
+"Belirtilen DSM tedarikçi faturasının veya iade faturasının onaylanması "
+"bekleniyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The API commission invoice reference was updated. Existing payment "
+"reconciliations were preserved."
+msgstr ""
+"API komisyon faturası referansı güncellendi. Mevcut ödeme uzlaşmaları "
+"korundu."

--- a/trendyol_integration/i18n/tr.po
+++ b/trendyol_integration/i18n/tr.po
@@ -7226,30 +7226,9 @@ msgid "Customer Payment Reconciled"
 msgstr "Müşteri Tahsilatı Uzlaştırıldı"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_payment__trendyol_commission_auto_match
-msgid ""
-"Enabled only for commission payments created by the invoice-specific "
-"matching flow. Legacy payments require a separately reviewed correction."
-msgstr ""
-"Yalnızca faturaya özel eşleştirme akışında oluşturulan komisyon ödemeleri "
-"için etkinleştirilir. Eski ödemeler için ayrı bir inceleme ve düzeltme "
-"gerekir."
-
-#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
 msgid "Is Trendyol Commission"
 msgstr "Trendyol Komisyonu"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"Legacy commission payments require a separately reviewed correction. No "
-"payment reconciliation was changed."
-msgstr ""
-"Eski komisyon ödemeleri için ayrı bir inceleme ve düzeltme gerekir. Ödeme "
-"uzlaşmalarında değişiklik yapılmadı."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
@@ -7345,11 +7324,6 @@ msgid ""
 msgstr ""
 "Bu ödeme birden fazla komisyon faturası referansını kapsıyor. İnceleme "
 "gerekiyor."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_auto_match
-msgid "Trendyol Commission Auto Match"
-msgstr "Trendyol Komisyonu Otomatik Eşleştirme"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_settlement_ids

--- a/trendyol_integration/i18n/trendyol_integration.pot
+++ b/trendyol_integration/i18n/trendyol_integration.pot
@@ -7023,24 +7023,8 @@ msgid "Customer Payment Reconciled"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_payment__trendyol_commission_auto_match
-msgid ""
-"Enabled only for commission payments created by the invoice-specific "
-"matching flow. Legacy payments require a separately reviewed correction."
-msgstr ""
-
-#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
 msgid "Is Trendyol Commission"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"Legacy commission payments require a separately reviewed correction. No "
-"payment reconciliation was changed."
 msgstr ""
 
 #. module: trendyol_integration
@@ -7127,11 +7111,6 @@ msgstr ""
 msgid ""
 "This payment covers multiple commission invoice references. Review is "
 "required."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_auto_match
-msgid "Trendyol Commission Auto Match"
 msgstr ""
 
 #. module: trendyol_integration

--- a/trendyol_integration/i18n/trendyol_integration.pot
+++ b/trendyol_integration/i18n/trendyol_integration.pot
@@ -6971,3 +6971,206 @@ msgstr ""
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
 msgid "Waiting Fraud Check"
 msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+#, python-format
+msgid "Commission Matching"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matched to the referenced vendor document."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matching is pending."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Customer Payment Reconciled"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__trendyol_commission_auto_match
+msgid ""
+"Enabled only for commission payments created by the invoice-specific "
+"matching flow. Legacy payments require a separately reviewed correction."
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
+msgid "Is Trendyol Commission"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Legacy commission payments require a separately reviewed correction. No "
+"payment reconciliation was changed."
+msgstr ""
+
+#. module: trendyol_integration
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+msgid "Match Commission Invoice"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__matched
+msgid "Matched"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Multiple vendor documents have this commission invoice reference."
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__review
+msgid "Review Required"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment amount differs from its settlement rows."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment and vendor document currencies differ."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment exceeds the referenced vendor document's remaining "
+"balance."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment is already reconciled with another document. Existing"
+" reconciliations were preserved."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment is closed without a matching vendor document."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment partner or company does not match the Trendyol "
+"backend."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The vendor document has no compatible open payable lines."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"This payment covers multiple commission invoice references. Review is "
+"required."
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_auto_match
+msgid "Trendyol Commission Auto Match"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_settlement_ids
+msgid "Trendyol Commission Settlement"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__waiting
+msgid "Waiting"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission invoice number from Trendyol."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission payment to be posted."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Waiting for the referenced DSM vendor bill or credit note to be posted."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The API commission invoice reference was updated. Existing payment "
+"reconciliations were preserved."
+msgstr ""

--- a/trendyol_integration/models/__init__.py
+++ b/trendyol_integration/models/__init__.py
@@ -18,3 +18,5 @@ from . import sale_order
 from . import sale_order_line
 from . import res_partner
 from . import stock_picking
+from . import account_payment
+from . import account_auto_reconcile

--- a/trendyol_integration/models/account_auto_reconcile.py
+++ b/trendyol_integration/models/account_auto_reconcile.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class AccountAutoReconcile(models.AbstractModel):
+    _inherit = "account.auto.reconcile"
+
+    def _get_payment_lines_domain(self, move, pay_term_account_ids):
+        """Reserve Trendyol commissions for their API-referenced vendor bills."""
+        return super()._get_payment_lines_domain(move, pay_term_account_ids) + [
+            ("payment_id.is_trendyol_commission", "=", False),
+        ]

--- a/trendyol_integration/models/account_payment.py
+++ b/trendyol_integration/models/account_payment.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api, fields, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    trendyol_commission_settlement_ids = fields.One2many(
+        "trendyol.settlement", "commission_payment_id"
+    )
+    is_trendyol_commission = fields.Boolean(
+        compute="_compute_is_trendyol_commission", store=True, index=True
+    )
+    trendyol_commission_auto_match = fields.Boolean(
+        readonly=True,
+        copy=False,
+        help="Enabled only for commission payments created by the invoice-specific "
+        "matching flow. Legacy payments require a separately reviewed correction.",
+    )
+
+    @api.depends("trendyol_commission_settlement_ids")
+    def _compute_is_trendyol_commission(self):
+        """Identify current and legacy commission payments by their actual links."""
+        for payment in self:
+            payment.is_trendyol_commission = bool(
+                payment.trendyol_commission_settlement_ids
+            )

--- a/trendyol_integration/models/account_payment.py
+++ b/trendyol_integration/models/account_payment.py
@@ -13,12 +13,6 @@ class AccountPayment(models.Model):
     is_trendyol_commission = fields.Boolean(
         compute="_compute_is_trendyol_commission", store=True, index=True
     )
-    trendyol_commission_auto_match = fields.Boolean(
-        readonly=True,
-        copy=False,
-        help="Enabled only for commission payments created by the invoice-specific "
-        "matching flow. Legacy payments require a separately reviewed correction.",
-    )
 
     @api.depends("trendyol_commission_settlement_ids")
     def _compute_is_trendyol_commission(self):

--- a/trendyol_integration/models/trendyol_backend.py
+++ b/trendyol_integration/models/trendyol_backend.py
@@ -1035,13 +1035,12 @@ class TrendyolBackend(models.Model):
         return total_imported
 
     def _reconcile_pending_commissions(self):
-        """Retry only new-flow payments; never automatically repair legacy ones."""
+        """Retry all posted, open commission payments without changing closed ones."""
         self.ensure_one()
         Settlement = self.env["trendyol.settlement"]
         pending_commissions = Settlement.search(
             [
                 ("backend_id", "=", self.id),
-                ("commission_payment_id.trendyol_commission_auto_match", "=", True),
                 ("commission_payment_id.state", "=", "posted"),
                 ("commission_payment_id.is_reconciled", "=", False),
             ]

--- a/trendyol_integration/models/trendyol_backend.py
+++ b/trendyol_integration/models/trendyol_backend.py
@@ -920,6 +920,21 @@ class TrendyolBackend(models.Model):
         else:
             start_date = end_date - timedelta(days=15)
 
+        # Revisit missing references only for payments created by the new flow.
+        # Legacy payments are not enrolled in automatic historical correction.
+        pending_dates = Settlement.search(
+            [
+                ("backend_id", "=", self.id),
+                ("commission_payment_id.trendyol_commission_auto_match", "=", True),
+                ("commission_payment_id.state", "=", "posted"),
+                ("commission_payment_id.is_reconciled", "=", False),
+                ("commission_invoice_number", "=", False),
+                ("transaction_date", "!=", False),
+            ]
+        ).mapped("transaction_date")
+        if pending_dates:
+            start_date = min(start_date, min(pending_dates) - timedelta(seconds=1))
+
         # Iterate in 15-day windows
         window_start = start_date
         total_imported = 0
@@ -993,10 +1008,37 @@ class TrendyolBackend(models.Model):
                         str(error),
                     )
 
+            self._reconcile_pending_commissions()
+
         self.last_settlement_sync = end_date
         _logger.info(
             "Imported %d settlements for backend %s", total_imported, self.name
         )
+
+    def _reconcile_pending_commissions(self):
+        """Retry only new-flow payments; never automatically repair legacy ones."""
+        self.ensure_one()
+        Settlement = self.env["trendyol.settlement"]
+        pending_commissions = Settlement.search(
+            [
+                ("backend_id", "=", self.id),
+                ("commission_payment_id.trendyol_commission_auto_match", "=", True),
+                ("commission_payment_id.state", "=", "posted"),
+                ("commission_payment_id.is_reconciled", "=", False),
+            ]
+        ).commission_payment_id
+        for payment in pending_commissions:
+            settlement = payment.trendyol_commission_settlement_ids[:1]
+            try:
+                with self.env.cr.savepoint():
+                    settlement._reconcile_commission_invoice()
+            except Exception as error:
+                payment.trendyol_commission_settlement_ids._set_commission_match(
+                    "review", str(error)
+                )
+                _logger.exception(
+                    "Failed to match Trendyol commission payment %s", payment.id
+                )
 
     def action_view_settlements(self):
         """View settlements for this backend."""

--- a/trendyol_integration/models/trendyol_backend.py
+++ b/trendyol_integration/models/trendyol_backend.py
@@ -920,65 +920,18 @@ class TrendyolBackend(models.Model):
         else:
             start_date = end_date - timedelta(days=15)
 
-        # Revisit missing references only for payments created by the new flow.
-        # Legacy payments are not enrolled in automatic historical correction.
-        pending_dates = Settlement.search(
-            [
-                ("backend_id", "=", self.id),
-                ("commission_payment_id.trendyol_commission_auto_match", "=", True),
-                ("commission_payment_id.state", "=", "posted"),
-                ("commission_payment_id.is_reconciled", "=", False),
-                ("commission_invoice_number", "=", False),
-                ("transaction_date", "!=", False),
-            ]
-        ).mapped("transaction_date")
-        if pending_dates:
-            start_date = min(start_date, min(pending_dates) - timedelta(seconds=1))
-
         # Iterate in 15-day windows
         window_start = start_date
         total_imported = 0
 
         while window_start < end_date:
             window_end = min(window_start + timedelta(days=15), end_date)
-            start_ts = _utc_to_trendyol_ts(window_start)
-            end_ts = _utc_to_trendyol_ts(window_end)
-
-            try:
-                page = 0
-                while True:
-                    result = client.get_settlements(
-                        start_date=start_ts,
-                        end_date=end_ts,
-                        transaction_types="Sale,Return",
-                        page=page,
-                        size=500,
-                    )
-                    content = result.get("content", [])
-                    if not content:
-                        break
-
-                    for item in content:
-                        Settlement._import_settlement(self, item)
-                        total_imported += 1
-
-                    total_pages = result.get("totalPages")
-                    if total_pages is not None and page + 1 >= total_pages:
-                        break
-                    page += 1
-                    if page >= 1000:
-                        raise UserError(_("Settlement import page limit reached."))
-
-            except TrendyolAPIError as e:
-                _logger.error(
-                    "Failed to import settlements for window %s - %s: %s",
-                    window_start,
-                    window_end,
-                    str(e),
-                )
-                raise
-
+            total_imported += self._import_settlement_window(
+                client, window_start, window_end
+            )
             window_start = window_end
+
+        self._refresh_missing_commission_references(client)
 
         if self.auto_reconcile_settlements:
             settlements = Settlement.search(
@@ -1014,6 +967,72 @@ class TrendyolBackend(models.Model):
         _logger.info(
             "Imported %d settlements for backend %s", total_imported, self.name
         )
+
+    def _refresh_missing_commission_references(self, client):
+        """Refresh missing invoice metadata, including closed legacy settlements."""
+        self.ensure_one()
+        pending = self.env["trendyol.settlement"].search(
+            [
+                ("backend_id", "=", self.id),
+                ("commission_amount", "!=", 0),
+                ("commission_invoice_number", "=", False),
+                ("transaction_date", "!=", False),
+            ]
+        )
+        # Invert the offset applied by _trendyol_ts_to_utc before choosing the
+        # API calendar day, including transactions near midnight.
+        pending_dates = sorted(
+            {
+                fields.Datetime.to_datetime((date + TRENDYOL_UTC_OFFSET).date())
+                for date in pending.mapped("transaction_date")
+            }
+        )
+        while pending_dates:
+            window_start = pending_dates[0]
+            window_limit = window_start + timedelta(days=15)
+            dates = [date for date in pending_dates if date < window_limit]
+            self._import_settlement_window(
+                client, window_start, dates[-1] + timedelta(days=1), pending
+            )
+            pending_dates = [date for date in pending_dates if date >= window_limit]
+
+    def _import_settlement_window(self, client, start_date, end_date, pending=None):
+        """Page through a window; a pending set restricts writes to its metadata."""
+        self.ensure_one()
+        Settlement = self.env["trendyol.settlement"]
+        pending_by_id = (
+            {row.trendyol_settlement_id: row for row in pending}
+            if pending is not None
+            else None
+        )
+        total_imported = 0
+        page = 0
+        while True:
+            result = client.get_settlements(
+                start_date=_utc_to_trendyol_ts(start_date),
+                end_date=_utc_to_trendyol_ts(end_date),
+                transaction_types="Sale,Return",
+                page=page,
+                size=500,
+            )
+            content = result.get("content", [])
+            if not content:
+                break
+            for item in content:
+                if pending_by_id is None:
+                    Settlement._import_settlement(self, item)
+                    total_imported += 1
+                else:
+                    row = pending_by_id.get(str(item.get("id")))
+                    if row:
+                        row._refresh_commission_reference(item)
+            total_pages = result.get("totalPages")
+            if total_pages is not None and page + 1 >= total_pages:
+                break
+            page += 1
+            if page >= 1000:
+                raise UserError(_("Settlement import page limit reached."))
+        return total_imported
 
     def _reconcile_pending_commissions(self):
         """Retry only new-flow payments; never automatically repair legacy ones."""

--- a/trendyol_integration/models/trendyol_settlement.py
+++ b/trendyol_integration/models/trendyol_settlement.py
@@ -230,10 +230,7 @@ class TrendyolSettlement(models.Model):
                 {
                     "commission_invoice_id": False,
                     "commission_match_state": "review"
-                    if (
-                        not self.commission_payment_id.trendyol_commission_auto_match
-                        or self.commission_payment_id.is_reconciled
-                    )
+                    if self.commission_payment_id.is_reconciled
                     else "waiting",
                     "commission_match_note": _(
                         "The API commission invoice reference was updated. "
@@ -289,13 +286,6 @@ class TrendyolSettlement(models.Model):
             abs(amount)
             for amount in self._get_reconciliation_group().mapped("commission_amount")
         )
-
-    def _create_commission_payment(self, payment_type):
-        """Opt in only newly created payments to invoice-specific matching."""
-        payment = super()._create_commission_payment(payment_type)
-        if payment:
-            payment.trendyol_commission_auto_match = True
-        return payment
 
     def _reconcile(self):
         """Reconcile all rows for one package payout exactly once."""
@@ -395,15 +385,6 @@ class TrendyolSettlement(models.Model):
         if not payment:
             return False
         rows = payment.trendyol_commission_settlement_ids
-        if not payment.trendyol_commission_auto_match:
-            return rows._set_commission_match(
-                "review",
-                _(
-                    "Legacy commission payments require a separately reviewed "
-                    "correction. "
-                    "No payment reconciliation was changed."
-                ),
-            )
         currency = payment.currency_id
         charged_rows = rows.filtered(
             lambda row: not currency.is_zero(row.commission_amount)

--- a/trendyol_integration/models/trendyol_settlement.py
+++ b/trendyol_integration/models/trendyol_settlement.py
@@ -75,6 +75,15 @@ class TrendyolSettlement(models.Model):
     commission_payment_id = fields.Many2one(
         "account.payment",
     )
+    commission_invoice_number = fields.Char(
+        compute="_compute_commission_invoice_number", store=True, index=True
+    )
+    commission_invoice_id = fields.Many2one("account.move", readonly=True)
+    commission_match_state = fields.Selection(
+        [("waiting", "Waiting"), ("matched", "Matched"), ("review", "Review Required")],
+        readonly=True,
+    )
+    commission_match_note = fields.Text(readonly=True)
 
     # Status
     state = fields.Selection(
@@ -108,6 +117,17 @@ class TrendyolSettlement(models.Model):
         """Parse Trendyol timestamp (ms, GMT+3) to naive UTC datetime."""
         return _trendyol_ts_to_utc(timestamp)
 
+    @api.depends("raw_data")
+    def _compute_commission_invoice_number(self):
+        """Keep the API invoice reference, including existing stored payloads."""
+        for settlement in self:
+            try:
+                data = json.loads(settlement.raw_data or "{}")
+                number = (data.get("commissionInvoiceSerialNumber") or "").strip()
+            except (ValueError, TypeError, AttributeError):
+                number = False
+            settlement.commission_invoice_number = number or False
+
     @api.model
     def _import_settlement(self, backend, data):
         """Import a single settlement from Trendyol API response.
@@ -133,6 +153,7 @@ class TrendyolSettlement(models.Model):
             limit=1,
         )
         if existing:
+            existing._refresh_commission_reference(data)
             return existing
 
         # Find linked trendyol.order
@@ -190,6 +211,35 @@ class TrendyolSettlement(models.Model):
             _logger.error("Failed to import settlement %s: %s", settlement_id, str(e))
             raise
 
+    def _refresh_commission_reference(self, data):
+        """Refresh metadata without rewriting posted amounts or reconciliation links."""
+        self.ensure_one()
+        number = (data.get("commissionInvoiceSerialNumber") or "").strip()
+        if not number or number == self.commission_invoice_number:
+            return
+        try:
+            stored_data = json.loads(self.raw_data or "{}")
+        except (ValueError, TypeError):
+            stored_data = {}
+        if not isinstance(stored_data, dict):
+            stored_data = {}
+        stored_data["commissionInvoiceSerialNumber"] = number
+        values = {"raw_data": json.dumps(stored_data, indent=2, ensure_ascii=False)}
+        if self.commission_payment_id:
+            values.update(
+                {
+                    "commission_invoice_id": False,
+                    "commission_match_state": "review"
+                    if self.commission_payment_id.is_reconciled
+                    else "waiting",
+                    "commission_match_note": _(
+                        "The API commission invoice reference was updated. "
+                        "Existing payment reconciliations were preserved."
+                    ),
+                }
+            )
+        self.write(values)
+
     def _marketplace_name(self):
         return _("Trendyol")
 
@@ -237,6 +287,13 @@ class TrendyolSettlement(models.Model):
             for amount in self._get_reconciliation_group().mapped("commission_amount")
         )
 
+    def _create_commission_payment(self, payment_type):
+        """Opt in only newly created payments to invoice-specific matching."""
+        payment = super()._create_commission_payment(payment_type)
+        if payment:
+            payment.trendyol_commission_auto_match = True
+        return payment
+
     def _reconcile(self):
         """Reconcile all rows for one package payout exactly once."""
         self.ensure_one()
@@ -251,6 +308,7 @@ class TrendyolSettlement(models.Model):
         )
         if reconciled:
             self._join_reconciled_group(group, reconciled)
+            self._reconcile_commission_invoice()
             return
 
         super()._reconcile()
@@ -265,6 +323,7 @@ class TrendyolSettlement(models.Model):
                     "manual_review_required": False,
                 }
             )
+            self._reconcile_commission_invoice()
         elif self.state == "error":
             (group - self).write(
                 {
@@ -315,3 +374,215 @@ class TrendyolSettlement(models.Model):
                 ),
             }
         )
+
+    def _set_commission_match(self, state, note=False, invoice=False):
+        """Report commission matching separately from customer reconciliation."""
+        values = {
+            "commission_match_state": state,
+            "commission_match_note": note,
+            "commission_invoice_id": invoice.id if invoice else False,
+        }
+        self.write(values)
+        return state == "matched"
+
+    def _reconcile_commission_invoice(self):
+        """Match a commission payment only to the vendor document named by the API."""
+        self.ensure_one()
+        payment = self.commission_payment_id
+        if not payment:
+            return False
+        rows = payment.trendyol_commission_settlement_ids
+        if not payment.trendyol_commission_auto_match:
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "Legacy commission payments require a separately reviewed "
+                    "correction. "
+                    "No payment reconciliation was changed."
+                ),
+            )
+        currency = payment.currency_id
+        charged_rows = rows.filtered(
+            lambda row: not currency.is_zero(row.commission_amount)
+        )
+        numbers = set(charged_rows.mapped("commission_invoice_number"))
+        if not numbers or False in numbers:
+            return rows._set_commission_match(
+                "waiting", _("Waiting for the commission invoice number from Trendyol.")
+            )
+        if len(numbers) != 1:
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "This payment covers multiple commission invoice references. "
+                    "Review is required."
+                ),
+            )
+        backend = self.backend_id
+        supplier = backend.trendyol_partner_id.commercial_partner_id
+        if (
+            len(rows.backend_id) != 1
+            or payment.partner_type != "supplier"
+            or payment.partner_id.commercial_partner_id != supplier
+            or payment.company_id != backend.company_id
+        ):
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment partner or company does not match "
+                    "the Trendyol backend."
+                ),
+            )
+        if payment.state != "posted":
+            return rows._set_commission_match(
+                "waiting", _("Waiting for the commission payment to be posted.")
+            )
+        if currency.compare_amounts(
+            sum(abs(row.commission_amount) for row in rows), payment.amount
+        ):
+            return rows._set_commission_match(
+                "review",
+                _("The commission payment amount differs from its settlement rows."),
+            )
+        invoice_number = numbers.pop()
+        invoices = self.env["account.move"].search(
+            [
+                ("company_id", "=", backend.company_id.id),
+                ("commercial_partner_id", "=", supplier.id),
+                (
+                    "move_type",
+                    "=",
+                    "in_invoice" if payment.payment_type == "outbound" else "in_refund",
+                ),
+                ("state", "=", "posted"),
+                "|",
+                ("ref", "=", invoice_number),
+                ("name", "=", invoice_number),
+            ],
+            limit=2,
+        )
+        if not invoices:
+            return rows._set_commission_match(
+                "waiting",
+                _(
+                    "Waiting for the referenced DSM vendor bill or credit note "
+                    "to be posted."
+                ),
+            )
+        if len(invoices) != 1:
+            return rows._set_commission_match(
+                "review",
+                _("Multiple vendor documents have this commission invoice reference."),
+            )
+        invoice = invoices
+        if invoice.currency_id != currency:
+            return rows._set_commission_match(
+                "review",
+                _("The commission payment and vendor document currencies differ."),
+                invoice,
+            )
+        payment_lines = payment.move_id.line_ids.filtered(
+            lambda line: line.account_type == "liability_payable"
+        )
+        partials = payment_lines.matched_debit_ids | payment_lines.matched_credit_ids
+        counterpart_lines = (
+            partials.debit_move_id | partials.credit_move_id
+        ) - payment_lines
+        if counterpart_lines.filtered(lambda line: line.move_id != invoice):
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment is already reconciled with another "
+                    "document. "
+                    "Existing reconciliations were preserved."
+                ),
+                invoice,
+            )
+        if payment.is_reconciled:
+            if counterpart_lines:
+                return rows._set_commission_match("matched", invoice=invoice)
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment is closed without a matching "
+                    "vendor document."
+                ),
+                invoice,
+            )
+        payment_lines = payment_lines.filtered(lambda line: not line.reconciled)
+        invoice_lines = invoice.line_ids.filtered(
+            lambda line: (
+                line.account_type == "liability_payable" and not line.reconciled
+            )
+        )
+        if (
+            not payment_lines
+            or not invoice_lines
+            or len(payment_lines.account_id) != 1
+            or payment_lines.account_id != invoice_lines.account_id
+            or sum(payment_lines.mapped("balance"))
+            * sum(invoice_lines.mapped("balance"))
+            >= 0
+        ):
+            return rows._set_commission_match(
+                "review",
+                _("The vendor document has no compatible open payable lines."),
+                invoice,
+            )
+        residual_field = (
+            "amount_residual"
+            if currency == backend.company_id.currency_id
+            else "amount_residual_currency"
+        )
+        payment_remaining = abs(sum(payment_lines.mapped(residual_field)))
+        invoice_remaining = abs(sum(invoice_lines.mapped(residual_field)))
+        if currency.compare_amounts(payment_remaining, invoice_remaining) > 0:
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment exceeds the referenced vendor "
+                    "document's remaining balance."
+                ),
+                invoice,
+            )
+        (payment_lines + invoice_lines).reconcile()
+        return rows._set_commission_match("matched", invoice=invoice)
+
+    def action_reconcile(self):
+        """Make a waiting commission explicit after successful customer collection."""
+        self.ensure_one()
+        action = super().action_reconcile()
+        if (
+            self.state == "reconciled"
+            and self.commission_payment_id
+            and self.commission_match_state != "matched"
+        ):
+            action["params"].update(
+                {
+                    "title": _("Customer Payment Reconciled"),
+                    "message": self.commission_match_note
+                    or _("Commission matching is pending."),
+                    "type": "warning",
+                }
+            )
+        return action
+
+    def action_reconcile_commission(self):
+        """Retry invoice-specific matching without creating another payment."""
+        self.ensure_one()
+        matched = self._reconcile_commission_invoice()
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": _("Commission Matching"),
+                "message": self.commission_match_note
+                or (
+                    _("Commission matched to the referenced vendor document.")
+                    if matched
+                    else _("Commission matching is pending.")
+                ),
+                "type": "success" if matched else "warning",
+                "sticky": not matched,
+            },
+        }

--- a/trendyol_integration/models/trendyol_settlement.py
+++ b/trendyol_integration/models/trendyol_settlement.py
@@ -230,7 +230,10 @@ class TrendyolSettlement(models.Model):
                 {
                     "commission_invoice_id": False,
                     "commission_match_state": "review"
-                    if self.commission_payment_id.is_reconciled
+                    if (
+                        not self.commission_payment_id.trendyol_commission_auto_match
+                        or self.commission_payment_id.is_reconciled
+                    )
                     else "waiting",
                     "commission_match_note": _(
                         "The API commission invoice reference was updated. "

--- a/trendyol_integration/tests/test_trendyol_settlement.py
+++ b/trendyol_integration/tests/test_trendyol_settlement.py
@@ -1,11 +1,32 @@
 # Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
+import json
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from odoo import fields
+
+from ..models.trendyol_backend import _utc_to_trendyol_ts
 from .common import TrendyolTestCase
 
 
 class TestTrendyolSettlement(TrendyolTestCase):
-    def _create_settlement_row(self, order, settlement_id, commission_amount):
+    def setUp(self):
+        super().setUp()
+        # Installed ERP stacks can shorten survey URLs during invoice posting.
+        # Keep this accounting test independent of that external service.
+        if "short.url.yourls" in self.env:
+            self.patch(
+                type(self.env["short.url.yourls"]),
+                "shorten_url",
+                lambda service, url: url,
+            )
+
+    def _create_settlement_row(
+        self, order, settlement_id, commission_amount, invoice_number=False
+    ):
         return self.env["trendyol.settlement"].create(
             {
                 "backend_id": self.backend.id,
@@ -16,6 +37,9 @@ class TestTrendyolSettlement(TrendyolTestCase):
                 "payment_order_id": "PAYOUT-1",
                 "trendyol_order_id": order.id,
                 "commission_amount": commission_amount,
+                "raw_data": json.dumps(
+                    {"commissionInvoiceSerialNumber": invoice_number}
+                ),
             }
         )
 
@@ -113,6 +137,251 @@ class TestTrendyolSettlement(TrendyolTestCase):
             }
         )
         return order, invoice
+
+    def _vendor_bill(self, reference, amount, date="2026-08-28", currency=False):
+        """Create a posted vendor bill without tax rounding ambiguity."""
+        expense = self.env["account.account"].search(
+            [
+                ("company_id", "=", self.env.company.id),
+                ("account_type", "=", "expense"),
+                ("deprecated", "=", False),
+            ],
+            limit=1,
+        )
+        bill = self.env["account.move"].create(
+            {
+                "move_type": "in_invoice",
+                "partner_id": self.backend.trendyol_partner_id.id,
+                "invoice_date": date,
+                "date": date,
+                "ref": reference,
+                "currency_id": (currency or self.env.company.currency_id).id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Commission",
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "account_id": expense.id,
+                            "tax_ids": [(5, 0, 0)],
+                        },
+                    )
+                ],
+            }
+        )
+        bill.action_post()
+        # Preserve the external vendor reference independently of entry numbering.
+        bill.ref = reference
+        return bill
+
+    def _payable_lines(self, move):
+        """Return the document's open payable lines."""
+        return move.line_ids.filtered(
+            lambda line: (
+                line.account_type == "liability_payable" and not line.reconciled
+            )
+        )
+
+    def test_commission_matches_api_invoice_instead_of_older_bill(self):
+        order, invoice = self._prepare_payout_order()
+        old = self._vendor_bill("DCF2026999900001", 15, "2026-01-21")
+        target = self._vendor_bill("DCF2026999900002", 15)
+        rows = self._create_settlement_row(
+            order, "EXACT-1", 10, target.ref
+        ) | self._create_settlement_row(order, "EXACT-2", 5, target.ref)
+        rows[0]._reconcile()
+        self.assertEqual(invoice.amount_residual, 0)
+        self.assertEqual(old.amount_residual, 15)
+        self.assertEqual(target.amount_residual, 0)
+        self.assertEqual(rows.commission_payment_id.reconciled_bill_ids, target)
+        self.assertTrue(rows.commission_payment_id.is_trendyol_commission)
+        self.assertTrue(rows.commission_payment_id.trendyol_commission_auto_match)
+        self.assertEqual(rows.mapped("commission_match_state"), ["matched", "matched"])
+
+    def test_missing_reference_is_excluded_from_general_reconciliation(self):
+        order, invoice = self._prepare_payout_order()
+        old = self._vendor_bill("DCF2026999900001", 15, "2026-01-21")
+        row = self._create_settlement_row(order, "WAIT-NUMBER", 15)
+        action = row.action_reconcile()
+        self.assertEqual(action["params"]["type"], "warning")
+        commission = row.commission_payment_id
+        self.env["account.auto.reconcile"].reconcile_partner(
+            self.backend.trendyol_partner_id
+        )
+        self.assertEqual(old.amount_residual, 15)
+        self.assertFalse(commission.is_reconciled)
+        self.assertEqual(row.commission_match_state, "waiting")
+        self.assertEqual(invoice.amount_residual, 0)
+
+        ordinary = self.env["account.payment"].create(
+            {
+                "payment_type": "outbound",
+                "partner_type": "supplier",
+                "partner_id": self.backend.trendyol_partner_id.id,
+                "amount": 15,
+                "currency_id": commission.currency_id.id,
+                "journal_id": commission.journal_id.id,
+            }
+        )
+        ordinary.action_post()
+        self.env["account.auto.reconcile"].reconcile_partner(
+            self.backend.trendyol_partner_id
+        )
+        self.assertTrue(ordinary.is_reconciled)
+        self.assertEqual(old.amount_residual, 0)
+        self.assertFalse(commission.is_reconciled)
+
+    def test_missing_vendor_bill_waits_then_reuses_the_same_payment(self):
+        order, _invoice = self._prepare_payout_order()
+        row = self._create_settlement_row(order, "WAIT-BILL", 15, "DCF2026999900002")
+        row._reconcile()
+        payment = row.commission_payment_id
+        self.assertFalse(payment.is_reconciled)
+        self.assertEqual(row.commission_match_state, "waiting")
+        bill = self._vendor_bill("DCF2026999900002", 15)
+        self.backend._reconcile_pending_commissions()
+        row.action_reconcile_commission()
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertEqual(payment.reconciled_bill_ids, bill, row.commission_match_note)
+        self.assertEqual(row.commission_match_state, "matched")
+
+    def test_bulk_vendor_bill_accepts_commissions_from_multiple_orders(self):
+        order, _invoice = self._prepare_payout_order()
+        bill = self._vendor_bill("DCF2026999900002", 30)
+        first = self._create_settlement_row(order, "BULK-1", 10, bill.ref)
+        first._reconcile()
+        _sale, second_order = self._create_sale_and_order(package_id="SECOND-PACKAGE")
+        second = self._create_settlement_row(second_order, "BULK-2", 20, bill.ref)
+        payment = second._create_commission_payment("outbound")
+        second.commission_payment_id = payment
+        second._reconcile_commission_invoice()
+        self.assertEqual(bill.amount_residual, 0)
+        self.assertTrue(first.commission_payment_id.is_reconciled)
+        self.assertTrue(second.commission_payment_id.is_reconciled)
+        self.assertNotEqual(first.commission_payment_id, second.commission_payment_id)
+
+    def test_reference_refresh_revisits_old_transactions_without_new_payments(self):
+        order, _invoice = self._prepare_payout_order()
+        row = self._create_settlement_row(order, "REFRESH-1", 15)
+        row.transaction_date = fields.Datetime.now() - timedelta(days=7)
+        row._reconcile()
+        payment = row.commission_payment_id
+        bill = self._vendor_bill("DCF2026999900002", 15)
+        previous_sync = fields.Datetime.now() - timedelta(days=1)
+        self.backend.write(
+            {"auto_reconcile_settlements": True, "last_settlement_sync": previous_sync}
+        )
+        client = SimpleNamespace(
+            get_settlements=Mock(
+                return_value={
+                    "content": [
+                        {
+                            "id": row.trendyol_settlement_id,
+                            "commissionInvoiceSerialNumber": bill.ref,
+                        }
+                    ],
+                    "totalPages": 1,
+                }
+            )
+        )
+        with patch.object(type(self.backend), "_get_api_client", return_value=client):
+            self.backend._import_settlements()
+        self.assertLess(
+            client.get_settlements.call_args.kwargs["start_date"],
+            _utc_to_trendyol_ts(previous_sync),
+        )
+        self.assertEqual(row.commission_invoice_number, bill.ref)
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertEqual(payment.reconciled_bill_ids, bill)
+        self.env["trendyol.settlement"]._import_settlement(
+            self.backend, {"id": row.trendyol_settlement_id}
+        )
+        self.assertEqual(row.commission_invoice_number, bill.ref)
+
+    def test_legacy_open_payments_are_protected_but_not_automatically_matched(self):
+        order, _invoice = self._prepare_payout_order()
+        row = self._create_settlement_row(order, "LEGACY-OPEN", 15)
+        row._reconcile()
+        payment = row.commission_payment_id
+        payment.trendyol_commission_auto_match = False
+        bill = self._vendor_bill("DCF2026999900002", 15)
+        self.env["trendyol.settlement"]._import_settlement(
+            self.backend,
+            {
+                "id": row.trendyol_settlement_id,
+                "commissionInvoiceSerialNumber": bill.ref,
+            },
+        )
+        self.backend._reconcile_pending_commissions()
+        row.action_reconcile_commission()
+        self.env["account.auto.reconcile"].reconcile_partner(
+            self.backend.trendyol_partner_id
+        )
+        self.assertTrue(payment.is_trendyol_commission)
+        self.assertFalse(payment.is_reconciled)
+        self.assertEqual(bill.amount_residual, 15)
+        self.assertEqual(row.commission_match_state, "review")
+
+    def test_existing_wrong_reconciliation_is_never_rewritten(self):
+        order, _invoice = self._prepare_payout_order()
+        row = self._create_settlement_row(order, "WRONG-MATCH", 15)
+        row._reconcile()
+        payment = row.commission_payment_id
+        old = self._vendor_bill("DCF2026999900001", 15, "2026-01-21")
+        (self._payable_lines(payment.move_id) + self._payable_lines(old)).reconcile()
+        original_links = (
+            payment.move_id.line_ids.matched_credit_ids
+            | payment.move_id.line_ids.matched_debit_ids
+        )
+        target = self._vendor_bill("DCF2026999900002", 15)
+        self.env["trendyol.settlement"]._import_settlement(
+            self.backend,
+            {
+                "id": row.trendyol_settlement_id,
+                "commissionInvoiceSerialNumber": target.ref,
+            },
+        )
+        row.action_reconcile_commission()
+        self.assertEqual(payment.reconciled_bill_ids, old)
+        self.assertTrue(original_links.exists())
+        self.assertEqual(target.amount_residual, 15)
+        self.assertEqual(row.commission_match_state, "review")
+
+    def test_conflicting_invoice_references_wait_for_review(self):
+        order, invoice = self._prepare_payout_order()
+        first = self._vendor_bill("DCF2026999900001", 10)
+        second = self._vendor_bill("DCF2026999900002", 5)
+        rows = self._create_settlement_row(
+            order, "CONFLICT-1", 10, first.ref
+        ) | self._create_settlement_row(order, "CONFLICT-2", 5, second.ref)
+        rows[0]._reconcile()
+        self.assertFalse(rows.commission_payment_id.is_reconciled)
+        self.assertEqual(rows.mapped("commission_match_state"), ["review", "review"])
+        self.assertEqual(first.amount_residual, 10)
+        self.assertEqual(second.amount_residual, 5)
+        self.assertEqual(invoice.amount_residual, 0)
+
+    def test_excess_payment_and_wrong_currency_do_not_reconcile(self):
+        order, _invoice = self._prepare_payout_order()
+        target = self._vendor_bill("DCF2026999900002", 5)
+        row = self._create_settlement_row(order, "EXCESS-1", 15, target.ref)
+        row._reconcile()
+        self.assertEqual(row.commission_match_state, "review")
+        self.assertFalse(row.commission_payment_id.is_reconciled)
+        self.assertEqual(target.amount_residual, 5)
+        other_currency = (
+            self.env.ref("base.USD")
+            if self.env.company.currency_id != self.env.ref("base.USD")
+            else self.env.ref("base.EUR")
+        )
+        foreign = self._vendor_bill("DCF2026999900003", 15, currency=other_currency)
+        row.raw_data = json.dumps({"commissionInvoiceSerialNumber": foreign.ref})
+        row.action_reconcile_commission()
+        self.assertEqual(row.commission_match_state, "review")
+        self.assertFalse(row.commission_payment_id.is_reconciled)
+        self.assertEqual(foreign.amount_residual, 15)
 
     def test_package_rows_are_reconciled_with_one_payment(self):
         order, invoice = self._prepare_payout_order()

--- a/trendyol_integration/tests/test_trendyol_settlement.py
+++ b/trendyol_integration/tests/test_trendyol_settlement.py
@@ -205,7 +205,6 @@ class TestTrendyolSettlement(TrendyolTestCase):
         self.assertEqual(target.amount_residual, 0)
         self.assertEqual(rows.commission_payment_id.reconciled_bill_ids, target)
         self.assertTrue(rows.commission_payment_id.is_trendyol_commission)
-        self.assertTrue(rows.commission_payment_id.trendyol_commission_auto_match)
         self.assertEqual(rows.mapped("commission_match_state"), ["matched", "matched"])
 
     def test_missing_reference_is_excluded_from_general_reconciliation(self):
@@ -318,7 +317,6 @@ class TestTrendyolSettlement(TrendyolTestCase):
         row.raw_data = json.dumps({"commissionAmount": 15, "credit": 100})
         row._reconcile()
         payment = row.commission_payment_id
-        payment.trendyol_commission_auto_match = False
         old = self._vendor_bill("DCF2026999900001", 15, "2026-01-21")
         (self._payable_lines(payment.move_id) + self._payable_lines(old)).reconcile()
         original_links = (
@@ -357,7 +355,6 @@ class TestTrendyolSettlement(TrendyolTestCase):
         self.assertEqual(row.commission_payment_id, payment)
         self.assertEqual(payment.reconciled_bill_ids, old)
         self.assertTrue(original_links.exists())
-        self.assertFalse(payment.trendyol_commission_auto_match)
         self.assertEqual(row.state, "reconciled")
         self.assertEqual(row.commission_match_state, "review")
         self.assertEqual(row.commission_amount, 15)
@@ -461,12 +458,11 @@ class TestTrendyolSettlement(TrendyolTestCase):
         self.assertFalse(row.commission_invoice_number)
         self.assertFalse(row.commission_payment_id)
 
-    def test_legacy_open_payments_are_protected_but_not_automatically_matched(self):
+    def test_existing_open_payments_are_matched_by_commission_cron(self):
         order, _invoice = self._prepare_payout_order()
         row = self._create_settlement_row(order, "LEGACY-OPEN", 15)
         row._reconcile()
         payment = row.commission_payment_id
-        payment.trendyol_commission_auto_match = False
         bill = self._vendor_bill("DCF2026999900002", 15)
         self.env["trendyol.settlement"]._import_settlement(
             self.backend,
@@ -475,18 +471,21 @@ class TestTrendyolSettlement(TrendyolTestCase):
                 "commissionInvoiceSerialNumber": bill.ref,
             },
         )
-        self.assertEqual(row.commission_match_state, "review")
-        self.backend._reconcile_pending_commissions()
-        row.action_reconcile_commission()
+        self.assertEqual(row.commission_match_state, "waiting")
         self.env["account.auto.reconcile"].reconcile_partner(
             self.backend.trendyol_partner_id
         )
         self.assertTrue(payment.is_trendyol_commission)
         self.assertFalse(payment.is_reconciled)
         self.assertEqual(bill.amount_residual, 15)
-        self.assertEqual(row.commission_match_state, "review")
+        self.backend._reconcile_pending_commissions()
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertTrue(payment.is_reconciled)
+        self.assertEqual(payment.reconciled_bill_ids, bill)
+        self.assertEqual(bill.amount_residual, 0)
+        self.assertEqual(row.commission_match_state, "matched")
 
-    def test_existing_wrong_reconciliation_is_never_rewritten(self):
+    def test_existing_match_is_preserved_until_manually_unreconciled(self):
         order, _invoice = self._prepare_payout_order()
         row = self._create_settlement_row(order, "WRONG-MATCH", 15)
         row._reconcile()
@@ -510,6 +509,15 @@ class TestTrendyolSettlement(TrendyolTestCase):
         self.assertTrue(original_links.exists())
         self.assertEqual(target.amount_residual, 15)
         self.assertEqual(row.commission_match_state, "review")
+        self.backend._reconcile_pending_commissions()
+        self.assertTrue(original_links.exists())
+        original_links.unlink()
+        self.backend._reconcile_pending_commissions()
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertEqual(payment.reconciled_bill_ids, target)
+        self.assertEqual(old.amount_residual, 15)
+        self.assertEqual(target.amount_residual, 0)
+        self.assertEqual(row.commission_match_state, "matched")
 
     def test_conflicting_invoice_references_wait_for_review(self):
         order, invoice = self._prepare_payout_order()

--- a/trendyol_integration/tests/test_trendyol_settlement.py
+++ b/trendyol_integration/tests/test_trendyol_settlement.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 from odoo import fields
 
 from ..models.trendyol_backend import _utc_to_trendyol_ts
+from ..models.trendyol_request import TrendyolAPIError
 from .common import TrendyolTestCase
 
 
@@ -127,7 +128,7 @@ class TestTrendyolSettlement(TrendyolTestCase):
                 ],
             }
         )
-        invoice.action_post()
+        self._post_fixture_invoice(invoice)
         order = self.env["trendyol.order"].create(
             {
                 "odoo_id": sale.id,
@@ -171,10 +172,17 @@ class TestTrendyolSettlement(TrendyolTestCase):
                 ],
             }
         )
-        bill.action_post()
+        self._post_fixture_invoice(bill)
         # Preserve the external vendor reference independently of entry numbering.
         bill.ref = reference
         return bill
+
+    def _post_fixture_invoice(self, invoice):
+        """Post accounting fixtures independently of deployment warning rules."""
+        if "ignore_exception" in invoice._fields:
+            invoice.ignore_exception = True
+        invoice.action_post()
+        self.assertEqual(invoice.state, "posted")
 
     def _payable_lines(self, move):
         """Return the document's open payable lines."""
@@ -275,15 +283,18 @@ class TestTrendyolSettlement(TrendyolTestCase):
         )
         client = SimpleNamespace(
             get_settlements=Mock(
-                return_value={
-                    "content": [
-                        {
-                            "id": row.trendyol_settlement_id,
-                            "commissionInvoiceSerialNumber": bill.ref,
-                        }
-                    ],
-                    "totalPages": 1,
-                }
+                side_effect=[
+                    {"content": [], "totalPages": 0},
+                    {
+                        "content": [
+                            {
+                                "id": row.trendyol_settlement_id,
+                                "commissionInvoiceSerialNumber": bill.ref,
+                            }
+                        ],
+                        "totalPages": 1,
+                    },
+                ]
             )
         )
         with patch.object(type(self.backend), "_get_api_client", return_value=client):
@@ -300,6 +311,156 @@ class TestTrendyolSettlement(TrendyolTestCase):
         )
         self.assertEqual(row.commission_invoice_number, bill.ref)
 
+    def test_daily_refresh_preserves_closed_legacy_payment_and_amounts(self):
+        order, invoice = self._prepare_payout_order()
+        row = self._create_settlement_row(order, "LEGACY-REFRESH", 15)
+        row.transaction_date = fields.Datetime.now() - timedelta(days=180)
+        row.raw_data = json.dumps({"commissionAmount": 15, "credit": 100})
+        row._reconcile()
+        payment = row.commission_payment_id
+        payment.trendyol_commission_auto_match = False
+        old = self._vendor_bill("DCF2026999900001", 15, "2026-01-21")
+        (self._payable_lines(payment.move_id) + self._payable_lines(old)).reconcile()
+        original_links = (
+            payment.move_id.line_ids.matched_credit_ids
+            | payment.move_id.line_ids.matched_debit_ids
+        )
+        target = self._vendor_bill("DCF2026999900002", 15)
+        self.backend.write(
+            {
+                "auto_reconcile_settlements": False,
+                "last_settlement_sync": fields.Datetime.now() - timedelta(days=1),
+            }
+        )
+        client = SimpleNamespace(
+            get_settlements=Mock(
+                side_effect=[
+                    {"content": []},
+                    {
+                        "content": [
+                            {
+                                "id": row.trendyol_settlement_id,
+                                "commissionInvoiceSerialNumber": target.ref,
+                                "commissionAmount": 999,
+                                "credit": 999,
+                            },
+                            {"id": "UNREQUESTED-HISTORY", "commissionAmount": 20},
+                        ],
+                        "totalPages": 1,
+                    },
+                ]
+            )
+        )
+        with patch.object(type(self.backend), "_get_api_client", return_value=client):
+            self.backend._import_settlements()
+        self.assertEqual(row.commission_invoice_number, target.ref)
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertEqual(payment.reconciled_bill_ids, old)
+        self.assertTrue(original_links.exists())
+        self.assertFalse(payment.trendyol_commission_auto_match)
+        self.assertEqual(row.state, "reconciled")
+        self.assertEqual(row.commission_match_state, "review")
+        self.assertEqual(row.commission_amount, 15)
+        self.assertEqual(json.loads(row.raw_data)["commissionAmount"], 15)
+        self.assertEqual(json.loads(row.raw_data)["credit"], 100)
+        self.assertEqual(invoice.amount_residual, 0)
+        self.assertEqual(target.amount_residual, 15)
+        self.assertFalse(
+            self.env["trendyol.settlement"].search(
+                [("trendyol_settlement_id", "=", "UNREQUESTED-HISTORY")]
+            )
+        )
+
+    def test_reference_refresh_pages_rows_without_payments_and_stops_when_filled(self):
+        _sale, order = self._create_sale_and_order()
+        row = self._create_settlement_row(order, "UNPAID-REFERENCE", 15)
+        row.transaction_date = fields.Datetime.now() - timedelta(days=90)
+        client = SimpleNamespace(
+            get_settlements=Mock(
+                side_effect=[
+                    {"content": [{"id": "UNREQUESTED-HISTORY"}], "totalPages": 2},
+                    {
+                        "content": [
+                            {
+                                "id": row.trendyol_settlement_id,
+                                "commissionInvoiceSerialNumber": "DCF2026999900002",
+                            }
+                        ],
+                        "totalPages": 2,
+                    },
+                ]
+            )
+        )
+        self.backend._refresh_missing_commission_references(client)
+        self.assertEqual(row.commission_invoice_number, "DCF2026999900002")
+        self.assertFalse(row.odoo_payment_id)
+        self.assertFalse(row.commission_payment_id)
+        self.assertEqual(
+            [call.kwargs["page"] for call in client.get_settlements.call_args_list],
+            [0, 1],
+        )
+        client.get_settlements.reset_mock()
+        self.backend._refresh_missing_commission_references(client)
+        client.get_settlements.assert_not_called()
+
+    def test_reference_refresh_uses_sparse_windows_and_trendyol_midnight(self):
+        _sale, order = self._create_sale_and_order()
+        for index, date in enumerate(
+            [
+                "2026-01-01 22:30:00",
+                "2026-01-15 22:30:00",
+                "2026-01-16 22:30:00",
+                "2026-07-01 22:30:00",
+            ]
+        ):
+            row = self._create_settlement_row(order, f"WINDOW-{index}", 15)
+            row.transaction_date = date
+        zero = self._create_settlement_row(order, "ZERO-COMMISSION", 0)
+        zero.transaction_date = "2025-01-01 12:00:00"
+        known = self._create_settlement_row(order, "KNOWN-REFERENCE", 15, "KNOWN")
+        known.transaction_date = "2025-02-01 12:00:00"
+        other_backend = self.backend.copy({"name": "Other Reference Backend"})
+        other = self._create_settlement_row(order, "OTHER-BACKEND", 15)
+        other.write(
+            {"backend_id": other_backend.id, "transaction_date": "2025-03-01 12:00:00"}
+        )
+        client = SimpleNamespace(get_settlements=Mock(return_value={"content": []}))
+        self.backend._refresh_missing_commission_references(client)
+        calls = client.get_settlements.call_args_list
+        expected = [
+            ("2026-01-02", "2026-01-17"),
+            ("2026-01-17", "2026-01-18"),
+            ("2026-07-02", "2026-07-03"),
+        ]
+        self.assertEqual(len(calls), len(expected))
+        for call, (start, end) in zip(calls, expected, strict=True):
+            self.assertEqual(
+                call.kwargs["start_date"],
+                _utc_to_trendyol_ts(fields.Datetime.to_datetime(start)),
+            )
+            self.assertEqual(
+                call.kwargs["end_date"],
+                _utc_to_trendyol_ts(fields.Datetime.to_datetime(end)),
+            )
+
+    def test_failed_reference_refresh_keeps_import_watermark(self):
+        _sale, order = self._create_sale_and_order()
+        row = self._create_settlement_row(order, "FAILED-REFERENCE", 15)
+        row.transaction_date = fields.Datetime.now() - timedelta(days=90)
+        previous_sync = fields.Datetime.now() - timedelta(days=1)
+        self.backend.last_settlement_sync = previous_sync
+        client = SimpleNamespace(
+            get_settlements=Mock(
+                side_effect=[{"content": []}, TrendyolAPIError("Finance unavailable")]
+            )
+        )
+        with patch.object(type(self.backend), "_get_api_client", return_value=client):
+            with self.assertRaises(TrendyolAPIError):
+                self.backend._import_settlements()
+        self.assertEqual(self.backend.last_settlement_sync, previous_sync)
+        self.assertFalse(row.commission_invoice_number)
+        self.assertFalse(row.commission_payment_id)
+
     def test_legacy_open_payments_are_protected_but_not_automatically_matched(self):
         order, _invoice = self._prepare_payout_order()
         row = self._create_settlement_row(order, "LEGACY-OPEN", 15)
@@ -314,6 +475,7 @@ class TestTrendyolSettlement(TrendyolTestCase):
                 "commissionInvoiceSerialNumber": bill.ref,
             },
         )
+        self.assertEqual(row.commission_match_state, "review")
         self.backend._reconcile_pending_commissions()
         row.action_reconcile_commission()
         self.env["account.auto.reconcile"].reconcile_partner(

--- a/trendyol_integration/views/trendyol_settlement_views.xml
+++ b/trendyol_integration/views/trendyol_settlement_views.xml
@@ -15,6 +15,12 @@
                         attrs="{'invisible': [('state', '=', 'reconciled')]}"
                     />
                     <field name="state" widget="statusbar" />
+                    <button
+                        name="action_reconcile_commission"
+                        string="Match Commission Invoice"
+                        type="object"
+                        attrs="{'invisible': [('commission_payment_id', '=', False)]}"
+                    />
                 </header>
                 <sheet>
                     <div
@@ -64,6 +70,14 @@
                         </group>
                     </group>
                     <notebook>
+                        <page string="Commission Matching" name="commission_matching">
+                            <group>
+                                <field name="commission_invoice_number" />
+                                <field name="commission_invoice_id" />
+                                <field name="commission_match_state" />
+                                <field name="commission_match_note" />
+                            </group>
+                        </page>
                         <page string="Raw Data" name="raw_data">
                             <field name="raw_data" />
                         </page>
@@ -94,6 +108,8 @@
                 <field name="payment_order_id" />
                 <field name="state" />
                 <field name="odoo_invoice_id" optional="show" />
+                <field name="commission_invoice_number" optional="show" />
+                <field name="commission_match_state" optional="show" />
             </tree>
         </field>
     </record>
@@ -108,6 +124,7 @@
                 <field name="barcode" />
                 <field name="payment_order_id" />
                 <field name="trendyol_settlement_id" />
+                <field name="commission_invoice_number" />
                 <separator />
                 <filter
                     name="imported"


### PR DESCRIPTION
Trendyol can initially return a null commission invoice reference and populate it later. Existing settlements kept the original snapshot, while the generic supplier reconciler could allocate their commission payments to unrelated older DSM bills.

Persist and refresh the API's `commissionInvoiceSerialNumber`, exclude linked Trendyol commission payments from generic matching, and match all posted, open Trendyol commission payments only to the exact posted supplier document after partner, company, currency, amount and residual checks. Missing references or documents remain pending; retries reuse the posted payment.

The existing daily financial import also refreshes missing references on historical, already-reconciled and not-yet-paid settlements. It queries only date windows containing missing references, with pagination and a 15-day maximum, independently of automatic accounting reconciliation. These historical queries update reference metadata only. Existing allocations remain protected. Once an incorrect historical allocation is explicitly unreconciled, the same payment becomes eligible for the normal commission cron without an old/new-payment flag. Order webhooks are not used for finance-reference updates.

Validation:

- 17 real Odoo settlement tests on an isolated installed-database clone: exact invoice matching, generic exclusion, late reference/bill arrival, legacy allocation preservation, cron rematching after explicit unreconciliation, sparse date windows, midnight conversion, pagination and failure watermark handling.
- Replayed previously captured finance API responses against historical clone records; references refreshed while closed payment allocations remained unchanged. Explicitly unreconciling one historical payment let the cron match that same payment to its referenced bill, without changing other payments.
- `pre-commit run -a` and `git diff --check`.

Module upgrade required: `trendyol_integration` 16.0.1.2.0. This change does not automatically undo historical accounting allocations.
