### PR TITLE
[I18N] Complete and simplify marketplace Turkish translations

### DIFF
--- a/marketplace_integration_base/i18n/marketplace_integration_base.pot
+++ b/marketplace_integration_base/i18n/marketplace_integration_base.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 07:17+0000\n"
-"PO-Revision-Date: 2026-04-27 07:17+0000\n"
+"POT-Creation-Date: 2026-09-08 07:30+0000\n"
+"PO-Revision-Date: 2026-09-08 07:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -129,6 +129,7 @@ msgid "Cargo Provider"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__changeset_change_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__changeset_change_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__changeset_change_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__changeset_change_ids
@@ -139,6 +140,7 @@ msgid "Changeset Changes"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__changeset_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__changeset_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__changeset_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__changeset_ids
@@ -197,6 +199,7 @@ msgid ""
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__count_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__count_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__count_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__count_changesets
@@ -207,6 +210,7 @@ msgid "Count Changesets"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changeset_changes
@@ -217,6 +221,7 @@ msgid "Count Pending Changeset Changes"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__count_pending_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changesets
@@ -317,6 +322,11 @@ msgstr ""
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__invoice_sent_date
 msgid "Invoice Sent Date"
+msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model,name:marketplace_integration_base.model_account_move_line
+msgid "Journal Item"
 msgstr ""
 
 #. module: marketplace_integration_base
@@ -443,11 +453,20 @@ msgid "Reconciled"
 msgstr ""
 
 #. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Reconciliation Failed"
+msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__transaction_type__return
 #: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__transaction_type__return
 msgid "Return"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__transaction_type__sale
 #: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__transaction_type__sale
 msgid "Sale"
 msgstr ""
@@ -492,6 +511,7 @@ msgid "Settlements"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__smart_search
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__smart_search
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__smart_search
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__smart_search
@@ -524,6 +544,7 @@ msgid "Success"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,help:marketplace_integration_base.field_account_move_line__count_pending_changeset_changes
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changeset_changes
@@ -534,6 +555,7 @@ msgid "The number of pending changes of this record"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,help:marketplace_integration_base.field_account_move_line__count_pending_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changesets
@@ -551,6 +573,7 @@ msgid "The operation has been queued."
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,help:marketplace_integration_base.field_account_move_line__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_order_mixin__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_settlement_mixin__count_changesets
@@ -558,6 +581,13 @@ msgstr ""
 #: model:ir.model.fields,help:marketplace_integration_base.field_sale_order_line__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_stock_picking__count_changesets
 msgid "The overall number of changesets of this record"
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The settlement could not be reconciled."
 msgstr ""
 
 #. module: marketplace_integration_base
@@ -600,6 +630,7 @@ msgid "UNMAPPED: %(product)s (Qty: %(qty)s, Price: %(price)s)"
 msgstr ""
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__user_can_see_changeset
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__user_can_see_changeset
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__user_can_see_changeset
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__user_can_see_changeset
@@ -612,18 +643,4 @@ msgstr ""
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__warehouse_ids
 msgid "Warehouses"
-msgstr ""
-
-#. module: marketplace_integration_base
-#. odoo-python
-#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
-#, python-format
-msgid "Reconciliation Failed"
-msgstr ""
-
-#. module: marketplace_integration_base
-#. odoo-python
-#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
-#, python-format
-msgid "The settlement could not be reconciled."
 msgstr ""

--- a/marketplace_integration_base/i18n/tr.po
+++ b/marketplace_integration_base/i18n/tr.po
@@ -6,15 +6,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 07:17+0000\n"
-"PO-Revision-Date: 2026-04-27 07:17+0000\n"
+"POT-Creation-Date: 2026-09-08 07:30+0000\n"
+"PO-Revision-Date: 2026-09-08 07:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: marketplace_integration_base
 #. odoo-python
@@ -35,14 +35,14 @@ msgstr "%(marketplace)s Hesaplaşması - Sipariş %(order)s"
 #: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
 #, python-format
 msgid "%(marketplace)s order not found for order number: %(order)s"
-msgstr "%(order)s sipariş numarası için %(marketplace)s siparişi bulunamadı"
+msgstr "%(marketplace)s siparişi bulunamadı: %(order)s"
 
 #. module: marketplace_integration_base
 #. odoo-python
 #: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
 #, python-format
 msgid "%s Payment Journal not configured on backend."
-msgstr "%s ödeme yevmiyesi backend üzerinde yapılandırılmamış."
+msgstr "%s için ödeme yevmiyesi seçilmemiş."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__active
@@ -82,7 +82,7 @@ msgstr "Faturayı Otomatik Gönder"
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__auto_sync_tracking
 msgid "Auto Sync Tracking"
-msgstr "Takibi Otomatik Senkronize Et"
+msgstr "Kargo Takibini Otomatik Eşitle"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__auto_confirm_orders
@@ -92,46 +92,45 @@ msgstr "Siparişleri Otomatik Onayla"
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_confirm_orders
 msgid "Automatically confirm imported orders"
-msgstr "İçe aktarılan siparişleri otomatik olarak onayla"
+msgstr "İçe aktarılan siparişleri otomatik onaylar."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_import_claims
 msgid "Automatically import customer claims via scheduled job"
-msgstr ""
-"Müşteri iade taleplerini zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "İade taleplerini zamanlanmış görevle içe aktarır."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_import_questions
 msgid "Automatically import customer questions via scheduled job"
-msgstr "Müşteri sorularını zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Müşteri sorularını zamanlanmış görevle içe aktarır."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_import_settlements
 msgid "Automatically import financial settlements via scheduled job"
-msgstr ""
-"Finansal hesaplaşmaları zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Hesaplaşmaları zamanlanmış görevle içe aktarır."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_import_orders
 msgid "Automatically import orders via scheduled job"
-msgstr "Siparişleri zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Siparişleri zamanlanmış görevle içe aktarır."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_reconcile_settlements
 msgid "Automatically reconcile imported settlements with invoices"
-msgstr "İçe aktarılan hesaplaşmaları faturalarla otomatik olarak uzlaştır"
+msgstr "İçe aktarılan hesaplaşmaları faturalarla otomatik uzlaştırır."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_sync_tracking
 msgid "Automatically send tracking numbers when delivery is done"
-msgstr "Teslimat tamamlandığında takip numaralarını otomatik olarak gönder"
+msgstr "Teslimat tamamlanınca takip numaralarını otomatik gönderir."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__cargo_provider_name
 msgid "Cargo Provider"
-msgstr "Kargo Sağlayıcı"
+msgstr "Kargo Firması"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__changeset_change_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__changeset_change_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__changeset_change_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__changeset_change_ids
@@ -139,9 +138,10 @@ msgstr "Kargo Sağlayıcı"
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_sale_order_line__changeset_change_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_stock_picking__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Changeset Değişiklikleri"
+msgstr "Değişiklik Kayıtları"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__changeset_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__changeset_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__changeset_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__changeset_ids
@@ -149,7 +149,7 @@ msgstr "Changeset Değişiklikleri"
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_sale_order_line__changeset_ids
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_stock_picking__changeset_ids
 msgid "Changesets"
-msgstr "Değişiklikler"
+msgstr "Değişiklik Grupları"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__claim_count
@@ -188,7 +188,7 @@ msgstr "Bağlantı başarısız: %s"
 #: code:addons/marketplace_integration_base/models/marketplace_backend.py:0
 #, python-format
 msgid "Connection to %s API successful!"
-msgstr "%s API bağlantısı başarılı!"
+msgstr "%s API bağlantısı kuruldu."
 
 #. module: marketplace_integration_base
 #. odoo-python
@@ -198,10 +198,11 @@ msgid ""
 "Could not create commission payment. Check marketplace partner and journal "
 "configuration."
 msgstr ""
-"Komisyon ödemesi oluşturulamadı. Pazaryeri partneri ve yevmiye "
-"yapılandırmasını kontrol edin."
+"Komisyon ödemesi oluşturulamadı. Pazaryeri cari hesabını ve ödeme "
+"yevmiyesini kontrol edin."
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__count_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__count_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__count_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__count_changesets
@@ -209,9 +210,10 @@ msgstr ""
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_sale_order_line__count_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_stock_picking__count_changesets
 msgid "Count Changesets"
-msgstr "Sayım Değişiklik Setleri"
+msgstr "Değişiklik Grubu Sayısı"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changeset_changes
@@ -219,9 +221,10 @@ msgstr "Sayım Değişiklik Setleri"
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_sale_order_line__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_stock_picking__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
+msgstr "Bekleyen Değişiklik Sayısı"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__count_pending_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changesets
@@ -229,7 +232,7 @@ msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_sale_order_line__count_pending_changesets
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_stock_picking__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Bekleyen Değişiklik Setlerini Say"
+msgstr "Bekleyen Değişiklik Grubu Sayısı"
 
 #. module: marketplace_integration_base
 #. odoo-python
@@ -284,8 +287,8 @@ msgid ""
 "Fallback product for unmapped marketplace items. If not set, unmapped items "
 "will be created as note lines."
 msgstr ""
-"Eşleştirilmemiş pazaryeri ürünleri için yedek ürün. Ayarlanmazsa "
-"eşleştirilmemiş ürünler not satırı olarak oluşturulur."
+"Eşleşmeyen pazaryeri ürünleri için kullanılacak ürün. Seçilmezse bu ürünler "
+"not satırı olarak eklenir."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__fiscal_position_id
@@ -319,7 +322,7 @@ msgstr "%s faturası zaten ödenmiş."
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__invoice_link_sent
 msgid "Invoice Link Sent"
-msgstr "Fatura Linki Gönderildi"
+msgstr "Fatura Bağlantısı Gönderildi"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__invoice_sent_date
@@ -327,24 +330,29 @@ msgid "Invoice Sent Date"
 msgstr "Fatura Gönderim Tarihi"
 
 #. module: marketplace_integration_base
+#: model:ir.model,name:marketplace_integration_base.model_account_move_line
+msgid "Journal Item"
+msgstr "Yevmiye Kalemi"
+
+#. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__last_claim_sync
 msgid "Last Claim Sync"
-msgstr "Son İade Talebi Senkronizasyonu"
+msgstr "Son İade Eşitlemesi"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__last_order_sync
 msgid "Last Order Sync"
-msgstr "Son Sipariş Senkronizasyonu"
+msgstr "Son Sipariş Eşitlemesi"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__last_question_sync
 msgid "Last Question Sync"
-msgstr "Son Soru Senkronizasyonu"
+msgstr "Son Soru Eşitlemesi"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__last_settlement_sync
 msgid "Last Settlement Sync"
-msgstr "Son Hesaplaşma Senkronizasyonu"
+msgstr "Son Hesaplaşma Eşitlemesi"
 
 #. module: marketplace_integration_base
 #. odoo-python
@@ -357,17 +365,17 @@ msgstr "Pazaryeri"
 #. module: marketplace_integration_base
 #: model:ir.model,name:marketplace_integration_base.model_marketplace_backend_mixin
 msgid "Marketplace Backend Mixin"
-msgstr "Pazaryeri Backend Mixin"
+msgstr "Pazaryeri Entegrasyon Altyapısı"
 
 #. module: marketplace_integration_base
 #: model:ir.model,name:marketplace_integration_base.model_marketplace_order_mixin
 msgid "Marketplace Order Mixin"
-msgstr "Pazaryeri Sipariş Mixin"
+msgstr "Pazaryeri Sipariş Altyapısı"
 
 #. module: marketplace_integration_base
 #: model:ir.model,name:marketplace_integration_base.model_marketplace_settlement_mixin
 msgid "Marketplace Settlement Mixin"
-msgstr "Pazaryeri Hesaplaşma Mixin"
+msgstr "Pazaryeri Hesaplaşma Altyapısı"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__name
@@ -386,14 +394,14 @@ msgstr "Bağlı Odoo satış siparişi bulunamadı."
 #: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
 #, python-format
 msgid "No posted credit note found for sale order %s"
-msgstr "%s satış siparişi için onaylanmış iade faturası bulunamadı"
+msgstr "%s siparişi için onaylı iade faturası bulunamadı."
 
 #. module: marketplace_integration_base
 #. odoo-python
 #: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
 #, python-format
 msgid "No posted invoice found for sale order %s"
-msgstr "%s satış siparişi için onaylanmış fatura bulunamadı"
+msgstr "%s siparişi için onaylı fatura bulunamadı."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__order_number
@@ -408,7 +416,7 @@ msgstr "Siparişler"
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_order_mixin__raw_data
 msgid "Original JSON data from marketplace API"
-msgstr "Pazaryeri API'sinden gelen orijinal JSON verisi"
+msgstr "Pazaryeri API'sinden alınan ham JSON verisi."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__odoo_payment_id
@@ -428,7 +436,7 @@ msgstr "Fiyat Listesi"
 #. module: marketplace_integration_base
 #: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_backend_mixin__environment__prod
 msgid "Production"
-msgstr "Üretim"
+msgstr "Canlı Ortam"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__question_count
@@ -450,11 +458,20 @@ msgid "Reconciled"
 msgstr "Uzlaştırıldı"
 
 #. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Reconciliation Failed"
+msgstr "Uzlaştırma Başarısız"
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__transaction_type__return
 #: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__transaction_type__return
 msgid "Return"
 msgstr "İade"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__transaction_type__sale
 #: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__transaction_type__sale
 msgid "Sale"
 msgstr "Satış"
@@ -477,7 +494,7 @@ msgstr "Satış Ekibi"
 #. module: marketplace_integration_base
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__auto_send_invoice
 msgid "Send invoice links via scheduled job"
-msgstr "Fatura linklerini zamanlanmış görev ile gönder"
+msgstr "Fatura bağlantılarını zamanlanmış görevle gönderir."
 
 #. module: marketplace_integration_base
 #. odoo-python
@@ -491,7 +508,7 @@ msgstr "Fatura gönder: %s"
 #: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
 #, python-format
 msgid "Settlement has been reconciled successfully."
-msgstr "Hesaplaşma başarıyla uzlaştırıldı."
+msgstr "Hesaplaşma uzlaştırıldı."
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__settlement_count
@@ -499,6 +516,7 @@ msgid "Settlements"
 msgstr "Hesaplaşmalar"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__smart_search
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__smart_search
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__smart_search
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__smart_search
@@ -531,6 +549,7 @@ msgid "Success"
 msgstr "Başarılı"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,help:marketplace_integration_base.field_account_move_line__count_pending_changeset_changes
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changeset_changes
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changeset_changes
@@ -538,9 +557,10 @@ msgstr "Başarılı"
 #: model:ir.model.fields,help:marketplace_integration_base.field_sale_order_line__count_pending_changeset_changes
 #: model:ir.model.fields,help:marketplace_integration_base.field_stock_picking__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "Bu kaydın bekleyen değişiklik sayısı"
+msgstr "Bu kayıtta bekleyen değişiklik sayısı."
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,help:marketplace_integration_base.field_account_move_line__count_pending_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__count_pending_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_order_mixin__count_pending_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_settlement_mixin__count_pending_changesets
@@ -548,7 +568,7 @@ msgstr "Bu kaydın bekleyen değişiklik sayısı"
 #: model:ir.model.fields,help:marketplace_integration_base.field_sale_order_line__count_pending_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_stock_picking__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
+msgstr "Bu kayıtta bekleyen değişiklik grubu sayısı."
 
 #. module: marketplace_integration_base
 #. odoo-python
@@ -558,6 +578,7 @@ msgid "The operation has been queued."
 msgstr "İşlem kuyruğa alındı."
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,help:marketplace_integration_base.field_account_move_line__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_backend_mixin__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_order_mixin__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_marketplace_settlement_mixin__count_changesets
@@ -565,7 +586,14 @@ msgstr "İşlem kuyruğa alındı."
 #: model:ir.model.fields,help:marketplace_integration_base.field_sale_order_line__count_changesets
 #: model:ir.model.fields,help:marketplace_integration_base.field_stock_picking__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Bu kaydın toplam değişiklik seti sayısı"
+msgstr "Bu kaydın toplam değişiklik grubu sayısı."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The settlement could not be reconciled."
+msgstr "Hesaplaşma kaydı uzlaştırılamadı."
 
 #. module: marketplace_integration_base
 #. odoo-python
@@ -577,7 +605,7 @@ msgstr "Bu hesaplaşma zaten uzlaştırılmış."
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__cargo_tracking_link
 msgid "Tracking Link"
-msgstr "Takip Linki"
+msgstr "Takip Bağlantısı"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__cargo_tracking_number
@@ -597,16 +625,17 @@ msgstr "İşlem Türü"
 #. module: marketplace_integration_base
 #: model:ir.model,name:marketplace_integration_base.model_stock_picking
 msgid "Transfer"
-msgstr "Teslimat"
+msgstr "Stok Transferi"
 
 #. module: marketplace_integration_base
 #. odoo-python
 #: code:addons/marketplace_integration_base/models/marketplace_order.py:0
 #, python-format
 msgid "UNMAPPED: %(product)s (Qty: %(qty)s, Price: %(price)s)"
-msgstr "EŞLEŞMEMİŞ: %(product)s (Miktar: %(qty)s, Fiyat: %(price)s)"
+msgstr "EŞLEŞMEDİ: %(product)s (Miktar: %(qty)s, Fiyat: %(price)s)"
 
 #. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_account_move_line__user_can_see_changeset
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__user_can_see_changeset
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_order_mixin__user_can_see_changeset
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__user_can_see_changeset
@@ -614,23 +643,9 @@ msgstr "EŞLEŞMEMİŞ: %(product)s (Miktar: %(qty)s, Fiyat: %(price)s)"
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_sale_order_line__user_can_see_changeset
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_stock_picking__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "Kullanıcı Değişiklikleri Görebilir"
+msgstr "Değişiklikleri Görebilir"
 
 #. module: marketplace_integration_base
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__warehouse_ids
 msgid "Warehouses"
 msgstr "Depolar"
-
-#. module: marketplace_integration_base
-#. odoo-python
-#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
-#, python-format
-msgid "Reconciliation Failed"
-msgstr "Uzlaştırma Başarısız"
-
-#. module: marketplace_integration_base
-#. odoo-python
-#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
-#, python-format
-msgid "The settlement could not be reconciled."
-msgstr "Hesaplaşma kaydı uzlaştırılamadı."

--- a/trendyol_integration/i18n/tr.po
+++ b/trendyol_integration/i18n/tr.po
@@ -6,45 +6,45 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 07:17+0000\n"
-"PO-Revision-Date: 2026-04-27 07:17+0000\n"
+"POT-Creation-Date: 2026-09-08 07:30+0000\n"
+"PO-Revision-Date: 2026-09-08 07:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_min_2016a_iscilik
 msgid " kullanılan eski Minimum İşcilik fiyatı TL"
-msgstr "Kullanılan eski minimum işçilik fiyatı TL"
+msgstr "Önceki minimum işçilik bedeli (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__bom_count
 msgid "# Bill of Material"
-msgstr "# Ürün Ağacı"
+msgstr "Ürün Ağacı Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__used_in_bom_count
 msgid "# BoM Where Used"
-msgstr "# Kullanılan Ürün Ağacı"
+msgstr "Kullanıldığı Ürün Ağacı Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__purchase_num_invoiced
 msgid "# Invoiced in Purchase"
-msgstr "# Satınalmada Faturalanan"
+msgstr "Faturalanan Alış Miktarı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__sale_num_invoiced
 msgid "# Invoiced in Sale"
-msgstr "# Satışta Faturalanan"
+msgstr "Faturalanan Satış Miktarı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_variant_count
 msgid "# Product Variants"
-msgstr "# Ürün Varyantları"
+msgstr "Varyant Sayısı"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -63,152 +63,152 @@ msgstr "%d ürün atlandı (zaten bağlı)."
 #. module: trendyol_integration
 #: model:ir.actions.report,print_report_name:trendyol_integration.trendyol_shipping_label_report
 msgid "'Trendyol Label - %s' % (object.name)"
-msgstr "'Trendyol Etiket - %s' % (object.name)"
+msgstr "'Trendyol Etiketi - %s' % (object.name)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_2014
 msgid "2014 Eski Fiyatı TL"
-msgstr "2014 Eski Fiyatı TL"
+msgstr "2014 Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_min_2014_iscilik
 msgid "2014 Min İşçcilik Fiyatı TL"
-msgstr "2014 Min. İşçilik Fiyatı TL"
+msgstr "2014 Min. İşçilik (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_2014_iscilik
 msgid "2014 işçilik Fiyatı TL"
-msgstr "2014 İşçilik Fiyatı TL"
+msgstr "2014 İşçilik Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_2014_iscilik
 msgid "2014 yılında kullanılan birim işçilik fiyatı TL"
-msgstr "2014 yılında kullanılan birim işçilik fiyatı TL"
+msgstr "2014 birim işçilik fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_min_2014_iscilik
 msgid "2014 yılında kullanılan eski Minimum İşçilik fiyatı TL"
-msgstr "2014 yılında kullanılan eski minimum işçilik fiyatı TL"
+msgstr "2014 minimum işçilik bedeli (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_2014
 msgid "2014 yılında kullanılan eski fiyatı TL"
-msgstr "2014 yılında kullanılan eski fiyatı TL"
+msgstr "2014 satış fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_2016a
 msgid "2015 Ekim Fiyatı TL"
-msgstr "2015 Ekim Fiyatı TL"
+msgstr "Ekim 2015 Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_min_2016a_iscilik
 msgid "2015 Ekim Min İscilik TL"
-msgstr "2015 Ekim Min. İşçilik TL"
+msgstr "Ekim 2015 Min. İşçilik (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_2016a_iscilik
 msgid "2015 Ekim birim işçilik fiyatı TL"
-msgstr "2015 Ekim birim işçilik fiyatı TL"
+msgstr "Ekim 2015 birim işçilik fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_2016a
 msgid "2015 Ekim fiyati TL"
-msgstr "2015 Ekim fiyatı TL"
+msgstr "Ekim 2015 fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_2016a_iscilik
 msgid "2015 Ekim isçilik fiyatı TL"
-msgstr "2015 Ekim işçilik fiyatı TL"
+msgstr "Ekim 2015 İşçilik Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_2015a
 msgid "2015 Ocak Eski Fiyatı TL"
-msgstr "2015 Ocak Eski Fiyatı TL"
+msgstr "Ocak 2015 Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_min_2015a_iscilik
 msgid "2015 Ocak Min İşçcilik TL"
-msgstr "2015 Ocak Min. İşçilik TL"
+msgstr "Ocak 2015 Min. İşçilik (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_2015a
 msgid "2015 Ocak eski fiyatı"
-msgstr "2015 Ocak eski fiyatı"
+msgstr "Ocak 2015 fiyatı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_2015a_iscilik
 msgid "2015 Ocak işçilik Fiyatı TL"
-msgstr "2015 Ocak İşçilik Fiyatı TL"
+msgstr "Ocak 2015 İşçilik Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_2015a_iscilik
 msgid "2015 Ocak kullanılan birim işçilik fiyatı"
-msgstr "2015 Ocak kullanılan birim işçilik fiyatı"
+msgstr "Ocak 2015 birim işçilik fiyatı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_min_2015a_iscilik
 msgid "2015 Ocak kullanılan eski Minimum İşçilik fiyatı TL"
-msgstr "2015 Ocak kullanılan eski minimum işçilik fiyatı TL"
+msgstr "Ocak 2015 minimum işçilik bedeli (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_2016b
 msgid "2016 Aralık Fiyatı TL"
-msgstr "2016 Aralık Fiyatı TL"
+msgstr "Aralık 2016 Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_min_2016b_iscilik
 msgid "2016 Aralık Min İsçilik TL"
-msgstr "2016 Aralık Min. İşçilik TL"
+msgstr "Aralık 2016 Min. İşçilik (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_min_2016b_iscilik
 msgid "2016 Aralık Minimum İşçilik fiyatı TL"
-msgstr "2016 Aralık minimum işçilik fiyatı TL"
+msgstr "Aralık 2016 minimum işçilik bedeli (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_2016b_iscilik
 msgid "2016 Aralık birim işçilik fiyatı TL"
-msgstr "2016 Aralık birim işçilik fiyatı TL"
+msgstr "Aralık 2016 birim işçilik fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_2016b
 msgid "2016 Aralık fiyatı TL"
-msgstr "2016 Aralık fiyatı TL"
+msgstr "Aralık 2016 fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_2016b_iscilik
 msgid "2016 Aralık isçilik fiyatı TL"
-msgstr "2016 Aralık işçilik fiyatı TL"
+msgstr "Aralık 2016 İşçilik Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_2017
 msgid "2017 Aralık Fiyatı TL"
-msgstr "2017 Aralık Fiyatı TL"
+msgstr "Aralık 2017 Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_min_2017_iscilik
 msgid "2017 Aralık Min İsçilik TL"
-msgstr "2017 Aralık Min. İşçilik TL"
+msgstr "Aralık 2017 Min. İşçilik (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_min_2017_iscilik
 msgid "2017 Aralık Minimum İşçilik fiyatı TL"
-msgstr "2017 Aralık minimum işçilik fiyatı TL"
+msgstr "Aralık 2017 minimum işçilik bedeli (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_2017_iscilik
 msgid "2017 Aralık birim işçilik fiyatı TL"
-msgstr "2017 Aralık birim işçilik fiyatı TL"
+msgstr "Aralık 2017 birim işçilik fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_2017
 msgid "2017 Aralık fiyatı TL"
-msgstr "2017 Aralık fiyatı TL"
+msgstr "Aralık 2017 fiyatı (TL)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_2017_iscilik
 msgid "2017 Aralık isçilik fiyatı TL"
-msgstr "2017 Aralık işçilik fiyatı TL"
+msgstr "Aralık 2017 İşçilik Fiyatı (TL)"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_sale_order_form_trendyol
@@ -228,7 +228,7 @@ msgid ""
 "                            </span>"
 msgstr ""
 "<span class=\"text-muted\">\n"
-"                                <b>Bilinen Trendyol Kargo Sağlayıcıları:</b><br/>\n"
+"                                <b>Trendyol Kargo Firmaları:</b><br/>\n"
 "                                Kolay Gelsin Marketplace, Ceva Tedarik Marketplace,\n"
 "                                DHL eCommerce Marketplace, PTT Kargo Marketplace,\n"
 "                                Sürat Kargo Marketplace, Trendyol Express Marketplace,\n"
@@ -244,7 +244,7 @@ msgstr "<span>İade Talebi </span>"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.trendyol_shipping_label
 msgid "<strong>Trendyol Order:</strong>"
-msgstr "<strong>Trendyol Sipariş:</strong>"
+msgstr "<strong>Trendyol Siparişi:</strong>"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__description_sale
@@ -253,9 +253,8 @@ msgid ""
 " This description will be copied to every Sales Order, Delivery Order and "
 "Customer Invoice/Credit Note"
 msgstr ""
-"Müşterilerinize iletmek istediğiniz ürün açıklaması. Bu açıklama her Satış "
-"Siparişi, Teslimat Siparişi ve Müşteri Faturası/Alacak Dekontuna "
-"kopyalanacaktır"
+"Müşteriye gösterilecek ürün açıklaması. Satış siparişine, teslimata, müşteri"
+" faturasına ve iade faturasına kopyalanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__detailed_type
@@ -264,21 +263,21 @@ msgid ""
 "A consumable product is a product for which stock is not managed.\n"
 "A service is a non-material product you provide."
 msgstr ""
-"Stoklanabilir ürün, stokunu yönettiğiniz bir üründür. Envanter uygulaması kurulu olmalıdır.\n"
-"Sarf malzeme, stoku yönetilmeyen bir üründür.\n"
-"Hizmet, sağladığınız maddi olmayan bir üründür."
+"Stoklanabilir ürün: Stoku takip edilir; Stok uygulaması gerekir.\n"
+"Sarf malzeme: Stoku takip edilmez.\n"
+"Hizmet: Fiziksel olmayan ürün veya hizmettir."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "A webhook is already registered for this backend."
-msgstr "Bu backend için zaten bir webhook kayıtlı."
+msgstr "Bu entegrasyonda zaten bir webhook kayıtlı."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "API Configuration"
-msgstr "API Yapılandırması"
+msgstr "API Ayarları"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__api_key
@@ -288,7 +287,7 @@ msgstr "API Anahtarı"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__api_secret
 msgid "API Secret"
-msgstr "API Şifresi"
+msgstr "API Gizli Anahtarı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__webhook_api_key
@@ -296,7 +295,7 @@ msgid ""
 "API key that Trendyol sends in x-api-key header when calling the webhook "
 "endpoint."
 msgstr ""
-"Trendyol'un webhook çağrısında x-api-key başlığında gönderdiği API anahtarı."
+"Trendyol'un webhook isteklerinde x-api-key başlığıyla gönderdiği anahtar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__accepted
@@ -315,14 +314,17 @@ msgstr "Erişim uyarısı"
 msgid ""
 "Accessories show up when the customer reviews the cart before payment "
 "(cross-sell strategy)."
-msgstr ""
-"Aksesuarlar, müşteri ödeme yapmadan önce sepeti incelediğinde görünür "
-"(çapraz satış stratejisi)."
+msgstr "Sepette, ödeme öncesinde müşteriye önerilen tamamlayıcı ürünler."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__accessory_product_ids
 msgid "Accessory Products"
 msgstr "Aksesuarlar"
+
+#. module: trendyol_integration
+#: model:ir.model,name:trendyol_integration.model_account_auto_reconcile
+msgid "Account Auto Reconcile"
+msgstr "Otomatik Hesap Uzlaştırma"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__account_tag_ids
@@ -347,7 +349,7 @@ msgstr "İşlem Gerekli"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Activate"
-msgstr "Aktifleştir"
+msgstr "Etkinleştir"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__active
@@ -373,7 +375,7 @@ msgstr "Aktiviteler"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__activity_exception_decoration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__activity_exception_decoration
 msgid "Activity Exception Decoration"
-msgstr "Aktivite İstisna Görünümü"
+msgstr "Aktivite Uyarı Görünümü"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__activity_state
@@ -396,7 +398,7 @@ msgstr "Aktivite Türü Simgesi"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__code_prefix
 msgid "Add prefix to product variant reference (default code)"
-msgstr "Ürün varyantı referansına ön ek ekle (varsayılan kod)"
+msgstr "Varyantın stok koduna ön ek ekler."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__additional_product_tag_ids
@@ -407,12 +409,12 @@ msgstr "Ek Ürün Etiketi"
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__trendyol_address_id
 #: model:ir.model.fields,help:trendyol_integration.field_res_users__trendyol_address_id
 msgid "Address ID from Trendyol for delivery address matching"
-msgstr "Teslimat adresi eşleştirmesi için Trendyol adres ID'si"
+msgstr "Teslimat adresini eşleştirmek için kullanılan Trendyol adres kimliği."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__all_product_tag_ids
 msgid "All Product Tag"
-msgstr "Tüm Ürün Etiketi"
+msgstr "Tüm Ürün Etiketleri"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category_attribute__allow_custom
@@ -432,10 +434,10 @@ msgid ""
 " - 'Base Set Manually' : User should set manually the value of the barcode base\n"
 " - 'Base managed by Sequence': System will generate the base via a sequence"
 msgstr ""
-"Son barkodda bir sayı (taban) içeren barkod oluşturmaya izin verir.\n"
+"Barkodun sayı bölümü elle veya numara dizisiyle belirlenir.\n"
 "\n"
-" - 'Taban Manuel Ayarlama': Kullanıcı barkod tabanının değerini manuel olarak ayarlamalıdır\n"
-" - 'Taban Sıra ile Yönetilir': Sistem tabanı bir sıra aracılığıyla oluşturacaktır"
+"Elle belirle: Barkod tabanını kullanıcı girer.\n"
+"Numara dizisi: Barkod tabanını sistem oluşturur."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__amount_undiscounted
@@ -483,28 +485,26 @@ msgstr "Cevap Gönderildi"
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_question.py:0
 #, python-format
-msgid "Answer Trendyol question: %s"
-msgstr "Trendyol sorusunu yanıtla: %s"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_question.py:0
-#, python-format
 msgid "Answer must be at least 10 characters long."
-msgstr "Cevap en az 10 karakter uzunluğunda olmalıdır."
+msgstr "Cevap en az 10 karakter olmalı."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_question.py:0
 #, python-format
 msgid "Answer must be at most 2000 characters long."
-msgstr "Cevap en fazla 2000 karakter uzunluğunda olmalıdır."
+msgstr "Cevap en fazla 2000 karakter olmalı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__answered
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_search
 msgid "Answered"
 msgstr "Cevaplandı"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_application_ids
+msgid "Applications"
+msgstr "Uygulamalar"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -535,17 +535,17 @@ msgstr "Onaylandı"
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_search
 msgid "Archived"
-msgstr "Arşivlenmiş"
+msgstr "Arşivlendi"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_claim_form
 msgid "Are you sure you want to approve this return claim?"
-msgstr "Bu iade talebini onaylamak istediğinizden emin misiniz?"
+msgstr "Bu iade talebi onaylansın mı?"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_order_form
 msgid "Are you sure you want to cancel this order in Trendyol?"
-msgstr "Bu siparişi Trendyol'da iptal etmek istediğinizden emin misiniz?"
+msgstr "Bu sipariş Trendyol'da iptal edilsin mi?"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__assembly_price
@@ -553,9 +553,18 @@ msgid "Assembly Price"
 msgstr "Montaj Fiyatı"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__assembly_price
+msgid ""
+"Assembly share of the customization price in USD. This is a breakdown field;"
+" sales pricing uses Total Customization Price."
+msgstr ""
+"Montajın özelleştirme bedelindeki payı (USD). Satışta Toplam Özelleştirme "
+"Fiyatı kullanılır."
+
+#. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__at_collection_point
 msgid "At Collection Point"
-msgstr "Toplama Noktasında"
+msgstr "Teslim Alma Noktasında"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__message_attachment_count
@@ -570,7 +579,7 @@ msgstr "Ek Sayısı"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__attr_price
 msgid "Attr. Value Price"
-msgstr "Özellik Değer Fiyatı"
+msgstr "Özellik Değeri Fiyatı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_attribute_value__attribute_id
@@ -592,7 +601,7 @@ msgstr "Özellik Değerleri"
 #: code:addons/trendyol_integration/models/trendyol_category.py:0
 #, python-format
 msgid "Attribute synchronization has been queued."
-msgstr "Özellik senkronizasyonu kuyruğa alındı."
+msgstr "Özellik eşitlemesi kuyruğa alındı."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -647,17 +656,17 @@ msgstr "Faturayı Otomatik Gönder"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Auto Sync"
-msgstr "Otomatik Senkronizasyon"
+msgstr "Otomatik Eşitleme"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__auto_sync_stock
 msgid "Auto Sync Stock"
-msgstr "Stoku Otomatik Senkronize Et"
+msgstr "Stoku Otomatik Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__auto_sync_tracking
 msgid "Auto Sync Tracking"
-msgstr "Takibi Otomatik Senkronize Et"
+msgstr "Kargo Takibini Otomatik Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__auto_confirm_orders
@@ -672,51 +681,48 @@ msgstr "Otomatik Yeniden Sipariş Kuralları"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_confirm_orders
 msgid "Automatically confirm imported orders"
-msgstr "İçe aktarılan siparişleri otomatik olarak onayla"
+msgstr "İçe aktarılan siparişleri otomatik onaylar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_import_questions
 msgid "Automatically import customer questions via scheduled job"
-msgstr "Müşteri sorularını zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Müşteri sorularını zamanlanmış görevle içe aktarır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_import_settlements
 msgid "Automatically import financial settlements via scheduled job"
-msgstr ""
-"Finansal hesaplaşmaları zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Hesaplaşmaları zamanlanmış görevle içe aktarır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_import_orders
 msgid "Automatically import orders via scheduled job"
-msgstr "Siparişleri zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "Siparişleri zamanlanmış görevle içe aktarır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_import_claims
 msgid "Automatically import returns/claims via scheduled job"
-msgstr "İade/talepleri zamanlanmış görev ile otomatik olarak içe aktar"
+msgstr "İade taleplerini zamanlanmış görevle içe aktarır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_reconcile_settlements
 msgid "Automatically reconcile imported settlements with invoices"
-msgstr "İçe aktarılan hesaplaşmaları faturalarla otomatik olarak uzlaştır"
+msgstr "İçe aktarılan hesaplaşmaları faturalarla otomatik uzlaştırır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_sync_tracking
 msgid "Automatically send tracking numbers when delivery is done"
-msgstr "Teslimat tamamlandığında takip numaralarını otomatik olarak gönder"
+msgstr "Teslimat tamamlanınca takip numaralarını otomatik gönderir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_sync_stock
 msgid "Automatically sync stock levels via scheduled job"
-msgstr "Stok seviyelerini zamanlanmış görev ile otomatik olarak senkronize et"
+msgstr "Stok miktarlarını zamanlanmış görevle eşitler."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_prices_auto_update
 msgid ""
 "Automatically update customization prices when customization lines change."
-msgstr ""
-"Özelleştirme satırları değiştiğinde özelleştirme fiyatlarını otomatik olarak"
-" güncelle."
+msgstr "Özelleştirme satırları değişince fiyatları otomatik günceller."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__trendyol_quantity
@@ -736,20 +742,19 @@ msgid ""
 "case the product is subcontracted, this can be used to determine the date at"
 " which components should be sent to the subcontractor."
 msgstr ""
-"Bu ürünü üretmek için ortalama teslim süresi (gün). Çok seviyeli ürün ağacı "
-"durumunda, bileşenlerin üretim teslim süreleri eklenecektir. Ürün fason "
-"üretim ise, bu değer bileşenlerin fason üreticiye gönderilmesi gereken "
-"tarihi belirlemek için kullanılabilir."
+"Üretim süresi (gün). Çok seviyeli ürün ağaçlarında bileşenlerin üretim "
+"süreleri eklenir. Fason üretimde, bileşenlerin gönderim tarihini belirlemek "
+"için de kullanılır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__sale_avg_price
 msgid "Avg. Price in Customer Invoices."
-msgstr "Müşteri Faturalarındaki Ort. Fiyat."
+msgstr "Müşteri faturalarındaki ortalama birim fiyat."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__purchase_avg_price
 msgid "Avg. Price in Vendor Bills"
-msgstr "Tedarikçi Faturalarındaki Ort. Fiyat"
+msgstr "Tedarikçi faturalarındaki ortalama birim fiyat."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__purchase_avg_price
@@ -764,12 +769,12 @@ msgstr "Ort. Satış Birim Fiyatı"
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__awaiting
 msgid "Awaiting"
-msgstr "Bekliyor"
+msgstr "Ödeme Onayı Bekliyor"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__variant_bom_ids
 msgid "BOM Product Variants"
-msgstr "Ürün Ağacı Ürün Varyantları"
+msgstr "Ürün Ağacı Varyantları"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_batch_request__backend_id
@@ -792,17 +797,17 @@ msgstr "Ürün Ağacı Ürün Varyantları"
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_search
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_search
 msgid "Backend"
-msgstr "Arka Uç"
+msgstr "Entegrasyon"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Backend Name"
-msgstr "Backend Adı"
+msgstr "Entegrasyon Adı"
 
 #. module: trendyol_integration
 #: model:ir.ui.menu,name:trendyol_integration.menu_trendyol_backends
 msgid "Backends"
-msgstr "Backend'ler"
+msgstr "Entegrasyonlar"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim_line__barcode
@@ -824,12 +829,12 @@ msgstr "Barkod Kuralı"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__valid_ean
 msgid "Barcode is valid EAN"
-msgstr "Barkod geçerli EAN"
+msgstr "Geçerli EAN Barkodu"
 
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_product_binding_barcode_backend_uniq
 msgid "Barcode must be unique per backend!"
-msgstr "Barkod her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu barkod zaten kullanılıyor."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__trendyol_barcode
@@ -839,22 +844,22 @@ msgstr "Trendyol'da kullanılan barkod (genellikle Odoo barkoduyla aynı)"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_baski
 msgid "Baski Depo Mevcut"
-msgstr "Baskı Depo Mevcut"
+msgstr "Baskı Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_baski
 msgid "Baski Depo Rezervesiz"
-msgstr "Baskı Depo Rezervesiz"
+msgstr "Baskı Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_baski
 msgid "Baski Depo Tahmini"
-msgstr "Baskı Depo Tahmini"
+msgstr "Baskı Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_batch_request__batch_request_id
 msgid "Batch Request ID"
-msgstr "Toplu İstek ID"
+msgstr "Toplu İstek No."
 
 #. module: trendyol_integration
 #: model:ir.actions.act_window,name:trendyol_integration.action_trendyol_batch_request
@@ -865,7 +870,7 @@ msgstr "Toplu İstekler"
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_batch_request_batch_request_id_backend_uniq
 msgid "Batch request ID must be unique per backend!"
-msgstr "Toplu istek ID her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu toplu istek numarası zaten kullanılıyor."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -897,7 +902,7 @@ msgstr "Bağlantılar Oluşturuldu"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_iscilik_fiyat
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_tl_fiyat
 msgid "Birim işçilik Fiyatı USD"
-msgstr "Birim İşçilik Fiyatı USD"
+msgstr "Birim İşçilik Fiyatı (USD)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__block_autoinvoicing
@@ -912,17 +917,17 @@ msgstr "Ürün Ağacı Bileşenleri"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_boya
 msgid "Boya Depo Mevcut"
-msgstr "Boya Depo Mevcut"
+msgstr "Boya Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_boya
 msgid "Boya Depo Rezervesiz"
-msgstr "Boya Depo Rezervesiz"
+msgstr "Boya Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_boya
 msgid "Boya Depo Tahmini"
-msgstr "Boya Depo Tahmini"
+msgstr "Boya Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_brand_id
@@ -935,12 +940,19 @@ msgstr "Marka"
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Brand synchronization has been queued."
-msgstr "Marka senkronizasyonu kuyruğa alındı."
+msgstr "Marka eşitlemesi kuyruğa alındı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Brand synchronization page limit reached."
+msgstr "Marka eşitlemesinde sayfa sınırına ulaşıldı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_export_wizard__trendyol_brand_id
 msgid "Brand to use for all selected products (optional)"
-msgstr "Tüm seçili ürünler için kullanılacak marka (opsiyonel)"
+msgstr "Seçili ürünlere atanacak marka (isteğe bağlı)."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -953,22 +965,31 @@ msgstr "Markalar"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_guncel_fiyat
 msgid "Bu seçenek seçili ise fiyatı yenidir."
-msgstr "Bu seçenek seçili ise fiyat yenidir."
+msgstr "Seçiliyse ürünün fiyatı günceldir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_cnc
 msgid "CNC Depo Mevcut"
-msgstr "CNC Depo Mevcut"
+msgstr "CNC Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_cnc
 msgid "CNC Depo Rezervesiz"
-msgstr "CNC Depo Rezervesiz"
+msgstr "CNC Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_cnc
 msgid "CNC Depo Tahmini"
-msgstr "CNC Depo Tahmini"
+msgstr "CNC Deposu — Tahmini Stok"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__cnc_price
+msgid ""
+"CNC share of the customization price in USD. This is a breakdown field; "
+"sales pricing uses Total Customization Price."
+msgstr ""
+"CNC işleminin özelleştirme bedelindeki payı (USD). Satışta Toplam "
+"Özelleştirme Fiyatı kullanılır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__campaign_id
@@ -983,12 +1004,12 @@ msgstr "Ürün Oluşturabilir"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__can_image_1024_be_zoomed
 msgid "Can Image 1024 be zoomed"
-msgstr "1024 Görsel yakınlaştırılabilir mi"
+msgstr "Ürün Görseli Büyütülebilir"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__can_image_variant_1024_be_zoomed
 msgid "Can Variant Image 1024 be zoomed"
-msgstr "1024 Varyant Görseli yakınlaştırılabilir mi"
+msgstr "Varyant Görseli Büyütülebilir"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__purchase_ok
@@ -1053,12 +1074,12 @@ msgstr "Kargo Eşleştirmeleri"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim__cargo_provider_name
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__cargo_provider_name
 msgid "Cargo Provider"
-msgstr "Kargo Sağlayıcı"
+msgstr "Kargo Firması"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__cargo_provider_id
 msgid "Cargo Provider ID"
-msgstr "Kargo Sağlayıcı ID"
+msgstr "Kargo Firması No."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim__cargo_sender_number
@@ -1068,7 +1089,7 @@ msgstr "Kargo Gönderici Numarası"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_cargo_mapping__trendyol_cargo_provider_name
 msgid "Cargo provider name from Trendyol API (cargoProviderName)"
-msgstr "Trendyol API'den gelen kargo sağlayıcı adı (cargoProviderName)"
+msgstr "Trendyol API'sindeki kargo firması adı (cargoProviderName)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__carrier_payment_type
@@ -1104,15 +1125,16 @@ msgstr "Kategori Rotaları"
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Category synchronization has been queued."
-msgstr "Kategori senkronizasyonu kuyruğa alındı."
+msgstr "Kategori eşitlemesi kuyruğa alındı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_export_wizard__trendyol_category_id
 msgid "Category to use for all selected products (optional)"
-msgstr "Tüm seçili ürünler için kullanılacak kategori (opsiyonel)"
+msgstr "Seçili ürünlere atanacak kategori (isteğe bağlı)."
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__changeset_change_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__changeset_change_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__changeset_change_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__changeset_change_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__changeset_change_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__changeset_change_ids
@@ -1135,10 +1157,11 @@ msgstr "Tüm seçili ürünler için kullanılacak kategori (opsiyonel)"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__changeset_change_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__changeset_change_ids
 msgid "Changeset Changes"
-msgstr "Changeset Değişiklikleri"
+msgstr "Değişiklik Kayıtları"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__changeset_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__changeset_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__changeset_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__changeset_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__changeset_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__changeset_ids
@@ -1161,7 +1184,7 @@ msgstr "Changeset Değişiklikleri"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__changeset_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__changeset_ids
 msgid "Changesets"
-msgstr "Değişiklikler"
+msgstr "Değişiklik Grupları"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -1209,7 +1232,7 @@ msgstr "İade Talebi Tarihi"
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_claim_claim_id_backend_uniq
 msgid "Claim ID must be unique per backend!"
-msgstr "İade talep ID her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu iade talebi numarası zaten kullanılıyor."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_claim_form
@@ -1237,7 +1260,7 @@ msgstr "İade talebi onayı kuyruğa alındı."
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_claim__auto_accepted
 msgid "Claim was automatically accepted after 48 hours"
-msgstr "İade talebi 48 saat sonra otomatik olarak kabul edildi"
+msgstr "İade talebi 48 saat sonunda otomatik kabul edildi."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -1260,7 +1283,14 @@ msgstr "İade Talepleri / İadeler"
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Claims import has been queued."
-msgstr "İade talebi içe aktarımı kuyruğa alındı."
+msgstr "İade talepleri içe aktarma kuyruğuna alındı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Claims import page limit reached."
+msgstr "İade aktarımında sayfa sınırına ulaşıldı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__cnc_price
@@ -1284,6 +1314,34 @@ msgid "Commission Amount"
 msgstr "Komisyon Tutarı"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr "Komisyon Faturası"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr "Komisyon Fatura No."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr "Komisyon Uzlaştırma Notu"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr "Komisyon Uzlaştırma Durumu"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+#, python-format
+msgid "Commission Matching"
+msgstr "Komisyon Uzlaştırma"
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_payment_id
 msgid "Commission Payment"
 msgstr "Komisyon Ödemesi"
@@ -1292,6 +1350,32 @@ msgstr "Komisyon Ödemesi"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_rate
 msgid "Commission Rate"
 msgstr "Komisyon Oranı"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matched to the referenced vendor document."
+msgstr "Komisyon, ilgili tedarikçi belgesiyle uzlaştırıldı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matching is pending."
+msgstr "Komisyon uzlaştırması bekliyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Commission payment %(payment)s for Trendyol orders %(orders)s was reconciled"
+" with this invoice."
+msgstr ""
+"Trendyol siparişleri: %(orders)s. %(payment)s komisyon ödemesi bu faturayla "
+"uzlaştırıldı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__company_id
@@ -1316,12 +1400,12 @@ msgstr "Tamamlandı"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__effective_date
 msgid "Completion date of the first delivery order."
-msgstr "İlk teslimat siparişinin tamamlanma tarihi."
+msgstr "İlk teslimatın tamamlandığı tarih."
 
 #. module: trendyol_integration
 #: model:ir.ui.menu,name:trendyol_integration.menu_trendyol_config
 msgid "Configuration"
-msgstr "Yapılandırma"
+msgstr "Ayarlar"
 
 #. module: trendyol_integration
 #: model_terms:ir.actions.act_window,help:trendyol_integration.action_trendyol_backend
@@ -1329,13 +1413,12 @@ msgid ""
 "Configure API credentials and sync settings to connect your Odoo instance "
 "with Trendyol marketplace."
 msgstr ""
-"Odoo örneğinizi Trendyol pazaryerine bağlamak için API kimlik bilgilerini ve"
-" senkronizasyon ayarlarını yapılandırın."
+"Trendyol bağlantısı için API bilgilerini ve eşitleme ayarlarını girin."
 
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_res_partner
 msgid "Contact"
-msgstr "İletişim"
+msgstr "İlgili Kişi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__purchase_method
@@ -1358,7 +1441,8 @@ msgid "Costing Method"
 msgstr "Maliyetlendirme Yöntemi"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__count_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__count_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__count_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__count_changesets
@@ -1381,10 +1465,11 @@ msgstr "Maliyetlendirme Yöntemi"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__count_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__count_changesets
 msgid "Count Changesets"
-msgstr "Sayım Değişiklik Setleri"
+msgstr "Değişiklik Grubu Sayısı"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__count_pending_changeset_changes
@@ -1407,10 +1492,11 @@ msgstr "Sayım Değişiklik Setleri"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__count_pending_changeset_changes
 msgid "Count Pending Changeset Changes"
-msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
+msgstr "Bekleyen Değişiklik Sayısı"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__count_pending_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__count_pending_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__count_pending_changesets
@@ -1433,17 +1519,17 @@ msgstr "Bekleyen Değişiklik Seti Değişikliklerini Say"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__count_pending_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__count_pending_changesets
 msgid "Count Pending Changesets"
-msgstr "Bekleyen Değişiklik Setlerini Say"
+msgstr "Bekleyen Değişiklik Grubu Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__mrp_production_count
 msgid "Count of MO generated"
-msgstr "Oluşturulan Üretim Emri sayısı"
+msgstr "Üretim Emri Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__state_id
 msgid "Country State of Origin"
-msgstr "Menşe Ülke İli"
+msgstr "Menşe İli/Eyaleti"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__country_code
@@ -1459,7 +1545,7 @@ msgstr "Menşe Ülke"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__origin_country_id
 msgid "Country of origin of the product i.e. product 'made in ____'."
-msgstr "Ürünün menşe ülkesi, yani ürün '____'da üretilmiştir."
+msgstr "Ürünün üretildiği ülke."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_export_wizard_form
@@ -1482,8 +1568,8 @@ msgid ""
 "Create and confirm Manufacturing Orders this many days in advance, to have enough time to replenish components or manufacture semi-finished products.\n"
 "Note that security lead times will also be considered when appropriate."
 msgstr ""
-"Bileşenleri tedarik etmek veya yarı mamul ürünleri üretmek için yeterli zaman bırakarak Üretim Emirlerini bu kadar gün önceden oluşturun ve onaylayın.\n"
-"Uygun olduğunda güvenlik teslim süreleri de dikkate alınacaktır."
+"Bileşen tedariki ve yarı mamul üretimi için üretim emirlerini belirtilen gün"
+" kadar erken oluşturup onaylar. Uygun güvenlik süreleri de hesaba katılır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__service_tracking
@@ -1498,12 +1584,12 @@ msgstr "Ürünü şimdi oluştur!"
 #. module: trendyol_integration
 #: model_terms:ir.actions.act_window,help:trendyol_integration.action_trendyol_backend
 msgid "Create your first Trendyol backend"
-msgstr "İlk Trendyol backend'inizi oluşturun"
+msgstr "Trendyol entegrasyonunu kurun"
 
 #. module: trendyol_integration
 #: model_terms:ir.actions.act_window,help:trendyol_integration.action_trendyol_product_binding
 msgid "Create your first Trendyol product binding"
-msgstr "İlk Trendyol ürün bağlantınızı oluşturun"
+msgstr "İlk Trendyol ürün bağlantısını oluşturun"
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__created
@@ -1556,7 +1642,7 @@ msgstr "Oluşturan"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__create_date
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__create_date
 msgid "Created on"
-msgstr "Oluşturulma"
+msgstr "Oluşturulma Tarihi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__date_order
@@ -1564,8 +1650,8 @@ msgid ""
 "Creation date of draft/sent orders,\n"
 "Confirmation date of confirmed orders."
 msgstr ""
-"Taslak/gönderilen siparişlerin oluşturulma tarihi,\n"
-"Onaylanan siparişlerin onay tarihi."
+"Taslak ve gönderilen tekliflerde oluşturulma tarihi; onaylı siparişlerde "
+"onay tarihi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__credit
@@ -1592,10 +1678,8 @@ msgid ""
 "stored in the Stock Location of the Warehouse of this Shop, or any of its children.\n"
 "Otherwise, this includes goods stored in any Stock Location with 'internal' type."
 msgstr ""
-"Ürünlerin mevcut miktarı.\n"
-"Tek bir Stok Konumu bağlamında, bu konumda veya alt konumlarında depolanan malları içerir.\n"
-"Tek bir Depo bağlamında, bu Deponun Stok Konumunda veya alt konumlarında depolanan malları içerir.\n"
-"Aksi takdirde, 'dahili' türündeki herhangi bir Stok Konumunda depolanan malları içerir."
+"Mevcut stok miktarı. Seçili konum/depo ve alt konumları kapsar; seçim yoksa "
+"tüm iç konumlar hesaplanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__current_revision_id
@@ -1615,13 +1699,13 @@ msgstr "Müşteri"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__trendyol_customer_id
 msgid "Customer ID"
-msgstr "Müşteri ID"
+msgstr "Müşteri No."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__trendyol_customer_id
 #: model:ir.model.fields,help:trendyol_integration.field_res_users__trendyol_customer_id
 msgid "Customer ID from Trendyol marketplace"
-msgstr "Trendyol pazaryerinden müşteri ID"
+msgstr "Trendyol'daki müşteri kimliği."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__sale_delay
@@ -1634,15 +1718,22 @@ msgid "Customer Name"
 msgstr "Müşteri Adı"
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Customer Payment Reconciled"
+msgstr "Müşteri Tahsilatı Uzlaştırıldı"
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__access_url
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__access_url
 msgid "Customer Portal URL"
-msgstr "Müşteri Portal URL"
+msgstr "Müşteri Portalı Adresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim_line__customer_reason
 msgid "Customer Reason"
-msgstr "Müşteri Nedeni"
+msgstr "Müşterinin İade Nedeni"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__partner_ref
@@ -1670,8 +1761,23 @@ msgid ""
 "Customer questions will appear here when imported from Trendyol.\n"
 "                Configure auto-import in backend settings or click \"Import Questions\" manually."
 msgstr ""
-"Trendyol'dan içe aktarıldığında müşteri soruları burada görüntülenecektir.\n"
-"                Backend ayarlarından otomatik içe aktarmayı yapılandırın veya manuel olarak \"Soruları İçe Aktar\" butonuna tıklayın."
+"Sorular Trendyol’dan alınır. Entegrasyon ayarlarından otomatik aktarımı açın"
+" veya \"Soruları İçe Aktar\"ı kullanın."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_attribute_value_id
+msgid "Customization Attribute Value"
+msgstr "Özelleştirme Özellik Değeri"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_base_product_id
+msgid "Customization Base Product"
+msgstr "Özelleştirilen Ana Ürün"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_flow_report_available
+msgid "Customization Flow Report Available"
+msgstr "Özelleştirme Akış Raporu Var"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_line_ids
@@ -1679,9 +1785,24 @@ msgid "Customization Lines"
 msgstr "Özelleştirme Satırları"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_mrp_signature
+msgid "Customization Mrp Signature"
+msgstr "Üretim Yapısı İmzası"
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_prices_auto_update
 msgid "Customization Prices Auto Update"
-msgstr "Özelleştirme Fiyatları Otomatik Güncelleme"
+msgstr "Özelleştirme Fiyatını Otomatik Güncelle"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_request_id
+msgid "Customization Request"
+msgstr "Özelleştirme Talebi"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__total_customization_price
+msgid "Customization surcharge used by sales pricing, in USD."
+msgstr "Satış fiyatına eklenen toplam özelleştirme bedeli (USD)."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_batch_request_search
@@ -1696,7 +1817,7 @@ msgstr "Müşterinin iade talep ettiği tarih"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__days_to_prepare_mo
 msgid "Days to prepare Manufacturing Order"
-msgstr "Üretim Emri Hazırlama Günleri"
+msgstr "Üretim Hazırlık Süresi (Gün)"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
@@ -1739,13 +1860,13 @@ msgid ""
 "Default ZPL label printer for Trendyol shipping labels. Used when the "
 "delivery carrier has no printer configured."
 msgstr ""
-"Trendyol kargo etiketleri için varsayılan ZPL etiket yazıcı. Nakliye "
-"firmasının yapılandırılmış yazıcısı olmadığında kullanılır."
+"Kargo firmasında yazıcı seçilmemişse Trendyol etiketleri için bu ZPL yazıcı "
+"kullanılır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__default_cargo_company_id
 msgid "Default delivery carrier for Trendyol orders"
-msgstr "Trendyol siparişleri için varsayılan nakliye firması"
+msgstr "Trendyol siparişlerinde kullanılacak varsayılan kargo firması."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__fiscal_position_id
@@ -1778,13 +1899,13 @@ msgid ""
 "Default unit of measure used for purchase orders. It must be in the same "
 "category as the default unit of measure."
 msgstr ""
-"Satınalma siparişlerinde kullanılan varsayılan ölçü birimi. Varsayılan ölçü "
-"birimi ile aynı kategoride olmalıdır."
+"Satınalma ölçü birimi. Ürünün varsayılan ölçü birimiyle aynı kategoride "
+"olmalıdır."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Delete Webhook"
-msgstr "Webhook Sil"
+msgstr "Webhook'u Sil"
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__delivered
@@ -1800,7 +1921,7 @@ msgstr "Teslimat Adresi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_cargo_mapping__carrier_id
 msgid "Delivery Carrier"
-msgstr "Nakliye Firması"
+msgstr "Kargo Firması"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__commitment_date
@@ -1820,22 +1941,22 @@ msgstr "Teslimat Yöntemi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__delivery_count
 msgid "Delivery Orders"
-msgstr "Teslimat Siparişleri"
+msgstr "Teslimatlar"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__delivery_price_try
 msgid "Delivery Price (TRY)"
-msgstr "Teslimat Fiyatı (TRY)"
+msgstr "Kargo Ücreti (TL)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__delivery_rating_success
 msgid "Delivery Rating Success"
-msgstr "Teslimat Derecelendirme Başarılı"
+msgstr "Kargo Ücreti Hesaplandı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__delivery_set
 msgid "Delivery Set"
-msgstr "Teslimat Seti"
+msgstr "Kargo Satırı Eklendi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__delivery_status
@@ -1845,7 +1966,7 @@ msgstr "Teslimat Durumu"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__recompute_delivery_price
 msgid "Delivery cost should be recomputed"
-msgstr "Teslimat maliyeti yeniden hesaplanmalı"
+msgstr "Kargo ücreti yeniden hesaplanmalı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__expected_date
@@ -1855,10 +1976,8 @@ msgid ""
 "shipping, the shipping policy of the order will be taken into account to "
 "either use the minimum or maximum lead time of the order lines."
 msgstr ""
-"Müşteriye taahhüt edebileceğiniz teslimat tarihi, Hizmet ürünleri durumunda "
-"sipariş satırlarının minimum teslim süresinden hesaplanır. Nakliye "
-"durumunda, minimum veya maksimum teslim süresini kullanmak için siparişin "
-"nakliye politikası dikkate alınacaktır."
+"Taahhüt edilebilir teslimat tarihi. Hizmetlerde en kısa süre kullanılır; "
+"sevkiyatta teslimat politikasına göre en kısa veya en uzun süre esas alınır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__sale_delay
@@ -1866,8 +1985,7 @@ msgid ""
 "Delivery lead time, in days. It's the number of days, promised to the "
 "customer, between the confirmation of the sales order and the delivery."
 msgstr ""
-"Teslimat süresi (gün). Satış siparişinin onayı ile teslimat arasında "
-"müşteriye taahhüt edilen gün sayısıdır."
+"Sipariş onayından teslimata kadar müşteriye taahhüt edilen süre (gün)."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__description
@@ -1878,12 +1996,12 @@ msgstr "Açıklama"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__public_description
 msgid "Description for e-Commerce"
-msgstr "E-Commerce için Açıklama"
+msgstr "E-Ticaret Açıklaması"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__description_pickingout
 msgid "Description on Delivery Orders"
-msgstr "Teslimat Siparişlerinde Açıklama"
+msgstr "Teslimat Açıklaması"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__description_picking
@@ -1893,7 +2011,12 @@ msgstr "Transferde Açıklama"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__description_pickingin
 msgid "Description on Receptions"
-msgstr "Teslim Almada Açıklama"
+msgstr "Mal Kabul Açıklaması"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_feature_ids
+msgid "Design Features"
+msgstr "Tasarım Özellikleri"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__destination_port
@@ -1903,7 +2026,7 @@ msgstr "Varış limanı"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__website_sequence
 msgid "Determine the display order in the Website E-commerce"
-msgstr "Website E-ticaret görünüm sırasını ayarla"
+msgstr "E-ticaret sitesindeki sıralamayı belirler."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__dimensional_uom_id
@@ -1942,12 +2065,12 @@ msgstr "Dolar Fiyatı"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_dolar
 msgid "Dolarla satılan ürünlerin fiyatı"
-msgstr "Dolarla satılan ürünlerin fiyatı"
+msgstr "Dolar cinsinden satış fiyatı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__domain_attribute_value_ids
 msgid "Domain Attribute Value"
-msgstr "Etki Alanı Özellik Değeri"
+msgstr "Seçilebilir Özellik Değerleri"
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_product_binding__sync_state__draft
@@ -1963,27 +2086,32 @@ msgstr "Geçerlilik Tarihi"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_min_iscilik_fiy
 msgid "En Az Toplam işçilik Fiyatı USD"
-msgstr "En Az Toplam İşçilik Fiyatı USD"
+msgstr "Minimum Toplam İşçilik (USD)"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_type_ids
+msgid "Enclosure Types"
+msgstr "Kutu Türleri"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_enjeksiyon
 msgid "Enjeksiyon Depo Mevcut"
-msgstr "Enjeksiyon Depo Mevcut"
+msgstr "Enjeksiyon Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_enjeksiyon
 msgid "Enjeksiyon Depo Rezervesiz"
-msgstr "Enjeksiyon Depo Rezervesiz"
+msgstr "Enjeksiyon Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_enjeksiyon
 msgid "Enjeksiyon Depo Tahmini"
-msgstr "Enjeksiyon Depo Tahmini"
+msgstr "Enjeksiyon Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__tracking
 msgid "Ensure the traceability of a storable product in your warehouse."
-msgstr "Deponuzda stoklanabilir bir ürünün izlenebilirliğini sağlayın."
+msgstr "Stoklanabilir ürünleri depoda izlemeyi sağlar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__environment
@@ -2029,7 +2157,7 @@ msgstr "Euro Fiyatı"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_euro
 msgid "Euro ile satılırken kullanılan temel fiyat"
-msgstr "Euro ile satılırken kullanılan temel fiyat"
+msgstr "Euro cinsinden satışta kullanılan temel fiyat."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__exception_ids
@@ -2088,14 +2216,13 @@ msgid ""
 " a validated expense can be re-invoice to a customer at its cost or sales "
 "price."
 msgstr ""
-"Giderler ve tedarikçi faturaları müşteriye yeniden faturalanabilir. Bu "
-"seçenekle, onaylanmış bir gider maliyet veya satış fiyatından müşteriye "
-"yeniden faturalanabilir."
+"Gider ve tedarikçi faturalarını müşteriye yansıtma yöntemi. Onaylı giderler "
+"maliyet veya satış fiyatıyla faturalanabilir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__validity_date
 msgid "Expiration"
-msgstr "Son Kullanma"
+msgstr "Geçerlilik Sonu"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_export_wizard_form
@@ -2131,7 +2258,7 @@ msgstr "Ek Kategoriler"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_batch_request__fail_count
 msgid "Fail Count"
-msgstr "Başarısız Sayısı"
+msgstr "Başarısız İşlem Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_batch_request__state__failed
@@ -2154,28 +2281,28 @@ msgstr "Başarısız Mesajlar"
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Failed to activate webhook: %s"
-msgstr "Webhook aktifleştirme başarısız: %s"
+msgstr "Webhook etkinleştirilemedi: %s"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Failed to deactivate webhook: %s"
-msgstr "Webhook devre dışı bırakma başarısız: %s"
+msgstr "Webhook devre dışı bırakılamadı: %s"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Failed to delete webhook: %s"
-msgstr "Webhook silme başarısız: %s"
+msgstr "Webhook silinemedi: %s"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Failed to register webhook: %s"
-msgstr "Webhook kayıt başarısız: %s"
+msgstr "Webhook kaydedilemedi: %s"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -2190,8 +2317,8 @@ msgid ""
 "Fallback product for unmapped Trendyol items. If not set, unmapped items "
 "will be created as note lines."
 msgstr ""
-"Eşleştirilmemiş Trendyol ürünleri için yedek ürün. Ayarlanmamışsa, "
-"eşleştirilmemiş ürünler not satırı olarak oluşturulur."
+"Eşleşmeyen Trendyol ürünleri için kullanılacak ürün. Seçilmezse bu ürünler "
+"not satırı olarak eklenir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__account_move_line_ids
@@ -2216,13 +2343,22 @@ msgstr "FedEx Gönderi Amacı"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__website_attachment_ids
 msgid "Files publicly downloadable from the product eCommerce page."
-msgstr "Websitesinden indirilebilen dosyalar."
+msgstr "Ürünün e-ticaret sayfasından herkese açık indirilebilen dosyalar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__carrier_id
 msgid "Fill this field if you plan to invoice the shipping based on picking."
+msgstr "Sevkiyata göre kargo ücreti faturalandırılacaksa doldurun."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_request_id
+msgid ""
+"Final customized product that owns this component. Only set on legacy staged"
+" component variants; new structures no longer generate component variants."
 msgstr ""
-"Nakliyeyi transfere göre faturalamayı planlıyorsanız bu alanı doldurun."
+"Bu bileşenin ait olduğu özelleştirilmiş son ürün. Yalnızca eski aşamalı "
+"bileşen varyantlarında kullanılır; yeni yapılarda bileşen varyantı "
+"oluşturulmaz."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
@@ -2247,9 +2383,8 @@ msgid ""
 "customers or sales orders/invoices.The default value comes from the "
 "customer."
 msgstr ""
-"Mali koşullar, belirli müşteriler veya satış siparişleri/faturalar için "
-"vergileri ve hesapları uyarlamak için kullanılır. Varsayılan değer "
-"müşteriden gelir."
+"Vergi ve hesapları müşteriye veya siparişe göre uyarlar. Varsayılan değer "
+"müşteri kaydından gelir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_guncel_fiyat
@@ -2293,10 +2428,8 @@ msgid ""
 "In a context with a single Warehouse, this includes goods stored in the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods stored in any Stock Location with 'internal' type."
 msgstr ""
-"Tahmini miktar (Eldeki Miktar - Çıkan + Gelen olarak hesaplanır)\n"
-"Tek bir Stok Konumu bağlamında, bu konumda veya alt konumlarında depolanan malları içerir.\n"
-"Tek bir Depo bağlamında, bu Deponun Stok Konumunda veya alt konumlarında depolanan malları içerir.\n"
-"Aksi takdirde, 'dahili' türündeki herhangi bir Stok Konumunda depolanan malları içerir."
+"Tahmini stok = mevcut − çıkacak + gelecek. Seçili konum/depo ve alt "
+"konumları kapsar; seçim yoksa tüm iç konumlar hesaplanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__free_qty
@@ -2306,10 +2439,8 @@ msgid ""
 "In a context with a single Warehouse, this includes goods stored in the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods stored in any Stock Location with 'internal' type."
 msgstr ""
-"Tahmini miktar (Eldeki Miktar - rezerve edilmiş miktar olarak hesaplanır)\n"
-"Tek bir Stok Konumu bağlamında, bu konumda veya alt konumlarında depolanan malları içerir.\n"
-"Tek bir Depo bağlamında, bu Deponun Stok Konumunda veya alt konumlarında depolanan malları içerir.\n"
-"Aksi takdirde, 'dahili' türündeki herhangi bir Stok Konumunda depolanan malları içerir."
+"Kullanılabilir stok = mevcut − ayrılan. Seçili konum/depo ve alt konumları "
+"kapsar; seçim yoksa tüm iç konumlar hesaplanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__virtual_available
@@ -2319,7 +2450,7 @@ msgstr "Tahmini Miktar"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__free_qty
 msgid "Free To Use Quantity "
-msgstr "Serbest Kullanım Miktarı "
+msgstr "Kullanılabilir Miktar"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category__full_path
@@ -2327,19 +2458,38 @@ msgid "Full Path"
 msgstr "Tam Yol"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_mrp_enabled
+msgid "Generate Customization Manufacturing"
+msgstr "Özelleştirme Üretim Yapısını Oluştur"
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__generate_type
 msgid "Generate Type"
 msgstr "Oluşturma Türü"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_mrp_enabled
+msgid ""
+"Generate staged component variants and BoMs when a customized variant of "
+"this template is approved."
+msgstr ""
+"Özelleştirilmiş varyant onaylandığında aşamalı bileşen varyantlarını ve ürün"
+" ağaçlarını oluşturur."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__generated_customization_bom_ids
+msgid "Generated Customization BoMs"
+msgstr "Özelleştirme Ürün Ağaçları"
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__packaging_ids
 msgid "Gives the different ways to package the same product."
-msgstr "Aynı ürünü paketlemenin farklı yollarını verir."
+msgstr "Aynı ürünün farklı paketleme seçenekleri."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__sequence
 msgid "Gives the sequence order when displaying a product list"
-msgstr "Ürün listesi görüntülenirken sıralama düzenini verir"
+msgstr "Ürün listesindeki sıralamayı belirler."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_search
@@ -2381,9 +2531,8 @@ msgid ""
 "Organisation, see http://www.wcoomd.org/. You can leave this field empty and"
 " configure the H.S. code on the product category."
 msgstr ""
-"G.T.İ.P. Kodu. Nomenklatür Dünya Gümrük Örgütü'nden edinilebilir, bkz. "
-"http://www.wcoomd.org/. Bu alanı boş bırakıp G.T.İ.P. kodunu ürün "
-"kategorisinde yapılandırabilirsiniz."
+"G.T.İ.P. kodu. Kod listesi: http://www.wcoomd.org/. Boş bırakılırsa ürün "
+"kategorisinden ayarlanabilir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__show_update_fpos
@@ -2465,7 +2614,7 @@ msgstr "Simge"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__activity_exception_icon
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__activity_exception_icon
 msgid "Icon to indicate an exception activity."
-msgstr "İstisna aktivitesini belirten simge."
+msgstr "Aktivite uyarısını gösteren simge."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__message_needaction
@@ -2475,7 +2624,7 @@ msgstr "İstisna aktivitesini belirten simge."
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__message_needaction
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__message_needaction
 msgid "If checked, new messages require your attention."
-msgstr "İşaretliyse, yeni mesajlar dikkatinizi gerektirir."
+msgstr "İşlem bekleyen yeni mesajlar var."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__message_has_error
@@ -2491,22 +2640,22 @@ msgstr "İşaretliyse, yeni mesajlar dikkatinizi gerektirir."
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__message_has_error
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__message_has_sms_error
 msgid "If checked, some messages have a delivery error."
-msgstr "İşaretliyse, bazı mesajlarda teslim hatası var."
+msgstr "Gönderilemeyen mesajlar var."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__is_published
 msgid "If checked, the product will be published on the website."
-msgstr "Eğer işaretlenirse, ürün web sitesinde yayınlanacaktır."
+msgstr "Seçiliyse ürün web sitesinde yayımlanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__set_product
 msgid "If set, an alert will be shown on the product page."
-msgstr "Eğer seçilirse, ürün sayfasında bir uyarı gösterilecektir."
+msgstr "Seçiliyse ürün sayfasında uyarı gösterilir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__sub_component
 msgid "If set, this product will not be shown in the shop."
-msgstr "Eğer seçilirse bu ürün mağazada gösterilmeyecektir."
+msgstr "Seçiliyse ürün mağazada gösterilmez."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__allow_negative_stock
@@ -2516,9 +2665,8 @@ msgid ""
 "related stock moves will be blocked if the stock level becomes negative with"
 " the stock move."
 msgstr ""
-"Bu seçenek ne üründe ne de ürün kategorisinde etkin değilse ve ürün "
-"stoklanabilir bir ürünse, stok hareketi ile stok seviyesi negatife düşecekse"
-" ilgili stok hareketlerinin doğrulanması engellenecektir."
+"Stoklanabilir ürünlerde bu izin hem üründe hem kategoride kapalıysa stoku "
+"negatife düşüren hareketler onaylanamaz."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__service_to_purchase
@@ -2527,22 +2675,19 @@ msgid ""
 "automatically created to buy the product. Tip: don't forget to set a vendor "
 "on the product."
 msgstr ""
-"İşaretlenirse, bu ürünü bir satış siparişi ile her sattığınızda, ürünü satın"
-" almak için otomatik olarak bir teklif talebi oluşturulur. İpucu: Üründe "
-"tedarikçi ayarlamayı unutmayın."
+"Her satış siparişinde bu ürün için otomatik satınalma teklifi açılır. Üründe"
+" bir tedarikçi seçilmelidir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__active
 msgid ""
 "If unchecked, it will allow you to hide the product without removing it."
-msgstr "İşaretsiz bırakılırsa, ürünü silmeden gizlemenizi sağlar."
+msgstr "İşareti kaldırarak ürünü silmeden gizleyebilirsiniz."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__pricelist_id
 msgid "If you change the pricelist, only newly added lines will be affected."
-msgstr ""
-"Fiyat listesini değiştirirseniz, yalnızca yeni eklenen satırlar "
-"etkilenecektir."
+msgstr "Fiyat listesi değişikliği yalnızca yeni eklenen satırları etkiler."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__picking_policy
@@ -2551,9 +2696,8 @@ msgid ""
 "based on the greatest product lead time. Otherwise, it will be based on the "
 "shortest."
 msgstr ""
-"Tüm ürünleri aynı anda teslim ederseniz, teslimat siparişi en uzun ürün "
-"teslim süresine göre planlanacaktır. Aksi takdirde en kısasına göre "
-"planlanacaktır."
+"Tek seferde teslimatta en uzun ürün teslim süresi, parçalı teslimatta en "
+"kısa süre esas alınır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__ignore_exception
@@ -2562,6 +2706,7 @@ msgstr "İstisnaları Yoksay"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_1920
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_ids
 msgid "Image"
 msgstr "Görsel"
 
@@ -2589,12 +2734,7 @@ msgstr "Görsel 512"
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__image_url
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_url
 msgid "Image URL"
-msgstr "Görsel URL"
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_ids
-msgid "Images"
-msgstr "Görseller"
+msgstr "Görsel Adresi"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
@@ -2669,6 +2809,11 @@ msgid "Imported"
 msgstr "İçe Aktarıldı"
 
 #. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__in_analysis
+msgid "In Analysis"
+msgstr "İncelemede"
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__standard_price
 msgid ""
 "In Standard Price & AVCO: value of the product (automatically computed in AVCO).\n"
@@ -2676,10 +2821,10 @@ msgid ""
 "        Used to value the product when the purchase cost is not known (e.g. inventory adjustment).\n"
 "        Used to compute margins on sale orders."
 msgstr ""
-"Standart Fiyat ve AVCO'da: ürünün değeri (AVCO'da otomatik hesaplanır).\n"
-"        FIFO'da: stoktan çıkacak bir sonraki birimin değeri (otomatik hesaplanır).\n"
-"        Satınalma maliyeti bilinmediğinde ürünü değerlemek için kullanılır (ör. envanter düzeltmesi).\n"
-"        Satış siparişlerinde kâr marjlarını hesaplamak için kullanılır."
+"Standart maliyette ürünün tanımlı maliyeti, AVCO’da otomatik hesaplanan "
+"ortalama maliyet, FIFO’da sıradaki çıkışın birim maliyeti kullanılır. "
+"Satınalma maliyeti bilinmeyen stok hareketlerini değerlemek ve satış kârını "
+"hesaplamak içindir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__property_account_income_id
@@ -2699,27 +2844,27 @@ msgstr "Teslim Şekli"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__incoterm_address_id
 msgid "Incoterm Address"
-msgstr "Incoterm Adresi"
+msgstr "Teslim Şekli Adresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__incoterm_location
 msgid "Incoterm Location"
-msgstr "Incoterm Konumu"
+msgstr "Teslim Şekli Konumu"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__first_reminder_mail_sent
 msgid "Indicates if the first quotation reminder has been sent."
-msgstr "İlk teklif hatırlatmasının gönderilip gönderilmediğini belirtir."
+msgstr "İlk teklif hatırlatması gönderildi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__packed
 msgid "Indicates if the sale order has been packed."
-msgstr "Satış siparişinin paketlenip paketlenmediğini belirtir."
+msgstr "Sipariş paketlendi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__second_reminder_mail_sent
 msgid "Indicates if the second quotation reminder has been sent."
-msgstr "İkinci teklif hatırlatmasının gönderilip gönderilmediğini belirtir."
+msgstr "İkinci teklif hatırlatması gönderildi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__insert_installation_price
@@ -2727,18 +2872,27 @@ msgid "Insert Installation Price"
 msgstr "Insert Yerleştirme Fiyatı"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__insert_installation_price
+msgid ""
+"Insert installation share of the customization price in USD. This is a "
+"breakdown field; sales pricing uses Total Customization Price."
+msgstr ""
+"Insert montajının özelleştirme bedelindeki payı (USD). Satışta Toplam "
+"Özelleştirme Fiyatı kullanılır."
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__settlement_journal_id
 msgid ""
 "Intermediary bank-type journal for Trendyol payments. When a real bank "
 "transfer arrives, reconcile against this journal."
 msgstr ""
-"Trendyol ödemeleri için aracı banka tipi günlük. Gerçek banka transferi "
-"geldiğinde, bu günlüğe karşı uzlaştırın."
+"Trendyol ödemelerini izleyen ara banka yevmiyesi. Bankaya gelen gerçek "
+"ödemeyi bu yevmiye üzerinden uzlaştırın."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__internal_note
 msgid "Internal Note"
-msgstr "Dahili Not"
+msgstr "İç Not"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__default_code
@@ -2749,21 +2903,19 @@ msgstr "İç Referans"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__internal_note
 msgid ""
 "Internal note for the order. This field is not visible to the customer."
-msgstr "Sipariş için dahili not. Bu alan müşteriye görünmez."
+msgstr "Müşteriye gösterilmeyen sipariş notu."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__barcode
 msgid "International Article Number used for product identification."
-msgstr "Ürün tanımlama için kullanılan Uluslararası Ürün Numarası."
+msgstr "Ürünü tanımlayan uluslararası ürün numarası."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__incoterm
 msgid ""
 "International Commercial Terms are a series of predefined commercial terms "
 "used in international transactions."
-msgstr ""
-"Uluslararası Ticari Terimler, uluslararası işlemlerde kullanılan önceden "
-"tanımlanmış bir dizi ticari terimdir."
+msgstr "Uluslararası ticarette kullanılan standart teslim koşulları."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__property_stock_inventory
@@ -2794,7 +2946,7 @@ msgstr "Fatura Sayısı"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__invoice_link_sent
 msgid "Invoice Link Sent"
-msgstr "Fatura Linki Gönderildi"
+msgstr "Fatura Bağlantısı Gönderildi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__invoice_sent_date
@@ -2816,14 +2968,14 @@ msgstr "Fatura Durumu"
 #: code:addons/trendyol_integration/models/trendyol_order.py:0
 #, python-format
 msgid "Invoice link already sent."
-msgstr "Fatura linki zaten gönderildi."
+msgstr "Fatura bağlantısı zaten gönderilmiş."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_order.py:0
 #, python-format
 msgid "Invoice link send has been queued."
-msgstr "Fatura linki gönderimi kuyruğa alındı."
+msgstr "Fatura bağlantısı gönderim kuyruğuna alındı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__invoiced
@@ -2863,12 +3015,12 @@ msgstr "Kit mi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category__is_leaf
 msgid "Is Leaf Category"
-msgstr "Yaprak Kategori mi"
+msgstr "En Alt Kategori"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__is_product_milestone
 msgid "Is Product Milestone"
-msgstr "Ürün Kilometre Taşı"
+msgstr "Aşamaya Göre Faturalanan Ürün"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__is_product_variant
@@ -2879,6 +3031,11 @@ msgstr "Ürün Varyantı mı"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__is_published
 msgid "Is Published"
 msgstr "Yayınlandı"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
+msgid "Is Trendyol Commission"
+msgstr "Trendyol Komisyonu"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__has_configurable_attributes
@@ -2901,31 +3058,25 @@ msgid "JSON data from batch request result"
 msgstr "Toplu istek sonucundan JSON verisi"
 
 #. module: trendyol_integration
-#: model:ir.model,name:trendyol_integration.model_account_move_line
-msgid "Journal Item"
-msgstr "Yevmiye Kalemi"
-
-#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_kaplama
 msgid "Kaplama Depo Mevcut"
-msgstr "Kaplama Depo Mevcut"
+msgstr "Kaplama Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_kaplama
 msgid "Kaplama Depo Rezervesiz"
-msgstr "Kaplama Depo Rezervesiz"
+msgstr "Kaplama Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_kaplama
 msgid "Kaplama Depo Tahmini"
-msgstr "Kaplama Depo Tahmini"
+msgstr "Kaplama Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__property_account_income_id
 msgid ""
 "Keep this field empty to use the default value from the product category."
-msgstr ""
-"Ürün kategorisinden varsayılan değeri kullanmak için bu alanı boş bırakın."
+msgstr "Boş bırakılırsa ürün kategorisindeki değer kullanılır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__property_account_expense_id
@@ -2934,14 +3085,13 @@ msgid ""
 " anglo-saxon accounting with automated valuation method is configured, the "
 "expense account on the product category will be used."
 msgstr ""
-"Ürün kategorisinden varsayılan değeri kullanmak için bu alanı boş bırakın. "
-"Otomatik değerleme yöntemiyle Anglo-Sakson muhasebe yapılandırılmışsa, ürün "
-"kategorisindeki gider hesabı kullanılacaktır."
+"Boş bırakılırsa kategori hesabı kullanılır. Anglo-Sakson muhasebe ve "
+"otomatik değerlemede kategorinin gider hesabı esas alınır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__label_printer_id
 msgid "Label Printer"
-msgstr "Etiket Yazıcı"
+msgstr "Etiket Yazıcısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__lasercut_price
@@ -2954,19 +3104,37 @@ msgid "Laser Marking Price"
 msgstr "Lazer İşaretleme Fiyatı"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__lasercut_price
+msgid ""
+"Laser cut share of the customization price in USD. This is a breakdown "
+"field; sales pricing uses Total Customization Price."
+msgstr ""
+"Lazer kesimin özelleştirme bedelindeki payı (USD). Satışta Toplam "
+"Özelleştirme Fiyatı kullanılır."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__laser_marking_price
+msgid ""
+"Laser marking share of the customization price in USD. This is a breakdown "
+"field; sales pricing uses Total Customization Price."
+msgstr ""
+"Lazer markalamanın özelleştirme bedelindeki payı (USD). Satışta Toplam "
+"Özelleştirme Fiyatı kullanılır."
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_brand_sync
 msgid "Last Brand Sync"
-msgstr "Son Marka Senkronizasyonu"
+msgstr "Son Marka Eşitlemesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_category_sync
 msgid "Last Category Sync"
-msgstr "Son Kategori Senkronizasyonu"
+msgstr "Son Kategori Eşitlemesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_claim_sync
 msgid "Last Claim Sync"
-msgstr "Son İade Talebi Senkronizasyonu"
+msgstr "Son İade Eşitlemesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__sale_last_deci
@@ -3000,12 +3168,17 @@ msgstr "Son Değiştirme Tarihi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_order_sync
 msgid "Last Order Sync"
-msgstr "Son Sipariş Senkronizasyonu"
+msgstr "Son Sipariş Eşitlemesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_question_sync
 msgid "Last Question Sync"
-msgstr "Son Soru Senkronizasyonu"
+msgstr "Son Soru Eşitlemesi"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__last_sent_list_price
+msgid "Last Sent List Price"
+msgstr "Son Gönderilen Liste Fiyatı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__last_sent_price
@@ -3020,22 +3193,22 @@ msgstr "Son Gönderilen Miktar"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_settlement_sync
 msgid "Last Settlement Sync"
-msgstr "Son Hesaplaşma Senkronizasyonu"
+msgstr "Son Hesaplaşma Eşitlemesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_stock_sync
 msgid "Last Stock Sync"
-msgstr "Son Stok Senkronizasyonu"
+msgstr "Son Stok Eşitlemesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__last_sync_date
 msgid "Last Sync Date"
-msgstr "Son Senkronizasyon Tarihi"
+msgstr "Son Eşitleme Tarihi"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Last Sync Times"
-msgstr "Son Senkronizasyon Zamanları"
+msgstr "Son Eşitleme Zamanları"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_attribute_value__write_uid
@@ -3073,12 +3246,12 @@ msgstr "Son Güncelleyen"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__write_date
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__write_date
 msgid "Last Updated on"
-msgstr "Son Güncelleme"
+msgstr "Son Güncelleme Tarihi"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_category_search
 msgid "Leaf Categories"
-msgstr "Yaprak Kategoriler"
+msgstr "En Alt Kategoriler"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_length
@@ -3096,18 +3269,18 @@ msgid ""
 "Link Odoo products to Trendyol by creating product bindings. You can then "
 "export them to Trendyol marketplace."
 msgstr ""
-"Ürün bağlantıları oluşturarak Odoo ürünlerini Trendyol'a bağlayın. Ardından "
-"bunları Trendyol pazaryerine aktarabilirsiniz."
+"Odoo ürünlerini Trendyol ürünleriyle eşleştirin. Ardından ürünleri "
+"Trendyol’a aktarabilirsiniz."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__trendyol_list_price
 msgid "List Price"
-msgstr "Satış Fiyatı"
+msgstr "Liste Fiyatı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__trendyol_list_price
 msgid "List price in TRY from configured pricelist"
-msgstr "Yapılandırılmış fiyat listesinden TRY cinsinden satış fiyatı"
+msgstr "Seçili fiyat listesindeki TL liste fiyatı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__location_id
@@ -3133,6 +3306,11 @@ msgstr "Ana İstisna"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__main_seller_id
 msgid "Main Vendor"
 msgstr "Ana Tedarikçi"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__maintenance_log_ids
+msgid "Maintenance Logs"
+msgstr "Bakım Kayıtları"
 
 #. module: trendyol_integration
 #: model:ir.module.category,description:trendyol_integration.module_category_trendyol
@@ -3163,7 +3341,7 @@ msgstr "Elle İnceleme"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__manual_review_required
 msgid "Manual Review Required"
-msgstr "Elle İnceleme Gerekiyor"
+msgstr "İnceleme Gerekli"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__valuation
@@ -3172,9 +3350,8 @@ msgid ""
 "        Automated: An accounting entry is automatically created to value the inventory when a product enters or leaves the company.\n"
 "        "
 msgstr ""
-"Manuel: Envanteri değerlemek için muhasebe kayıtları otomatik olarak kaydedilmez.\n"
-"        Otomatik: Bir ürün şirkete girdiğinde veya çıktığında envanteri değerlemek için otomatik olarak bir muhasebe kaydı oluşturulur.\n"
-"        "
+"Manuel: Stok değerleme fişi otomatik oluşturulmaz.\n"
+"Otomatik: Stok giriş ve çıkışlarında değerleme fişi oluşturulur."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__service_type
@@ -3183,9 +3360,9 @@ msgid ""
 "Timesheets on contract: Invoice based on the tracked hours on the related timesheet.\n"
 "Create a task and track hours: Create a task on the sales order validation and track the work hours."
 msgstr ""
-"Siparişte miktarı manuel ayarla: Analitik hesap oluşturmadan, manuel girilen miktara göre faturalandırma.\n"
-"Sözleşme üzerinde zaman çizelgeleri: İlgili zaman çizelgesinde takip edilen saatlere göre faturalandırma.\n"
-"Görev oluştur ve saatleri takip et: Satış siparişi doğrulamasında bir görev oluşturur ve çalışma saatlerini takip eder."
+"Elle girilen miktar: Analitik hesap açmadan bu miktarı faturala.\n"
+"Çalışma süresi: İlgili zaman çizelgesindeki saatleri faturala.\n"
+"Görev ve süre takibi: Sipariş onayında görev aç ve çalışma saatlerini kaydet."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__mrp_product_qty
@@ -3210,12 +3387,17 @@ msgstr "Üretici Ürün Adı"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__manufacturer_purl
 msgid "Manufacturer Product URL"
-msgstr "Üretici Ürün URL"
+msgstr "Üretici Ürün Adresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__produce_delay
 msgid "Manufacturing Lead Time"
-msgstr "Üretim Teslim Süresi"
+msgstr "Üretim Süresi"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_mrp_locked
+msgid "Manufacturing Structure Locked"
+msgstr "Üretim Yapısı Kilitli"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__mrp_production_ids
@@ -3225,7 +3407,7 @@ msgstr "Bu satış siparişiyle ilişkili üretim emirleri."
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__cargo_mapping_ids
 msgid "Map Trendyol cargo providers to Odoo delivery carriers"
-msgstr "Trendyol kargo sağlayıcılarını Odoo nakliye firmalarıyla eşleştirin"
+msgstr "Trendyol kargo firmalarını Odoo’daki karşılıklarıyla eşleştirin."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_category_attribute__odoo_attribute_id
@@ -3255,7 +3437,22 @@ msgstr "Kâr Marjı Bitiş Tarihi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_maske
 msgid "Maske Depo Mevcut"
-msgstr "Maske Depo Mevcut"
+msgstr "Maske Deposu — Mevcut Stok"
+
+#. module: trendyol_integration
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+msgid "Match Commission Invoice"
+msgstr "Komisyonu Uzlaştır"
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__matched
+msgid "Matched"
+msgstr "Uzlaştırıldı"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_material_ids
+msgid "Materials"
+msgstr "Malzemeler"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__medium_id
@@ -3265,27 +3462,27 @@ msgstr "Araç"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_incoming_merkez
 msgid "Merkez Depo Gelen"
-msgstr "Merkez Depo Gelen"
+msgstr "Merkez Deposu — Gelen Miktar"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_outgoing_merkez
 msgid "Merkez Depo Giden"
-msgstr "Merkez Depo Giden"
+msgstr "Merkez Deposu — Giden Miktar"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_merkez
 msgid "Merkez Depo Mevcut"
-msgstr "Merkez Depo Mevcut"
+msgstr "Merkez Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_merkez
 msgid "Merkez Depo Rezervesiz"
-msgstr "Merkez Depo Rezervesiz"
+msgstr "Merkez Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_merkez
 msgid "Merkez Depo Tahmini"
-msgstr "Merkez Depo Tahmini"
+msgstr "Merkez Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__message_has_error
@@ -3320,22 +3517,22 @@ msgstr "Mesajlar"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_metal
 msgid "Metal Depo Mevcut"
-msgstr "Metal Depo Mevcut"
+msgstr "Metal Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_metal
 msgid "Metal Depo Rezervesiz"
-msgstr "Metal Depo Rezervesiz"
+msgstr "Metal Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_metal
 msgid "Metal Depo Tahmini"
-msgstr "Metal Depo Tahmini"
+msgstr "Metal Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__milestone_count
 msgid "Milestone Count"
-msgstr "Kilometre Taşı Sayısı"
+msgstr "Aşama Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__min_order_qty
@@ -3350,31 +3547,37 @@ msgstr "Minimum Stok Kuralları"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_min_iscilik_fiy
 msgid "Minimum işçilik Fiyatı USD"
-msgstr "Minimum İşçilik Fiyatı USD"
+msgstr "Minimum İşçilik Fiyatı (USD)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__min_order_qty
 msgid ""
 "Minimum order quantity for this product in the webshop. Set 0 to disable "
 "this feature."
-msgstr ""
-"Ürün sayfasında minimum sipariş miktarını ayarlayın. Bu özelliği devre dışı "
-"bırakmak için 0 ayarlayın."
+msgstr "Web mağazasındaki minimum sipariş miktarı. 0 ise sınır uygulanmaz."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_montaj
 msgid "Montaj Depo Mevcut"
-msgstr "Montaj Depo Mevcut"
+msgstr "Montaj Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_montaj
 msgid "Montaj Depo Rezervesiz"
-msgstr "Montaj Depo Rezervesiz"
+msgstr "Montaj Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_montaj
 msgid "Montaj Depo Tahmini"
-msgstr "Montaj Depo Tahmini"
+msgstr "Montaj Deposu — Tahmini Stok"
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Multiple vendor documents have this commission invoice reference."
+msgstr ""
+"Bu komisyon fatura numarasıyla birden fazla tedarikçi belgesi bulundu."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__my_activity_date_deadline
@@ -3520,7 +3723,7 @@ msgstr "Henüz Trendyol sorusu yok"
 #: code:addons/trendyol_integration/models/trendyol_claim.py:0
 #, python-format
 msgid "No claim lines to approve."
-msgstr "Onaylanacak iade talep satırı yok."
+msgstr "Onaylanacak iade satırı yok."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -3548,7 +3751,7 @@ msgstr "İptal edilecek sipariş satırı bulunamadı."
 #: code:addons/trendyol_integration/models/trendyol_order.py:0
 #, python-format
 msgid "No posted invoice found for this order."
-msgstr "Bu sipariş için onaylanmış fatura bulunamadı."
+msgstr "Bu sipariş için onaylı fatura bulunamadı."
 
 #. module: trendyol_integration
 #: model_terms:ir.actions.act_window,help:trendyol_integration.action_trendyol_settlement
@@ -3567,14 +3770,14 @@ msgstr "Gönderilecek takip numarası yok."
 #: code:addons/trendyol_integration/models/trendyol_claim.py:0
 #, python-format
 msgid "No valid line IDs found to approve."
-msgstr "Onaylanacak geçerli satır ID bulunamadı."
+msgstr "Onaylanacak geçerli satır kimliği bulunamadı."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_question.py:0
 #, python-format
 msgid "No web URL available for this question."
-msgstr "Bu soru için web URL mevcut değil."
+msgstr "Bu sorunun web bağlantısı yok."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -3583,7 +3786,7 @@ msgstr "Bu soru için web URL mevcut değil."
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "No webhook is registered for this backend."
-msgstr "Bu backend için kayıtlı webhook yok."
+msgstr "Bu entegrasyonda kayıtlı webhook yok."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__normal_cost
@@ -3655,7 +3858,7 @@ msgstr "İşlem gerektiren mesaj sayısı"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__message_has_error_counter
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__message_has_error_counter
 msgid "Number of messages with delivery error"
-msgstr "Teslim hatalı mesaj sayısı"
+msgstr "Gönderilemeyen mesaj sayısı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__nbr_moves_out
@@ -3680,7 +3883,7 @@ msgstr "Odoo Kategorisi"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Odoo Configuration"
-msgstr "Odoo Yapılandırması"
+msgstr "Odoo Ayarları"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
@@ -3707,7 +3910,7 @@ msgstr "Odoo Değeri"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_cargo_mapping__carrier_id
 msgid "Odoo delivery carrier to assign for this Trendyol cargo provider"
-msgstr "Bu Trendyol kargo sağlayıcısı için atanacak Odoo nakliye firması"
+msgstr "Bu Trendyol kargo firması için kullanılacak Odoo kargo firması."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_claim__odoo_return_picking_id
@@ -3730,8 +3933,9 @@ msgid ""
 "On Sales order confirmation, this product can generate a project and/or task.         From those, you can track the service you are selling.\n"
 "         'In sale order's project': Will use the sale order's configured project if defined or fallback to         creating a new project based on the selected template."
 msgstr ""
-"Satış siparişi onayında, bu ürün bir proje ve/veya görev oluşturabilir. Bunlardan sattığınız hizmeti takip edebilirsiniz.\n"
-"         'Satış siparişinin projesinde': Tanımlanmışsa satış siparişinin yapılandırılmış projesini kullanır, aksi takdirde seçili şablona dayalı yeni bir proje oluşturur."
+"Sipariş onayında hizmet takibi için proje ve/veya görev oluşturulur. "
+"\"Siparişin projesinde\" seçeneği mevcut projeyi kullanır; proje yoksa "
+"seçili şablondan oluşturur."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__purchase_method
@@ -3739,8 +3943,8 @@ msgid ""
 "On ordered quantities: Control bills based on ordered quantities.\n"
 "On received quantities: Control bills based on received quantities."
 msgstr ""
-"Sipariş edilen miktarlara göre: Faturaları sipariş edilen miktarlara göre kontrol edin.\n"
-"Teslim alınan miktarlara göre: Faturaları teslim alınan miktarlara göre kontrol edin."
+"Sipariş edilen miktar: Faturayı sipariş miktarına göre kontrol et.\n"
+"Teslim alınan miktar: Faturayı teslim alınan miktara göre kontrol et."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__require_payment
@@ -3764,12 +3968,12 @@ msgstr "Yalnızca onaylanmış ürünler güncellenebilir."
 #: code:addons/trendyol_integration/models/trendyol_product_binding.py:0
 #, python-format
 msgid "Only approved products can have stock/price synced."
-msgstr "Yalnızca onaylanmış ürünlerin stok/fiyatı senkronize edilebilir."
+msgstr "Stok ve fiyat yalnızca onaylı ürünlerde eşitlenebilir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_category__is_leaf
 msgid "Only leaf categories can be used for products"
-msgstr "Ürünler için yalnızca yaprak kategoriler kullanılabilir"
+msgstr "Ürünlerde yalnızca alt kategorisi olmayan kategoriler kullanılabilir."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -3852,13 +4056,20 @@ msgid "Order import has been queued."
 msgstr "Sipariş içe aktarımı kuyruğa alındı."
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Order import page limit reached."
+msgstr "Sipariş içe aktarma sayfa sınırına ulaştı."
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__invoice_policy
 msgid ""
 "Ordered Quantity: Invoice quantities ordered by the customer.\n"
 "Delivered Quantity: Invoice quantities delivered to the customer."
 msgstr ""
-"Sipariş Miktarı: Müşteri tarafından sipariş edilen fatura miktarları.\n"
-"Teslim Edilen Miktar: Müşteriye teslim edilen fatura miktarları."
+"Sipariş miktarı: Sipariş edilen miktarı faturala.\n"
+"Teslim edilen miktar: Teslim edilen miktarı faturala."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -3876,9 +4087,8 @@ msgid ""
 "Orders will appear here when imported from Trendyol. Configure auto-import "
 "in backend settings or click \"Import Orders\" manually."
 msgstr ""
-"Trendyol'dan içe aktarıldığında siparişler burada görüntülenecektir. Backend"
-" ayarlarından otomatik içe aktarmayı yapılandırın veya manuel olarak "
-"\"Siparişleri İçe Aktar\" butonuna tıklayın."
+"Siparişler Trendyol’dan alınır. Entegrasyon ayarlarından otomatik aktarımı "
+"açın veya \"Siparişleri İçe Aktar\"ı kullanın."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__country_of_origin
@@ -3890,7 +4100,7 @@ msgstr "Ürün Menşei"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__raw_data
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__raw_data
 msgid "Original JSON data from Trendyol"
-msgstr "Trendyol'dan gelen orijinal JSON verisi"
+msgstr "Trendyol’dan alınan ham JSON verisi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__unrevisioned_name
@@ -3910,12 +4120,12 @@ msgstr "Satınalma Sipariş Satırları"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__trendyol_package_id
 msgid "Package ID"
-msgstr "Paket ID"
+msgstr "Paket No."
 
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_order_package_id_backend_uniq
 msgid "Package ID must be unique per backend!"
-msgstr "Paket ID her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu paket numarası zaten kullanılıyor."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__packed
@@ -3926,6 +4136,15 @@ msgstr "Paketlendi"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__paint_price
 msgid "Paint Price"
 msgstr "Boya Fiyatı"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__paint_price
+msgid ""
+"Paint share of the customization price in USD. This is a breakdown field; "
+"sales pricing uses Total Customization Price."
+msgstr ""
+"Boyanın özelleştirme bedelindeki payı (USD). Satışta Toplam Özelleştirme "
+"Fiyatı kullanılır."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_category_search
@@ -3945,7 +4164,7 @@ msgstr "Üst Yol"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__partner_credit_warning
 msgid "Partner Credit Warning"
-msgstr "İş Ortağı Kredi Uyarısı"
+msgstr "Cari Hesap Kredi Uyarısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_cari_urun
@@ -3957,9 +4176,7 @@ msgstr "Cari Ürün"
 msgid ""
 "Partner record representing Trendyol. Used as reference on settlement "
 "payments and for reporting purposes."
-msgstr ""
-"Trendyol'u temsil eden iş ortağı kaydı. Hesaplaşma ödemeleri ve raporlama "
-"amacıyla referans olarak kullanılır."
+msgstr "Komisyon ödemeleri ve raporlarda kullanılacak Trendyol cari kaydı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__odoo_payment_id
@@ -3990,7 +4207,7 @@ msgstr "Ödeme Emri"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__reference
 msgid "Payment Ref."
-msgstr "Ödeme Ref."
+msgstr "Ödeme Açıklaması"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__payment_status
@@ -4003,6 +4220,7 @@ msgid "Payment Terms"
 msgstr "Ödeme Koşulları"
 
 #. module: trendyol_integration
+#: model:ir.model,name:trendyol_integration.model_account_payment
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__payment_ids
 msgid "Payments"
 msgstr "Ödemeler"
@@ -4025,39 +4243,39 @@ msgid ""
 "Percentage of time delivered compared to the prepaid amount that must be "
 "reached for the upselling opportunity activity to be triggered."
 msgstr ""
-"Ek satış fırsatı aktivitesinin tetiklenmesi için ön ödemeli tutara kıyasla "
-"ulaşılması gereken teslim edilen süre yüzdesi."
+"Ek satış fırsatı oluşturmak için ön ödenen hizmetin tamamlanması gereken "
+"yüzdesi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__picking
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_order_search
 msgid "Picking"
-msgstr "Transfer"
+msgstr "Hazırlanıyor"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/wizards/category_sync_wizard.py:0
 #, python-format
 msgid "Please select at least one option to sync."
-msgstr "Lütfen senkronize edilecek en az bir seçenek seçin."
+msgstr "Eşitlenecek en az bir seçenek seçin."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/wizards/product_export_wizard.py:0
 #, python-format
 msgid "Please select at least one product."
-msgstr "Lütfen en az bir ürün seçin."
+msgstr "En az bir ürün seçin."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__access_url
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__access_url
 msgid "Portal Access URL"
-msgstr "Portal Erişim URL"
+msgstr "Portal Adresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__revision_count
 msgid "Previous versions count"
-msgstr "Önceki versiyon sayısı"
+msgstr "Önceki Sürüm Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_batch_request__request_type__price_inventory
@@ -4088,7 +4306,7 @@ msgstr "Fiyat Listesi"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__pricelist_id
 msgid "Pricelist to use for Trendyol prices (must be in TRY)"
-msgstr "Trendyol fiyatları için kullanılacak fiyat listesi (TRY olmalı)"
+msgstr "Trendyol’da kullanılacak TL fiyat listesi."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
@@ -4121,21 +4339,21 @@ msgstr "Tedarik Grubu"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_variant_id
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
 msgid "Product"
-msgstr "Ürün Şablonu"
+msgstr "Ürün"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/wizards/product_export_wizard.py:0
 #, python-format
 msgid "Product %s already has a binding for this backend."
-msgstr "Ürün %s bu backend için zaten bir bağlantıya sahip."
+msgstr "%s ürünü bu entegrasyona zaten bağlı."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/wizards/product_export_wizard.py:0
 #, python-format
 msgid "Product %s has no barcode or internal reference."
-msgstr "Ürün %s barkod veya iç referansa sahip değil."
+msgstr "%s ürününde barkod veya stok kodu yok."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__attribute_line_ids
@@ -4162,6 +4380,11 @@ msgid "Product Category"
 msgstr "Ürün Kategorisi"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_ids
+msgid "Product Classes"
+msgstr "Ürün Sınıfları"
+
+#. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_batch_request__request_type__product_create
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_batch_request_search
 msgid "Product Create"
@@ -4175,12 +4398,12 @@ msgstr "Ürün Silme"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__trendyol_product_id
 msgid "Product ID assigned by Trendyol after approval"
-msgstr "Onay sonrası Trendyol tarafından atanan ürün ID"
+msgstr "Trendyol’un onay sonrası verdiği ürün kimliği."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_id_configurator_domain
 msgid "Product Id Configurator Domain"
-msgstr "Ürün ID Yapılandırıcı Alanı"
+msgstr "Yapılandırıcı Ürün Filtresi"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_form
@@ -4190,7 +4413,7 @@ msgstr "Ürün Görseli"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__product_image_url
 msgid "Product Image URL"
-msgstr "Ürün Görsel URL"
+msgstr "Ürün Görseli Adresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim_line__product_name
@@ -4216,7 +4439,7 @@ msgstr "Ürün Şablonu"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_tooltip
 msgid "Product Tooltip"
-msgstr "Ürün Araç İpucu"
+msgstr "Ürün Bilgi İpucu"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__detailed_type
@@ -4233,7 +4456,7 @@ msgstr "Ürün Güncelleme"
 #: model:ir.model,name:trendyol_integration.model_product_product
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_id
 msgid "Product Variant"
-msgstr "Ürün"
+msgstr "Ürün Varyantı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_attribute_ids
@@ -4243,7 +4466,7 @@ msgstr "Ürün özellikleri"
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_product_binding_product_backend_uniq
 msgid "Product can only be bound once per backend!"
-msgstr "Ürün her backend için yalnızca bir kez bağlanabilir!"
+msgstr "Ürün aynı entegrasyona yalnızca bir kez bağlanabilir."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -4257,7 +4480,7 @@ msgstr "Ürün dışa aktarımı kuyruğa alındı."
 #: code:addons/trendyol_integration/models/trendyol_product_binding.py:0
 #, python-format
 msgid "Product image URL is required for %s"
-msgstr "%s için ürün görsel URL'si gereklidir"
+msgstr "%s için ürün görseli adresi gerekli."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -4271,7 +4494,7 @@ msgstr "Ürün henüz Trendyol'da onaylanmadı."
 #: code:addons/trendyol_integration/models/trendyol_product_binding.py:0
 #, python-format
 msgid "Product price must be greater than 0 for %s"
-msgstr "%s için ürün fiyatı 0'dan büyük olmalıdır"
+msgstr "%s için ürün fiyatı 0’dan büyük olmalı."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -4283,7 +4506,7 @@ msgstr "Ürün güncellemesi kuyruğa alındı."
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_backend__environment__prod
 msgid "Production"
-msgstr "Üretim"
+msgstr "Canlı Ortam"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__property_stock_production
@@ -4340,9 +4563,7 @@ msgstr "Sağlayıcı"
 #: model:ir.model.fields,help:trendyol_integration.field_product_product__image_url
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__image_url
 msgid "Public HTTPS URL for product image (used for marketplace integrations)"
-msgstr ""
-"Ürün görseli için genel HTTPS URL'si (pazaryeri entegrasyonları için "
-"kullanılır)"
+msgstr "Pazaryerlerinde kullanılacak, herkese açık HTTPS ürün görseli adresi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__description_purchase
@@ -4352,7 +4573,7 @@ msgstr "Satınalma Açıklaması"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__purchase_gap
 msgid "Purchase Gap"
-msgstr "Satınalma Boşluğu"
+msgstr "Satınalma Farkı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__purchase_line_warn
@@ -4377,22 +4598,22 @@ msgstr "Yerleştirme Kuralları"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__question_user_ids
 msgid "Q&A Notification Users"
-msgstr "S&C Bildirim Kullanıcıları"
+msgstr "Soru Bildirimi Alacak Kullanıcılar"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Q&A Settings"
-msgstr "S&C Ayarları"
+msgstr "Soru-Cevap Ayarları"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_increment_step
 msgid "Qty Increment Step"
-msgstr "Adet artış adımı"
+msgstr "Miktar Artış Adımı"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qc_triggers
-msgid "Quality control triggers"
-msgstr "Kalite kontrol tetikleyicileri"
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qc_test_ids
+msgid "Quality Tests"
+msgstr "Kalite Testleri"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim_line__quantity
@@ -4417,10 +4638,8 @@ msgid ""
 "In a context with a single Warehouse, this includes goods arriving to the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods arriving to any Stock Location with 'internal' type."
 msgstr ""
-"Planlanan gelen ürünlerin miktarı.\n"
-"Tek bir Stok Konumu bağlamında, bu Konuma veya alt konumlarına gelen malları içerir.\n"
-"Tek bir Depo bağlamında, bu Deponun Stok Konumuna veya alt konumlarına gelen malları içerir.\n"
-"Aksi takdirde, 'dahili' türündeki herhangi bir Stok Konumuna gelen malları içerir."
+"Beklenen giriş miktarı. Seçili konum/depo ve alt konumları kapsar; seçim "
+"yoksa tüm iç konumlar hesaplanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__outgoing_qty
@@ -4430,10 +4649,8 @@ msgid ""
 "In a context with a single Warehouse, this includes goods leaving the Stock Location of this Warehouse, or any of its children.\n"
 "Otherwise, this includes goods leaving any Stock Location with 'internal' type."
 msgstr ""
-"Planlanan çıkan ürünlerin miktarı.\n"
-"Tek bir Stok Konumu bağlamında, bu Konumdan veya alt konumlarından çıkan malları içerir.\n"
-"Tek bir Depo bağlamında, bu Deponun Stok Konumundan veya alt konumlarından çıkan malları içerir.\n"
-"Aksi takdirde, 'dahili' türündeki herhangi bir Stok Konumundan çıkan malları içerir."
+"Beklenen çıkış miktarı. Seçili konum/depo ve alt konumları kapsar; seçim "
+"yoksa tüm iç konumlar hesaplanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__visible_qty_configurator
@@ -4448,7 +4665,7 @@ msgstr "Soru"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_form
 msgid "Question & Answer"
-msgstr "Soru & Cevap"
+msgstr "Soru ve Cevap"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__question_date
@@ -4459,7 +4676,7 @@ msgstr "Soru Tarihi"
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_question_question_id_backend_uniq
 msgid "Question ID must be unique per backend!"
-msgstr "Soru ID her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu soru numarası zaten kullanılıyor."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_form
@@ -4476,6 +4693,13 @@ msgstr "Soru içe aktarımı kuyruğa alındı."
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Question import page limit reached."
+msgstr "Soru aktarımında sayfa sınırına ulaşıldı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__question_count
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 #, python-format
@@ -4485,14 +4709,14 @@ msgstr "Sorular"
 #. module: trendyol_integration
 #: model:ir.ui.menu,name:trendyol_integration.menu_trendyol_questions
 msgid "Questions (Q&A)"
-msgstr "Sorular (S&C)"
+msgstr "Sorular ve Cevaplar"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/wizards/category_sync_wizard.py:0
 #, python-format
 msgid "Queued synchronization for: %s"
-msgstr "%s için senkronizasyon kuyruğa alındı"
+msgstr "%s için eşitleme kuyruğa alındı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__sale_order_template_id
@@ -4532,7 +4756,7 @@ msgstr "Yeniden Faturalama Politikası görünür"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_claim_line__trendyol_reason
 msgid "Reason assessed by Trendyol"
-msgstr "Trendyol tarafından değerlendirilen neden"
+msgstr "Trendyol’un belirlediği iade nedeni."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__cancel_reason_id
@@ -4547,7 +4771,7 @@ msgstr "Müşterinin iade için belirttiği neden"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__receipt_id
 msgid "Receipt"
-msgstr "Alış"
+msgstr "Dekont"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.trendyol_shipping_label
@@ -4573,7 +4797,7 @@ msgstr "Referans"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__code_prefix
 msgid "Reference Prefix"
-msgstr "Referans Ön Eki"
+msgstr "Kod Ön Eki"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__reference_mask
@@ -4590,15 +4814,11 @@ msgid ""
 " `fancyA/l~r~l` (for variant with Color \"Red\" and Size \"L\")  `fancyA/x~y~x` (for variant with Color \"Yellow\" and Size \"XL\")\n"
 "Note: make sure characters \"[,]\" do not appear in your attribute name"
 msgstr ""
-"Bu şablondan oluşturulan bir varyantın iç referanslarını oluşturmak için referans maskesi.\n"
-"Örnek:\n"
-"2 özelliğe sahip ABC adlı bir ürün: Boyut ve Renk:\n"
-"Ürün: ABC\n"
-"Renk: Kırmızı(k), Sarı(s), Siyah(si)\n"
-"Boyut: L (l), XL(x)\n"
-"Varyant referans maskesini `[Renk]-[Boyut]` olarak ayarladığınızda, varyantlardaki varsayılan kod `k-l` `si-l` `k-x` gibi olacaktır.\n"
-"İsterseniz, maskede özellik adının birden fazla görünmesini sağlayabilirsiniz.\n"
-"Not: \\'[,]\\' karakterlerinin özellik adınızda görünmediğinden emin olun"
+"Varyant kodu şablonu. Özellik adlarını köşeli parantez içinde yazın.\n"
+"Örnek: Color: Red(r), Yellow(y), Black(b); Size: L(l), XL(x).\n"
+"[Color]-[Size] → r-l, b-l, r-x.\n"
+"Aynı özellik tekrar kullanılabilir: fancyA/[Size]~[Color]~[Size] → fancyA/l~r~l, fancyA/x~y~x.\n"
+"Özellik adlarında [, ] ve , kullanmayın."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__origin
@@ -4656,8 +4876,8 @@ msgid ""
 "Request a online signature and/or payment to the customer in order to "
 "confirm orders automatically."
 msgstr ""
-"Siparişleri otomatik olarak onaylamak için müşteriden online imza ve/veya "
-"ödeme talep edin."
+"Siparişi otomatik onaylamak için müşteriden çevrim içi imza ve/veya ödeme "
+"ister."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category_attribute__required
@@ -4723,12 +4943,12 @@ msgstr "İade Transferi"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_claim_form
 msgid "Return Shipping"
-msgstr "İade Kargo"
+msgstr "İade Kargosu"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim__cargo_tracking_link
 msgid "Return Tracking Link"
-msgstr "İade Takip Linki"
+msgstr "İade Takip Bağlantısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim__cargo_tracking_number
@@ -4741,9 +4961,8 @@ msgid ""
 "Return claims will appear here when imported from Trendyol. Configure auto-"
 "import in backend settings or click \"Import Claims\" manually."
 msgstr ""
-"Trendyol'dan içe aktarıldığında iade talepleri burada görüntülenecektir. "
-"Backend ayarlarından otomatik içe aktarmayı yapılandırın veya manuel olarak "
-"\"İadeleri İçe Aktar\" butonuna tıklayın."
+"İadeler Trendyol’dan alınır. Entegrasyon ayarlarından otomatik aktarımı açın"
+" veya \"İade Taleplerini İçe Aktar\"ı kullanın."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -4770,6 +4989,11 @@ msgid "Returns"
 msgstr "İadeler"
 
 #. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__review
+msgid "Review Required"
+msgstr "İnceleme Gerekli"
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__revision_number
 msgid "Revision"
 msgstr "Revizyon"
@@ -4790,8 +5014,7 @@ msgid ""
 "Rules of origin determine where goods originate, i.e. not where they have been shipped from, but where they have been produced or manufactured.\n"
 "As such, the ‘origin’ is the 'economic nationality' of goods traded in commerce."
 msgstr ""
-"Menşe kuralları, malların nereden geldiğini belirler, yani nereden sevk edildiklerini değil, nerede üretildiğini veya imal edildiğini.\n"
-"Bu nedenle 'menşe', ticarette alınıp satılan malların 'ekonomik milliyeti'dir."
+"Menşe, ürünün üretildiği ülkeyi belirtir; sevk edildiği ülke değildir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__message_has_sms_error
@@ -4836,7 +5059,7 @@ msgstr "Son 360 gündeki satış"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__trendyol_sale_price
 msgid "Sale price in TRY (if different from list price)"
-msgstr "TRY cinsinden satış fiyatı (liste fiyatından farklıysa)"
+msgstr "Liste fiyatından farklıysa kullanılacak TL satış fiyatı."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_search
@@ -4851,7 +5074,7 @@ msgstr "Satış Açıklaması"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__sales_gap
 msgid "Sales Gap"
-msgstr "Satış Boşluğu"
+msgstr "Satış Farkı"
 
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_sale_order
@@ -4899,7 +5122,7 @@ msgstr "Satınalma Fiyatı"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_search
 msgid "Search Backends"
-msgstr "Backend'lerde Ara"
+msgstr "Entegrasyonlarda Ara"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_batch_request_search
@@ -4955,7 +5178,7 @@ msgstr "İkinci Hatırlatma Gönderildi"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__access_token
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__access_token
 msgid "Security Token"
-msgstr "Güvenlik Belirteci"
+msgstr "Güvenlik Anahtarı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__product_brand_id
@@ -4965,7 +5188,7 @@ msgstr "Bu ürün için bir marka seçin"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__project_id
 msgid "Select a non billable project on which tasks can be created."
-msgstr "Görevlerin oluşturulabileceği faturalandırılmayan bir proje seçin."
+msgstr "Görev açılacak, faturalandırılmayan projeyi seçin."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__barcode_rule_id
@@ -4980,19 +5203,18 @@ msgid ""
 "Selecting \"Blocking Message\" will throw an exception with the message and "
 "block the flow. The Message has to be written in the next field."
 msgstr ""
-"\"Uyarı\" seçeneğini seçmek kullanıcıyı mesajla bilgilendirir, \"Engelleyici"
-" Mesaj\" seçeneğini seçmek mesajla bir istisna fırlatır ve akışı engeller. "
-"Mesaj bir sonraki alana yazılmalıdır."
+"\"Uyarı\" mesajı gösterir. \"Engelleyici Mesaj\" işlemi de durdurur. "
+"Gösterilecek mesajı sonraki alana yazın."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__seller_id
 msgid "Seller ID"
-msgstr "Satıcı ID"
+msgstr "Satıcı No."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__seller_revenue
 msgid "Seller Revenue"
-msgstr "Satıcı Geliri"
+msgstr "Satıcı Hakedişi"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_form
@@ -5014,7 +5236,7 @@ msgstr "Gönderim Kuyruğa Alındı"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__auto_send_invoice
 msgid "Send invoice links to Trendyol via nightly batch cron"
-msgstr "Gece toplu zamanlayıcı ile Trendyol'a fatura linklerini gönder"
+msgstr "Fatura bağlantılarını her gece Trendyol’a gönderir."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -5058,9 +5280,7 @@ msgstr "Set Ürün?"
 msgid ""
 "Set a step for product quantity increment in the product page. Set 0 to "
 "disable this feature."
-msgstr ""
-"Ürün sayfasında ürün adet artış adımını ayarlayın. Bu özelliği devre dışı "
-"bırakmak için 0 ayarlayın."
+msgstr "Ürün sayfasındaki miktar artış adımı. 0 ise adım kısıtı uygulanmaz."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
@@ -5070,21 +5290,21 @@ msgstr "Taslağa Çevir"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__manual_review_required
 msgid ""
-"Set when reconciliation needs a human decision. Such rows are skipped by "
-"the automatic reconciliation pass."
+"Set when reconciliation needs a human decision. Such rows are skipped by the"
+" automatic reconciliation pass."
 msgstr ""
-"Uzlaştırmanın insan kararı gerektirdiği durumlarda işaretlenir. Bu satırlar "
-"otomatik uzlaştırma turunda atlanır."
+"Elle incelenecek kayıtları işaretler. Bu satırlar otomatik uzlaştırmada "
+"atlanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__trendyol_settlement_id
 msgid "Settlement ID"
-msgstr "Hesaplaşma ID"
+msgstr "Hesaplaşma No."
 
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_settlement_settlement_id_backend_uniq
 msgid "Settlement ID must be unique per backend!"
-msgstr "Hesaplaşma ID her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu hesaplaşma numarası zaten kullanılıyor."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -5092,6 +5312,13 @@ msgstr "Hesaplaşma ID her backend için benzersiz olmalıdır!"
 #, python-format
 msgid "Settlement import has been queued."
 msgstr "Hesaplaşma içe aktarımı kuyruğa alındı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Settlement import page limit reached."
+msgstr "Hesaplaşma aktarımında sayfa sınırına ulaşıldı."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -5110,8 +5337,8 @@ msgid ""
 "Settlements are imported from Trendyol's finance API and used\n"
 "                to reconcile invoices with marketplace payments."
 msgstr ""
-"Hesaplaşmalar Trendyol'un finans API'sinden içe aktarılır ve\n"
-"                faturaları pazaryeri ödemeleriyle uzlaştırmak için kullanılır."
+"Trendyol finans kayıtları, faturaları pazaryeri ödemeleriyle uzlaştırmak "
+"için kullanılır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__shipment_package_id
@@ -5121,7 +5348,7 @@ msgstr "Gönderi Paketi"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__trendyol_package_id
 msgid "Shipment package ID in Trendyol"
-msgstr "Trendyol'daki gönderi paket ID'si"
+msgstr "Trendyol gönderi paketinin kimliği."
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__shipped
@@ -5137,7 +5364,7 @@ msgstr "Nakliye"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__picking_policy
 msgid "Shipping Policy"
-msgstr "Ürün Teslimat Politikası"
+msgstr "Teslimat Politikası"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__short_public_description
@@ -5147,22 +5374,22 @@ msgstr "E-Ticaret Kısa Açıklaması"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__show_forecasted_qty_status_button
 msgid "Show Forecasted Qty Status Button"
-msgstr "Tahmini Miktar Durum Butonunu Göster"
+msgstr "Tahmini Stok Düğmesini Göster"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__show_on_hand_qty_status_button
 msgid "Show On Hand Qty Status Button"
-msgstr "Eldeki Miktar Durum Butonunu Göster"
+msgstr "Mevcut Stok Düğmesini Göster"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__show_volume_uom_warning
 msgid "Show Volume Uom Warning"
-msgstr "Hacim ÖB Uyarısını Göster"
+msgstr "Hacim Birimi Uyarısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__show_weight_uom_warning
 msgid "Show Weight Uom Warning"
-msgstr "Ağırlık ÖB Uyarısını Göster"
+msgstr "Ağırlık Birimi Uyarısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__signature
@@ -5182,27 +5409,27 @@ msgstr "İmza Tarihi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_incoming_sincan
 msgid "Sincan Depo Gelen"
-msgstr "Sincan Depo Gelen"
+msgstr "Sincan Deposu — Gelen Miktar"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_outgoing_sincan
 msgid "Sincan Depo Giden"
-msgstr "Sincan Depo Giden"
+msgstr "Sincan Deposu — Giden Miktar"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_sincan
 msgid "Sincan Depo Mevcut"
-msgstr "Sincan Depo Mevcut"
+msgstr "Sincan Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_sincan
 msgid "Sincan Depo Rezervesiz"
-msgstr "Sincan Depo Rezervesiz"
+msgstr "Sincan Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_sincan
 msgid "Sincan Depo Tahmini"
-msgstr "Sincan Depo Tahmini"
+msgstr "Sincan Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_export_wizard__skip_existing
@@ -5212,15 +5439,16 @@ msgstr "Mevcut Bağlantıları Atla"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_export_wizard__skip_existing
 msgid "Skip products that already have a binding for this backend"
-msgstr "Bu backend için zaten bağlantısı olan ürünleri atla"
+msgstr "Bu entegrasyona zaten bağlı ürünleri atlar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category_attribute__slicer
 msgid "Slicer"
-msgstr "Dilimleyici"
+msgstr "Ayrı Ürün Kartı Oluşturur"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__smart_search
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__smart_search
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__smart_search
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__smart_search
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__smart_search
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__smart_search
@@ -5274,10 +5502,14 @@ msgid ""
 "        First In First Out (FIFO): The products are valued supposing those that enter the company first will also leave it first.\n"
 "        "
 msgstr ""
-"Standart Fiyat: Ürünler, üründe tanımlanan standart maliyetleriyle değerlenir.\n"
-"        Ortalama Maliyet (AVCO): Ürünler ağırlıklı ortalama maliyetle değerlenir.\n"
-"        İlk Giren İlk Çıkar (FIFO): Ürünler, şirkete ilk girenlerin ilk çıkacağı varsayılarak değerlenir.\n"
-"        "
+"Standart maliyet: Üründe tanımlı maliyet kullanılır.\n"
+"Ortalama maliyet (AVCO): Ağırlıklı ortalama kullanılır.\n"
+"İlk giren ilk çıkar (FIFO): Stoka önce girenin önce çıktığı kabul edilir."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_base_product_id
+msgid "Standard variant from which this customized product was created."
+msgstr "Bu özelleştirilmiş ürünün oluşturulduğu standart varyant."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__hs_code
@@ -5285,13 +5517,13 @@ msgid ""
 "Standardized code for international shipping and goods declaration. At the "
 "moment, only used for FedEx and USPS shipping providers."
 msgstr ""
-"Uluslararası nakliye ve mal beyanı için standartlaştırılmış kod. Şu anda "
-"yalnızca FedEx ve USPS nakliye sağlayıcıları için kullanılmaktadır."
+"Uluslararası sevkiyat ve gümrük beyanı kodu. Şu anda FedEx ve USPS için "
+"kullanılır."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_category_sync_wizard_form
 msgid "Start Sync"
-msgstr "Senkronizasyonu Başlat"
+msgstr "Eşitlemeyi Başlat"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__state
@@ -5303,7 +5535,7 @@ msgstr "Durum"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__state_id_domain
 msgid "State Id Domain"
-msgstr "İl/Eyalet Alanı"
+msgstr "İl/Eyalet Filtresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_batch_request__state
@@ -5342,10 +5574,9 @@ msgid ""
 "Today: Activity date is today\n"
 "Planned: Future activities."
 msgstr ""
-"Aktivitelere dayalı durum\n"
-"Gecikmiş: Son tarih geçmiş\n"
-"Bugün: Aktivite tarihi bugün\n"
-"Planlanmış: Gelecek aktiviteler."
+"Gecikmiş: Son tarih geçti.\n"
+"Bugün: Aktivitenin tarihi bugün.\n"
+"Planlanmış: Aktivitenin tarihi ileride."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
@@ -5377,14 +5608,14 @@ msgstr "Stok Değerleme Katmanı"
 #: code:addons/trendyol_integration/models/trendyol_product_binding.py:0
 #, python-format
 msgid "Stock/price sync has been queued."
-msgstr "Stok/fiyat senkronizasyonu kuyruğa alındı."
+msgstr "Stok ve fiyat eşitlemesi kuyruğa alındı."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Stock/price synchronization has been queued."
-msgstr "Stok/fiyat senkronizasyonu kuyruğa alındı."
+msgstr "Stok ve fiyat eşitlemesi kuyruğa alındı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__stock_move_ids
@@ -5394,7 +5625,7 @@ msgstr "Stok Hareketleri"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__storage_category_capacity_ids
 msgid "Storage Category Capacity"
-msgstr "Depolama Kategori Kapasitesi"
+msgstr "Depolama Kategorisi Kapasitesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__sub_component
@@ -5414,46 +5645,45 @@ msgstr "Fason Hizmet"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_batch_request__success_count
 msgid "Success Count"
-msgstr "Başarılı Sayısı"
+msgstr "Başarılı İşlem Sayısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__normal_cost
 msgid "Sum of Multiplication of Cost price and quantity of Vendor Bills"
-msgstr "Tedarikçi Faturalarının maliyet fiyatı ve miktarı çarpımının toplamı"
+msgstr "Tedarikçi fatura miktarları × maliyet fiyatı toplamı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__turnover
 msgid ""
 "Sum of Multiplication of Invoice price and quantity of Customer Invoices"
-msgstr "Müşteri Faturalarının fatura fiyatı ve miktarı çarpımının toplamı"
+msgstr "Müşteri fatura miktarları × fatura birim fiyatı toplamı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__total_cost
 msgid "Sum of Multiplication of Invoice price and quantity of Vendor Bills "
-msgstr "Tedarikçi Faturalarının fatura fiyatı ve miktarı çarpımının toplamı "
+msgstr "Tedarikçi fatura miktarları × fatura birim fiyatı toplamı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__sale_expected
 msgid ""
 "Sum of Multiplication of Sale Catalog price and quantity of Customer "
 "Invoices"
-msgstr ""
-"Müşteri Faturalarının satış katalog fiyatı ve miktarı çarpımının toplamı"
+msgstr "Müşteri fatura miktarları × katalog satış fiyatı toplamı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__sale_num_invoiced
 msgid "Sum of Quantity in Customer Invoices"
-msgstr "Müşteri Faturalarındaki miktar toplamı"
+msgstr "Müşteri faturalarındaki toplam miktar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__purchase_num_invoiced
 msgid "Sum of Quantity in Vendor Bills"
-msgstr "Tedarikçi Faturalarındaki miktar toplamı"
+msgstr "Tedarikçi faturalarındaki toplam miktar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_batch_request__error_messages
 msgid "Summary of errors from failed items"
-msgstr "Başarısız kalemlerden hata özeti"
+msgstr "Başarısız işlemlerin hata özeti."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__surface_ids
@@ -5468,12 +5698,12 @@ msgstr "Anket Sayısı"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__survey_url
 msgid "Survey URL"
-msgstr "Anket URL"
+msgstr "Anket Adresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__survey_url_qr
 msgid "Survey URL QR"
-msgstr "Anket URL QR"
+msgstr "Anket QR Kodu"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__survey_ids
@@ -5483,56 +5713,56 @@ msgstr "Anketler"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Sync"
-msgstr "Senkronizasyon"
+msgstr "Eşitleme"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_category_form
 msgid "Sync Attributes"
-msgstr "Özellikleri Senkronize Et"
+msgstr "Özellikleri Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category_sync_wizard__sync_attributes
 msgid "Sync Attributes for Leaf Categories"
-msgstr "Yaprak Kategoriler İçin Özellikleri Senkronize Et"
+msgstr "En Alt Kategori Özelliklerini Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category_sync_wizard__sync_brands
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Sync Brands"
-msgstr "Markaları Senkronize Et"
+msgstr "Markaları Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category_sync_wizard__sync_categories
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Sync Categories"
-msgstr "Kategorileri Senkronize Et"
+msgstr "Kategorileri Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.actions.act_window,name:trendyol_integration.action_trendyol_category_sync_wizard
 msgid "Sync Categories & Brands"
-msgstr "Kategori ve Markaları Senkronize Et"
+msgstr "Kategori ve Markaları Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__sync_error
 msgid "Sync Error"
-msgstr "Senkronizasyon Hatası"
+msgstr "Eşitleme Hatası"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
 msgid "Sync Info"
-msgstr "Senkronizasyon Bilgisi"
+msgstr "Eşitleme Bilgisi"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/wizards/category_sync_wizard.py:0
 #, python-format
 msgid "Sync Queued"
-msgstr "Senkronizasyon Kuyruğa Alındı"
+msgstr "Eşitleme Kuyruğa Alındı"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Sync Settings"
-msgstr "Senkronizasyon Ayarları"
+msgstr "Eşitleme Ayarları"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -5543,33 +5773,33 @@ msgstr "Senkronizasyon Ayarları"
 #: code:addons/trendyol_integration/models/trendyol_product_binding.py:0
 #, python-format
 msgid "Sync Started"
-msgstr "Senkronizasyon Başlatıldı"
+msgstr "Eşitleme Başlatıldı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__sync_state
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_search
 msgid "Sync State"
-msgstr "Senkronizasyon Durumu"
+msgstr "Eşitleme Durumu"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Sync Status"
-msgstr "Senkronizasyon Durumu"
+msgstr "Eşitleme Durumu"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
 msgid "Sync Stock/Price"
-msgstr "Stok/Fiyat Senkronize Et"
+msgstr "Stok ve Fiyatı Eşitle"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Sync Stock/Prices"
-msgstr "Stok/Fiyat Senkronize Et"
+msgstr "Stok ve Fiyatları Eşitle"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_category_sync_wizard_form
 msgid "Sync Trendyol Data"
-msgstr "Trendyol Verilerini Senkronize Et"
+msgstr "Trendyol Verilerini Eşitle"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -5577,21 +5807,21 @@ msgstr "Trendyol Verilerini Senkronize Et"
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Sync Trendyol brands: %s"
-msgstr "Trendyol markalarını senkronize et: %s"
+msgstr "Trendyol markalarını eşitle: %s"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Sync Trendyol categories: %s"
-msgstr "Trendyol kategorilerini senkronize et: %s"
+msgstr "Trendyol kategorilerini eşitle: %s"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Sync Trendyol metadata: %s"
-msgstr "Trendyol meta verilerini senkronize et: %s"
+msgstr "Trendyol tanım verilerini eşitle: %s"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -5599,28 +5829,28 @@ msgstr "Trendyol meta verilerini senkronize et: %s"
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Sync Trendyol stock/prices: %s"
-msgstr "Trendyol stok/fiyatları senkronize et: %s"
+msgstr "Trendyol stok ve fiyatlarını eşitle: %s"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/wizards/category_sync_wizard.py:0
 #, python-format
 msgid "Sync attributes for %s"
-msgstr "%s için özellikleri senkronize et"
+msgstr "%s özelliklerini eşitle"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_category.py:0
 #, python-format
 msgid "Sync attributes for category: %s"
-msgstr "Kategori için özellikleri senkronize et: %s"
+msgstr "Kategori özelliklerini eşitle: %s"
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_product_binding.py:0
 #, python-format
 msgid "Sync stock/price: %s"
-msgstr "Stok/fiyat senkronize et: %s"
+msgstr "Stok ve fiyatı eşitle: %s"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__tag_ids
@@ -5632,8 +5862,7 @@ msgstr "Etiketler"
 msgid ""
 "Tags to be set on the base and tax journal items created for this product."
 msgstr ""
-"Bu ürün için oluşturulan temel ve vergi günlük kalemlerine ayarlanacak "
-"etiketler."
+"Bu ürünün matrah ve vergi yevmiye kalemlerinde kullanılacak etiketler."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__tasks_count
@@ -5670,9 +5899,7 @@ msgstr "Vergiler"
 msgid ""
 "Technical field to correctly show the currently selected company's currency "
 "that corresponds to the totaled value of the product's valuation layers"
-msgstr ""
-"Ürünün değerleme katmanlarının toplam değerine karşılık gelen, seçili "
-"şirketin para birimini doğru şekilde göstermek için teknik alan"
+msgstr "Stok değerleme toplamının ait olduğu şirket para birimini gösterir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__show_volume_uom_warning
@@ -5680,8 +5907,8 @@ msgid ""
 "Technical field used to warn the user to change the volumeuom since the "
 "value for product_volume is too small and has beenrounded."
 msgstr ""
-"product_volume değeri çok küçük olduğundan ve yuvarlandığından, kullanıcıyı "
-"hacim ölçü birimini değiştirmesi konusunda uyarmak için teknik alan."
+"Hacim çok küçük olduğu için yuvarlandıysa hacim birimini değiştirme uyarısı "
+"gösterir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__show_weight_uom_warning
@@ -5689,17 +5916,24 @@ msgid ""
 "Technical field used to warn the user to change the weightuom since the "
 "value for product_weight is too small and has beenrounded."
 msgstr ""
-"product_weight değeri çok küçük olduğundan ve yuvarlandığından, kullanıcıyı "
-"ağırlık ölçü birimini değiştirmesi konusunda uyarmak için teknik alan."
+"Ağırlık çok küçük olduğu için yuvarlandıysa ağırlık birimini değiştirme "
+"uyarısı gösterir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__state_id_domain
 msgid ""
 "Technical field, used to compute dynamically state domain depending on the "
 "country."
+msgstr "Seçili ülkeye göre kullanılabilecek il/eyaletleri belirler."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_mrp_locked
+msgid ""
+"Technical lock that prevents an already-generated customization "
+"specification from being changed in place."
 msgstr ""
-"Ülkeye bağlı olarak il/eyalet alanını dinamik olarak hesaplamak için teknik "
-"alan."
+"Oluşturulmuş özelleştirme yapısının sonradan değiştirilmesini önleyen teknik"
+" kilit."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__terms_type
@@ -5717,6 +5951,16 @@ msgid "Test Connection"
 msgstr "Bağlantıyı Test Et"
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The API commission invoice reference was updated. Existing payment "
+"reconciliations were preserved."
+msgstr ""
+"Komisyon fatura numarası güncellendi. Mevcut ödeme eşleşmeleri korundu."
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__country_code
 msgid ""
 "The ISO country code in two chars. \n"
@@ -5726,12 +5970,64 @@ msgstr ""
 "Bu alanı hızlı arama için kullanabilirsiniz."
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__partner_user_id
-msgid "The internal user in charge of this contact."
-msgstr "Bu kontakla ilgilenen dahili kullanıcı."
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment amount differs from its settlement rows."
+msgstr ""
+"Komisyon ödemesi, hesaplaşma satırlarındaki komisyon toplamıyla uyuşmuyor."
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_move_line__count_pending_changeset_changes
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment and vendor document currencies differ."
+msgstr "Komisyon ödemesi ile tedarikçi belgesinin para birimleri farklı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment exceeds the referenced vendor document's remaining "
+"balance."
+msgstr "Komisyon ödemesi, ilgili tedarikçi belgesinin açık bakiyesini aşıyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment is already reconciled with another document. Existing"
+" reconciliations were preserved."
+msgstr ""
+"Komisyon ödemesi başka bir belgeyle eşleşmiş. Mevcut eşleşmeler korundu."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment is closed without a matching vendor document."
+msgstr "Komisyon ödemesi, tedarikçi belgesiyle eşleşmeden kapanmış."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment partner or company does not match the Trendyol "
+"backend."
+msgstr ""
+"Komisyon ödemesinin cari hesabı veya şirketi Trendyol ayarlarıyla uyuşmuyor."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__partner_user_id
+msgid "The internal user in charge of this contact."
+msgstr "Bu kişiden sorumlu iç kullanıcı."
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,help:trendyol_integration.field_product_product__count_pending_changeset_changes
 #: model:ir.model.fields,help:trendyol_integration.field_product_template__count_pending_changeset_changes
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__count_pending_changeset_changes
@@ -5754,10 +6050,11 @@ msgstr "Bu kontakla ilgilenen dahili kullanıcı."
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__count_pending_changeset_changes
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__count_pending_changeset_changes
 msgid "The number of pending changes of this record"
-msgstr "Bu kaydın bekleyen değişiklik sayısı"
+msgstr "Bu kayıtta bekleyen değişiklik sayısı."
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_product__count_pending_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_template__count_pending_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__count_pending_changesets
@@ -5780,10 +6077,11 @@ msgstr "Bu kaydın bekleyen değişiklik sayısı"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__count_pending_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__count_pending_changesets
 msgid "The number of pending changesets of this record"
-msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
+msgstr "Bu kayıtta bekleyen değişiklik grubu sayısı."
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_move_line__count_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_product__count_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_template__count_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__count_changesets
@@ -5806,12 +6104,12 @@ msgstr "Bu kaydın bekleyen değişiklik setlerinin sayısı"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__count_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__count_changesets
 msgid "The overall number of changesets of this record"
-msgstr "Bu kaydın toplam değişiklik seti sayısı"
+msgstr "Bu kaydın toplam değişiklik grubu sayısı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__reference
 msgid "The payment communication of this sale order."
-msgstr "Bu satış siparişinin ödeme iletişimi."
+msgstr "Bu siparişin ödeme açıklaması."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__payment_currency_id
@@ -5829,28 +6127,35 @@ msgid ""
 "The sale price is managed from the product template. Click on the 'Configure"
 " Variants' button to set the extra attribute prices."
 msgstr ""
-"Satış fiyatı ürün şablonundan yönetilir. Ek özellik fiyatlarını ayarlamak "
-"için 'Varyantları Yapılandır' butonuna tıklayın."
+"Satış fiyatı ürün şablonundan yönetilir. Ek özellik fiyatları için "
+"\"Varyantları Yapılandır\"ı kullanın."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The vendor document has no compatible open payable lines."
+msgstr "Tedarikçi belgesinde uzlaştırılabilecek açık borç satırı yok."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__product_volume
 msgid "The volume in the product's volume UOM."
-msgstr "Ürünün hacim ÖB'sindeki hacim."
+msgstr "Seçili hacim birimine göre ürünün hacmi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__product_weight
 msgid "The weight in the product's weight UOM."
-msgstr "Ürünün ağırlık ÖB'sindeki ağırlık."
+msgstr "Seçili ağırlık birimine göre ürünün ağırlığı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_category_attribute__varianter
 msgid "This attribute creates product variants"
-msgstr "Bu özellik ürün varyantları oluşturur"
+msgstr "Bu özellik, aynı ürün kartındaki varyantları ayırır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_category_attribute__slicer
 msgid "This attribute is a slicer attribute"
-msgstr "Bu özellik bir dilimleyici özelliğidir"
+msgstr "Bu özellik, Trendyol’da ayrı bir ürün kartı oluşturur."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_category_attribute__required
@@ -5862,9 +6167,7 @@ msgstr "Bu özellik ürün oluşturma için zorunludur"
 msgid ""
 "This field is used to search the product with keywords that do not exist in "
 "the product name."
-msgstr ""
-"Bu alan, ürün adında bulunmayan anahtar kelimelerle ürünü aramak için "
-"kullanılır."
+msgstr "Ürünü, adında geçmeyen anahtar kelimelerle bulmayı sağlar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__campaign_id
@@ -5872,8 +6175,7 @@ msgid ""
 "This is a name that helps you keep track of your different campaign efforts,"
 " e.g. Fall_Drive, Christmas_Special"
 msgstr ""
-"Bu, farklı kampanya çalışmalarınızı takip etmenize yardımcı olan bir addır, "
-"ör. Sonbahar_Kampanya, Noel_Özel"
+"Kampanyaları ayırt etmek için kullanılan ad. Örnek: Sonbahar Kampanyası."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__commitment_date
@@ -5881,13 +6183,13 @@ msgid ""
 "This is the delivery date promised to the customer. If set, the delivery "
 "order will be scheduled based on this date rather than product lead times."
 msgstr ""
-"Bu, müşteriye taahhüt edilen teslimat tarihidir. Ayarlanırsa, teslimat "
-"siparişi ürün teslim süreleri yerine bu tarihe göre planlanacaktır."
+"Müşteriye taahhüt edilen teslimat tarihi. Girilirse sevkiyat, ürün teslim "
+"süreleri yerine bu tarihe göre planlanır."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__medium_id
 msgid "This is the method of delivery, e.g. Postcard, Email, or Banner Ad"
-msgstr "Bu, teslimat yöntemidir, ör. Kartpostal, E-posta veya Banner Reklam"
+msgstr "Pazarlama kanalı. Örnek: e-posta, kartpostal veya banner reklam."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__source_id
@@ -5895,13 +6197,34 @@ msgid ""
 "This is the source of the link, e.g. Search Engine, another domain, or name "
 "of email list"
 msgstr ""
-"Bu, bağlantının kaynağıdır, ör. Arama Motoru, başka bir alan adı veya "
-"e-posta listesi adı"
+"Bağlantının geldiği kaynak. Örnek: arama motoru, başka bir site veya e-posta"
+" listesi."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__price_extra
 msgid "This is the sum of the extra price of all attributes"
-msgstr "Bu, tüm özelliklerin ek fiyatlarının toplamıdır"
+msgstr "Tüm özelliklerin ek fiyatları toplamı."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"This payment covers multiple commission invoice references. Review is "
+"required."
+msgstr "Bu ödeme birden fazla komisyon faturasını kapsıyor. İnceleme gerekli."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"This payout row arrived after the payout was reconciled. Its commission is "
+"not covered by the commission payment already recorded and needs manual "
+"review."
+msgstr ""
+"Bu satır uzlaştırmadan sonra geldi. Komisyonu mevcut ödemeye dahil değil; "
+"elle kontrol edin."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__no_create_variants
@@ -5909,8 +6232,8 @@ msgid ""
 "This selection defines if variants for all attribute combinations are going "
 "to be created automatically at saving time."
 msgstr ""
-"Bu seçim, tüm özellik kombinasyonları için varyantların kayıt sırasında "
-"otomatik olarak oluşturulup oluşturulmayacağını tanımlar."
+"Kaydederken tüm özellik kombinasyonları için otomatik varyant oluşturulup "
+"oluşturulmayacağını belirler."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__property_stock_production
@@ -5918,8 +6241,8 @@ msgid ""
 "This stock location will be used, instead of the default one, as the source "
 "location for stock moves generated by manufacturing orders."
 msgstr ""
-"Bu stok konumu, varsayılan konum yerine, üretim emirleri tarafından "
-"oluşturulan stok hareketleri için kaynak konum olarak kullanılacaktır."
+"Üretim emirlerinin stok hareketlerinde kullanılacak kaynak konum; "
+"varsayılanın yerine geçer."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__property_stock_inventory
@@ -5927,32 +6250,27 @@ msgid ""
 "This stock location will be used, instead of the default one, as the source "
 "location for stock moves generated when you do an inventory."
 msgstr ""
-"Bu stok konumu, varsayılan konum yerine, envanter sayımı yaptığınızda "
-"oluşturulan stok hareketleri için kaynak konum olarak kullanılacaktır."
+"Envanter sayım hareketlerinde kullanılacak kaynak konum; varsayılanın yerine"
+" geçer."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__responsible_id
 msgid ""
 "This user will be responsible of the next activities related to logistic "
 "operations for this product."
-msgstr ""
-"Bu kullanıcı, bu ürünün lojistik işlemleriyle ilgili sonraki aktivitelerden "
-"sorumlu olacaktır."
+msgstr "Ürünün sonraki lojistik aktivitelerinden sorumlu kullanıcı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__barcode_base
 msgid ""
 "This value is used to generate barcode according to the setting of the "
 "barcode rule."
-msgstr ""
-"Bu değer, barkod kuralı ayarına göre barkod oluşturmak için kullanılır."
+msgstr "Barkod kuralına göre barkod oluşturmak için kullanılan değer."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_category_sync_wizard__sync_attributes
 msgid "This will sync attributes for all leaf categories. May take some time."
-msgstr ""
-"Bu, tüm yaprak kategorilerin özelliklerini senkronize edecektir. Biraz zaman"
-" alabilir."
+msgstr "En alt kategorilerin özellikleri eşitlenir. İşlem biraz sürebilir."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__service_upsell_threshold
@@ -5962,12 +6280,12 @@ msgstr "Eşik Değer"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__timesheet_encode_uom_id
 msgid "Timesheet Encoding Unit"
-msgstr "Zaman Çizelgesi Kodlama Birimi"
+msgstr "Zaman Çizelgesi Süre Birimi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__timesheet_total_duration
 msgid "Timesheet Total Duration"
-msgstr "Zaman Çizelgesi Toplam Süre"
+msgstr "Toplam Çalışma Süresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__timesheet_count
@@ -5987,17 +6305,17 @@ msgstr "Uzlaştırılacak"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_torna
 msgid "Torna Depo Mevcut"
-msgstr "Torna Depo Mevcut"
+msgstr "Torna Deposu — Mevcut Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_unreserved_torna
 msgid "Torna Depo Rezervesiz"
-msgstr "Torna Depo Rezervesiz"
+msgstr "Torna Deposu — Kullanılabilir Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_torna
 msgid "Torna Depo Tahmini"
-msgstr "Torna Depo Tahmini"
+msgstr "Torna Deposu — Tahmini Stok"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__amount_total
@@ -6027,7 +6345,7 @@ msgstr "Toplam Kâr Marjı"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__total_margin_rate
 msgid "Total Margin Rate(%)"
-msgstr "Toplam Kâr Marjı Oranı(%)"
+msgstr "Toplam Kâr Marjı (%)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim__total_quantity
@@ -6050,17 +6368,11 @@ msgid "Total margin * 100 / Turnover"
 msgstr "Toplam kâr marjı * 100 / Ciro"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__total_customization_price
-msgid "Total price for all customizations in USD."
-msgstr "USD cinsinden tüm özelleştirmeler için toplam fiyat."
-
-#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__timesheet_total_duration
 msgid ""
 "Total recorded duration, expressed in the encoding UoM, and rounded to the "
 "unit"
-msgstr ""
-"Kodlama ÖB'sinde ifade edilen ve birime yuvarlanan toplam kayıtlı süre"
+msgstr "Seçili süre birimine çevrilmiş ve yuvarlanmış toplam kayıtlı süre."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__service_type
@@ -6070,7 +6382,7 @@ msgstr "Hizmet Takibi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__tracking
 msgid "Tracking"
-msgstr "İzleme"
+msgstr "Takip"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.trendyol_shipping_label
@@ -6080,7 +6392,7 @@ msgstr "Takip Barkodu"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__cargo_tracking_link
 msgid "Tracking Link"
-msgstr "Takip Linki"
+msgstr "Takip Bağlantısı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__cargo_tracking_number
@@ -6118,7 +6430,7 @@ msgstr "İşlemler"
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_stock_picking
 msgid "Transfer"
-msgstr "Teslimat"
+msgstr "Stok Transferi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__picking_ids
@@ -6145,7 +6457,7 @@ msgstr "Trendyol"
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__trendyol_address_id
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_users__trendyol_address_id
 msgid "Trendyol Address ID"
-msgstr "Trendyol Adres ID"
+msgstr "Trendyol Adres No."
 
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_attribute_value
@@ -6160,17 +6472,17 @@ msgstr "Trendyol Özellikleri"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
 msgid "Trendyol Backend"
-msgstr "Trendyol Arka Uç"
+msgstr "Trendyol Entegrasyonu"
 
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_backend
 msgid "Trendyol Backend Configuration"
-msgstr "Trendyol Backend Yapılandırması"
+msgstr "Trendyol Entegrasyon Ayarları"
 
 #. module: trendyol_integration
 #: model:ir.actions.act_window,name:trendyol_integration.action_trendyol_backend
 msgid "Trendyol Backends"
-msgstr "Trendyol Backend'leri"
+msgstr "Trendyol Entegrasyonları"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__trendyol_barcode
@@ -6181,7 +6493,7 @@ msgstr "Trendyol Barkodu"
 #: model:ir.model,name:trendyol_integration.model_trendyol_batch_request
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_batch_request_form
 msgid "Trendyol Batch Request"
-msgstr "Trendyol Toplu İstek"
+msgstr "Trendyol Toplu İsteği"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__trendyol_binding_count
@@ -6212,12 +6524,12 @@ msgstr "Trendyol Markaları"
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_cargo_mapping
 msgid "Trendyol Cargo Provider Mapping"
-msgstr "Trendyol Kargo Sağlayıcı Eşleştirme"
+msgstr "Trendyol Kargo Eşleştirmesi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_cargo_mapping__trendyol_cargo_provider_name
 msgid "Trendyol Cargo Provider Name"
-msgstr "Trendyol Kargo Sağlayıcı Adı"
+msgstr "Trendyol Kargo Firması"
 
 #. module: trendyol_integration
 #: model:ir.actions.act_window,name:trendyol_integration.action_trendyol_category
@@ -6240,7 +6552,7 @@ msgstr "Trendyol Kategori Özelliği"
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_category_sync_wizard
 msgid "Trendyol Category Sync Wizard"
-msgstr "Trendyol Kategori Senkronizasyon Sihirbazı"
+msgstr "Trendyol Kategori Eşitleme Sihirbazı"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_claim_form
@@ -6255,17 +6567,17 @@ msgstr "Trendyol İade Talebi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim__trendyol_claim_id
 msgid "Trendyol Claim ID"
-msgstr "Trendyol İade Talep ID"
+msgstr "Trendyol İade Talebi No."
 
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_claim_line
 msgid "Trendyol Claim Line"
-msgstr "Trendyol İade Talep Satırı"
+msgstr "Trendyol İade Talebi Satırı"
 
 #. module: trendyol_integration
 #: model:ir.actions.act_window,name:trendyol_integration.action_trendyol_claim
 msgid "Trendyol Claims"
-msgstr "Trendyol İadeler"
+msgstr "Trendyol İade Talepleri"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -6273,6 +6585,11 @@ msgstr "Trendyol İadeler"
 #, python-format
 msgid "Trendyol Commission - Order %s"
 msgstr "Trendyol Komisyonu - Sipariş %s"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_settlement_ids
+msgid "Trendyol Commission Settlement"
+msgstr "Trendyol Komisyon Hesaplaşması"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -6285,7 +6602,7 @@ msgstr "Trendyol Müşterisi"
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__trendyol_customer_id
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_users__trendyol_customer_id
 msgid "Trendyol Customer ID"
-msgstr "Trendyol Müşteri ID"
+msgstr "Trendyol Müşteri No."
 
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_question
@@ -6303,12 +6620,12 @@ msgstr "Trendyol Kimliği"
 #. module: trendyol_integration
 #: model:ir.module.category,name:trendyol_integration.module_category_trendyol
 msgid "Trendyol Integration"
-msgstr "Trendyol Entegrasyon"
+msgstr "Trendyol Entegrasyonu"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim_line__trendyol_line_id
 msgid "Trendyol Line ID"
-msgstr "Trendyol Satır ID"
+msgstr "Trendyol Satır No."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
@@ -6342,12 +6659,12 @@ msgstr "Trendyol Siparişleri"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__trendyol_partner_id
 msgid "Trendyol Partner"
-msgstr "Trendyol İş Ortağı"
+msgstr "Trendyol Cari Hesabı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__settlement_journal_id
 msgid "Trendyol Payment Journal"
-msgstr "Trendyol Ödeme Günlüğü"
+msgstr "Trendyol Ödeme Yevmiyesi"
 
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_product_binding
@@ -6358,12 +6675,12 @@ msgstr "Trendyol Ürün Bağlantısı"
 #. module: trendyol_integration
 #: model:ir.model,name:trendyol_integration.model_trendyol_product_export_wizard
 msgid "Trendyol Product Export Wizard"
-msgstr "Trendyol Ürün Dışa Aktarım Sihirbazı"
+msgstr "Trendyol Ürün Aktarma Sihirbazı"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__trendyol_product_id
 msgid "Trendyol Product ID"
-msgstr "Trendyol Ürün ID"
+msgstr "Trendyol Ürün No."
 
 #. module: trendyol_integration
 #: model:ir.actions.act_window,name:trendyol_integration.action_trendyol_product_binding
@@ -6383,7 +6700,7 @@ msgstr "Trendyol Sorusu"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__trendyol_question_id
 msgid "Trendyol Question ID"
-msgstr "Trendyol Soru ID"
+msgstr "Trendyol Soru No."
 
 #. module: trendyol_integration
 #: model:ir.actions.act_window,name:trendyol_integration.action_trendyol_question
@@ -6393,7 +6710,7 @@ msgstr "Trendyol Soruları"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_claim_line__trendyol_reason
 msgid "Trendyol Reason"
-msgstr "Trendyol Nedeni"
+msgstr "Trendyol İade Nedeni"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
@@ -6439,7 +6756,7 @@ msgstr "Trendyol barkodu gereklidir."
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_brand_trendyol_id_backend_uniq
 msgid "Trendyol brand ID must be unique per backend!"
-msgstr "Trendyol marka ID her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu Trendyol marka numarası zaten kullanılıyor."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -6451,7 +6768,7 @@ msgstr "%s ürünü için Trendyol markası gereklidir"
 #. module: trendyol_integration
 #: model:ir.model.constraint,message:trendyol_integration.constraint_trendyol_category_trendyol_id_backend_uniq
 msgid "Trendyol category ID must be unique per backend!"
-msgstr "Trendyol kategori ID her backend için benzersiz olmalıdır!"
+msgstr "Aynı entegrasyonda bu Trendyol kategori numarası zaten kullanılıyor."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -6462,14 +6779,24 @@ msgstr "%s ürünü için Trendyol kategorisi gereklidir"
 
 #. module: trendyol_integration
 #. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_order.py:0
+#, python-format
+msgid ""
+"Trendyol customer information is not available yet. Retry the import later."
+msgstr ""
+"Trendyol müşteri bilgileri henüz hazır değil. Aktarımı daha sonra tekrar "
+"deneyin."
+
+#. module: trendyol_integration
+#. odoo-python
 #: code:addons/trendyol_integration/models/stock_picking.py:0
 #, python-format
 msgid ""
 "Trendyol order %s has been cancelled. The sale order has been cancelled. You"
 " cannot validate this picking."
 msgstr ""
-"Trendyol siparişi %s iptal edildi. Satış siparişi iptal edildi. Bu sevkiyatı"
-" onaylayamazsınız."
+"%s Trendyol siparişi ve bağlı satış siparişi iptal edildi. Bu transfer "
+"onaylanamaz."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -6512,19 +6839,19 @@ msgstr "Trendyol: Hesaplaşmaları İçe Aktar"
 #: model:ir.actions.server,name:trendyol_integration.cron_send_invoices_ir_actions_server
 #: model:ir.cron,cron_name:trendyol_integration.cron_send_invoices
 msgid "Trendyol: Send Invoice Links"
-msgstr "Trendyol: Fatura Linklerini Gönder"
+msgstr "Trendyol: Fatura Bağlantılarını Gönder"
 
 #. module: trendyol_integration
 #: model:ir.actions.server,name:trendyol_integration.cron_sync_metadata_ir_actions_server
 #: model:ir.cron,cron_name:trendyol_integration.cron_sync_metadata
 msgid "Trendyol: Sync Categories and Brands"
-msgstr "Trendyol: Kategori ve Markaları Senkronize Et"
+msgstr "Trendyol: Kategori ve Markaları Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.actions.server,name:trendyol_integration.cron_sync_stock_prices_ir_actions_server
 #: model:ir.cron,cron_name:trendyol_integration.cron_sync_stock_prices
 msgid "Trendyol: Sync Stock and Prices"
-msgstr "Trendyol: Stok ve Fiyatları Senkronize Et"
+msgstr "Trendyol: Stok ve Fiyatları Eşitle"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__turnover
@@ -6553,12 +6880,12 @@ msgstr "Tür Adı"
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__activity_exception_decoration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_question__activity_exception_decoration
 msgid "Type of the exception activity on record."
-msgstr "Kayıttaki istisna aktivitesinin türü."
+msgstr "Kayıttaki aktivite uyarısının türü."
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_form
 msgid "Type your answer here (min 10, max 2000 characters)..."
-msgstr "Cevabınızı buraya yazın (min 10, maks 2000 karakter)..."
+msgstr "Cevabınızı yazın (10–2000 karakter)..."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__currency_id_usd
@@ -6576,9 +6903,32 @@ msgid "UTM source to set on Trendyol orders"
 msgstr "Trendyol siparişlerine atanacak UTM kaynağı"
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__print_price
+msgid ""
+"UV print share of the customization price in USD. This is a breakdown field;"
+" sales pricing uses Total Customization Price."
+msgstr ""
+"UV baskının özelleştirme bedelindeki payı (USD). Satışta Toplam Özelleştirme"
+" Fiyatı kullanılır."
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__unanswered
+msgid "Unanswered"
+msgstr "Yanıtsız"
+
+#. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__undelivered
 msgid "Undelivered"
-msgstr "Teslim Edilmedi"
+msgstr "Teslim Edilemedi"
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_attribute_value_id
+msgid ""
+"Unique customization identifier shared by the final product and all of its "
+"generated components."
+msgstr ""
+"Son ürün ve oluşturulan tüm bileşenlerin paylaştığı benzersiz özelleştirme "
+"kimliği."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__uom_id
@@ -6591,41 +6941,6 @@ msgid "Unit of Measure Name"
 msgstr "Ölçü Birimi Adı"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__cnc_price
-msgid "Unit price for CNC customization in USD."
-msgstr "USD cinsinden CNC özelleştirme birim fiyatı."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__print_price
-msgid "Unit price for UV print customization in USD."
-msgstr "USD cinsinden UV baskı özelleştirme birim fiyatı."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__assembly_price
-msgid "Unit price for assembly customization in USD."
-msgstr "USD cinsinden montaj özelleştirme birim fiyatı."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__insert_installation_price
-msgid "Unit price for insert installation customization in USD."
-msgstr "USD cinsinden insert yerleştirme özelleştirme birim fiyatı."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__lasercut_price
-msgid "Unit price for laser cut customization in USD."
-msgstr "USD cinsinden lazer kesim özelleştirme birim fiyatı."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__laser_marking_price
-msgid "Unit price for laser marking customization in USD."
-msgstr "USD cinsinden lazer işaretleme özelleştirme birim fiyatı."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__paint_price
-msgid "Unit price for paint customization in USD."
-msgstr "USD cinsinden boya özelleştirme birim fiyatı."
-
-#. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_order.py:0
 #, python-format
@@ -6635,7 +6950,7 @@ msgstr "Bilinmeyen Ürün"
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__unpacked
 msgid "Unpacked"
-msgstr "Paketlenmedi"
+msgstr "Paket Bölündü"
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__unresolved
@@ -6660,7 +6975,7 @@ msgstr "Vergiler Hariç Toplam (USD)"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__dimensional_uom_id
 msgid "UoM for length, height, width"
-msgstr "Uzunluk, yükseklik, genişlik için ÖB"
+msgstr "Uzunluk, yükseklik ve genişlik için ölçü birimi."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -6679,7 +6994,7 @@ msgstr "Güncelleme Başlatıldı"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_order_form
 msgid "Update Tracking"
-msgstr "Takip Güncelle"
+msgstr "Kargo Takibini Güncelle"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_product_binding_form
@@ -6698,7 +7013,7 @@ msgstr "Ürünü Trendyol'da güncelle: %s"
 #: code:addons/trendyol_integration/models/trendyol_order.py:0
 #, python-format
 msgid "Update tracking: %s"
-msgstr "Takip güncelle: %s"
+msgstr "Kargo takibini güncelle: %s"
 
 #. module: trendyol_integration
 #: model:res.groups,name:trendyol_integration.group_trendyol_user
@@ -6706,7 +7021,8 @@ msgid "User"
 msgstr "Kullanıcı"
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__user_can_see_changeset
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__user_can_see_changeset
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__user_can_see_changeset
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__user_can_see_changeset
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__user_can_see_changeset
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__user_can_see_changeset
@@ -6729,13 +7045,12 @@ msgstr "Kullanıcı"
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__user_can_see_changeset
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__user_can_see_changeset
 msgid "User Can See Changeset"
-msgstr "Kullanıcı Değişiklikleri Görebilir"
+msgstr "Değişiklikleri Görebilir"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__question_user_ids
 msgid "Users to notify when new customer questions are imported"
-msgstr ""
-"Yeni müşteri soruları içe aktarıldığında bilgilendirilecek kullanıcılar"
+msgstr "Yeni müşteri sorularında bildirim alacak kullanıcılar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__vat_rate
@@ -6767,7 +7082,7 @@ msgstr "Değerler"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__variant_default_code_error
 msgid "Variant Default Code Error"
-msgstr "Varyant Varsayılan Kod Hatası"
+msgstr "Varyant Kod Hatası"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_variant_1920
@@ -6817,7 +7132,7 @@ msgstr "Varyant Tedarikçisi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__variant_seller_ids_2
 msgid "Variant Seller Ids 2"
-msgstr "Varyant Satıcı ID'leri 2"
+msgstr "Varyant Tedarikçileri"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_template_variant_value_ids
@@ -6832,12 +7147,12 @@ msgstr "Varyant oluşturma"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__reference_mask
 msgid "Variant reference mask"
-msgstr "Varyant referans maskesi"
+msgstr "Varyant Kod Şablonu"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_category_attribute__varianter
 msgid "Varianter"
-msgstr "Varyantçı"
+msgstr "Varyant Özelliği"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__supplier_taxes_id
@@ -6869,7 +7184,7 @@ msgstr "Hacim Ölçü Birimi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_volume
 msgid "Volume in product UOM"
-msgstr "Ürün ÖB'sinde hacim"
+msgstr "Ürün Birimine Göre Hacim"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__volume_uom_name
@@ -6877,9 +7192,19 @@ msgid "Volume unit of measure label"
 msgstr "Hacim ölçü birimi etiketi"
 
 #. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__waiting
+msgid "Waiting"
+msgstr "Bekliyor"
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
+msgid "Waiting Fraud Check"
+msgstr "Güvenlik Kontrolü Bekliyor"
+
+#. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_in_action
 msgid "Waiting In Action"
-msgstr "İşlemde Bekliyor"
+msgstr "İşlem Bekliyor"
 
 #. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__waiting_for_answer
@@ -6894,9 +7219,31 @@ msgid "Waiting for Approve"
 msgstr "Onay Bekliyor"
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission invoice number from Trendyol."
+msgstr "Trendyol komisyon fatura numarası bekleniyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission payment to be posted."
+msgstr "Komisyon ödemesinin onaylanması bekleniyor."
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Waiting for the referenced DSM vendor bill or credit note to be posted."
+msgstr "İlgili DSM faturasının veya iade faturasının onaylanması bekleniyor."
+
+#. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_claim_search
 msgid "Waiting in Action"
-msgstr "İşlemde Bekliyor"
+msgstr "İşlem Bekliyor"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__warehouse_id
@@ -6912,12 +7259,12 @@ msgstr "Depolar"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__warehouse_ids
 msgid "Warehouses to use for stock calculations and order fulfillment"
-msgstr "Stok hesaplamaları ve sipariş karşılama için kullanılacak depolar"
+msgstr "Stok hesabı ve sipariş hazırlığı için kullanılacak depolar."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_question__web_url
 msgid "Web URL"
-msgstr "Web URL"
+msgstr "Web Adresi"
 
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_backend_form
@@ -6934,7 +7281,7 @@ msgstr "Webhook API Anahtarı"
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Webhook Activated"
-msgstr "Webhook Aktifleştirildi"
+msgstr "Webhook Etkinleştirildi"
 
 #. module: trendyol_integration
 #. odoo-python
@@ -6960,19 +7307,19 @@ msgstr "Webhook Kaydedildi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__webhook_url
 msgid "Webhook URL"
-msgstr "Webhook URL"
+msgstr "Webhook Adresi"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__webhook_url
 msgid "Webhook endpoint URL for this backend"
-msgstr "Bu backend için webhook uç noktası URL'si"
+msgstr "Bu entegrasyonun webhook adresi."
 
 #. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Webhook has been activated on Trendyol."
-msgstr "Webhook Trendyol'da aktifleştirildi."
+msgstr "Webhook Trendyol’da etkinleştirildi."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -7008,12 +7355,12 @@ msgstr "Web Sitesi Mesajları"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__website_sequence
 msgid "Website Sequence"
-msgstr "Website Sırası"
+msgstr "Web Sitesi Sırası"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__website_attachment_ids
 msgid "Website attachments"
-msgstr "Websitesi dosyaları"
+msgstr "Web Sitesi Dosyaları"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__website_message_ids
@@ -7038,7 +7385,7 @@ msgstr "Ağırlık Ölçü Birimi"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_weight
 msgid "Weight in product UOM"
-msgstr "Ürün ÖB'sinde ağırlık"
+msgstr "Ürün Birimine Göre Ağırlık"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__weight_uom_name
@@ -7048,7 +7395,7 @@ msgstr "Ağırlık ölçü birimi etiketi"
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_category_sync_wizard_form
 msgid "What to Sync"
-msgstr "Ne Senkronize Edilecek"
+msgstr "Eşitlenecek Veriler"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__auto_orderpoint_template_ids
@@ -7057,9 +7404,8 @@ msgid ""
 "Action will automatically generate or update the reordering rules of the "
 "product."
 msgstr ""
-"Bir veya birden fazla otomatik yeniden sipariş kuralı seçildiğinde, "
-"Zamanlanan İşlem ürünün yeniden sipariş kurallarını otomatik olarak "
-"oluşturur veya günceller."
+"Otomatik stok yenileme kuralı seçildiğinde, zamanlanmış görev ürünün "
+"kurallarını oluşturur veya günceller."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__product_width
@@ -7074,7 +7420,7 @@ msgstr "Cevabınız"
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_backend__seller_id
 msgid "Your Trendyol seller ID"
-msgstr "Trendyol satıcı ID'niz"
+msgstr "Trendyol satıcı numaranız."
 
 #. module: trendyol_integration
 #. odoo-python
@@ -7091,302 +7437,24 @@ msgstr "Dahili stok/SKU kodunuz"
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_iscilik_fiyat
 msgid "işçilik Fiyatı USD"
-msgstr "İşçilik Fiyatı USD"
+msgstr "İşçilik Fiyatı (USD)"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_onceki
 msgid "Önceki Fiyatı"
-msgstr "Önceki Fiyatı"
+msgstr "Önceki Fiyat"
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_onceki
 msgid "Önceki fiyatı"
-msgstr "Önceki fiyatı"
+msgstr "Önceki fiyat."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_fiyat_onceki_iscilik
 msgid "Önceki işçilik fiyatı"
-msgstr "Önceki işçilik fiyatı"
+msgstr "Önceki işçilik fiyatı."
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_onceki_iscilik
 msgid "Önceki İşçilik Fiyatı"
 msgstr "Önceki İşçilik Fiyatı"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Brand synchronization page limit reached."
-msgstr "Marka senkronizasyonu sayfa sınırına ulaştı."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Claims import page limit reached."
-msgstr "İade içe aktarma sayfa sınırına ulaştı."
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__in_analysis
-msgid "In Analysis"
-msgstr "İncelemede"
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__last_sent_list_price
-msgid "Last Sent List Price"
-msgstr "Son Gönderilen Liste Fiyatı"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Order import page limit reached."
-msgstr "Sipariş içe aktarma sayfa sınırına ulaştı."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Question import page limit reached."
-msgstr "Soru içe aktarma sayfa sınırına ulaştı."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Settlement import page limit reached."
-msgstr "Hesaplaşma içe aktarma sayfa sınırına ulaştı."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "This payout row arrived after the payout was reconciled. Its commission is not covered by the commission payment already recorded and needs manual review."
-msgstr "Bu ödeme satırı, ödeme uzlaştırıldıktan sonra geldi. Komisyonu, daha önce kaydedilen komisyon ödemesinin kapsamında değil ve elle incelenmesi gerekiyor."
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__unanswered
-msgid "Unanswered"
-msgstr "Yanıtsız"
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
-msgid "Waiting Fraud Check"
-msgstr "Fraud Kontrolü Bekliyor"
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_id
-msgid "Commission Invoice"
-msgstr "Komisyon Faturası"
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_number
-msgid "Commission Invoice Number"
-msgstr "Komisyon Fatura Numarası"
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_note
-msgid "Commission Match Note"
-msgstr "Komisyon Eşleştirme Notu"
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_state
-msgid "Commission Match State"
-msgstr "Komisyon Eşleştirme Durumu"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
-#, python-format
-msgid "Commission Matching"
-msgstr "Komisyon Eşleştirme"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Commission matched to the referenced vendor document."
-msgstr "Komisyon, belirtilen tedarikçi belgesiyle uzlaştırıldı."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Commission matching is pending."
-msgstr "Komisyon eşleştirmesi bekliyor."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Customer Payment Reconciled"
-msgstr "Müşteri Tahsilatı Uzlaştırıldı"
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
-msgid "Is Trendyol Commission"
-msgstr "Trendyol Komisyonu"
-
-#. module: trendyol_integration
-#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
-msgid "Match Commission Invoice"
-msgstr "Komisyon Faturasıyla Uzlaştır"
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__matched
-msgid "Matched"
-msgstr "Uzlaştırıldı"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Multiple vendor documents have this commission invoice reference."
-msgstr ""
-"Bu komisyon fatura referansına sahip birden fazla tedarikçi belgesi var."
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__review
-msgid "Review Required"
-msgstr "İnceleme Gerekli"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The commission payment amount differs from its settlement rows."
-msgstr ""
-"Komisyon ödemesinin tutarı, hakediş satırlarının toplamıyla uyuşmuyor."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The commission payment and vendor document currencies differ."
-msgstr "Komisyon ödemesi ile tedarikçi belgesinin para birimleri farklı."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The commission payment exceeds the referenced vendor document's remaining "
-"balance."
-msgstr ""
-"Komisyon ödemesi, belirtilen tedarikçi belgesinin kalan bakiyesini aşıyor."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The commission payment is already reconciled with another document. Existing"
-" reconciliations were preserved."
-msgstr ""
-"Komisyon ödemesi başka bir belgeyle uzlaştırılmış. Mevcut uzlaşmalar "
-"korundu."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The commission payment is closed without a matching vendor document."
-msgstr "Komisyon ödemesi, ilgili tedarikçi belgesine bağlanmadan kapanmış."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The commission payment partner or company does not match the Trendyol "
-"backend."
-msgstr ""
-"Komisyon ödemesinin iş ortağı veya şirketi Trendyol yapılandırmasıyla "
-"uyuşmuyor."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The vendor document has no compatible open payable lines."
-msgstr "Tedarikçi belgesinde uyumlu ve açık bir satıcı hesabı satırı yok."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"This payment covers multiple commission invoice references. Review is "
-"required."
-msgstr ""
-"Bu ödeme birden fazla komisyon faturası referansını kapsıyor. İnceleme "
-"gerekiyor."
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_settlement_ids
-msgid "Trendyol Commission Settlement"
-msgstr "Trendyol Komisyon Hakedişi"
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__waiting
-msgid "Waiting"
-msgstr "Bekliyor"
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Waiting for the commission invoice number from Trendyol."
-msgstr "Trendyol komisyon fatura numarası bekleniyor."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Waiting for the commission payment to be posted."
-msgstr "Komisyon ödemesinin onaylanması bekleniyor."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"Waiting for the referenced DSM vendor bill or credit note to be posted."
-msgstr ""
-"Belirtilen DSM tedarikçi faturasının veya iade faturasının onaylanması "
-"bekleniyor."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The API commission invoice reference was updated. Existing payment "
-"reconciliations were preserved."
-msgstr ""
-"API komisyon faturası referansı güncellendi. Mevcut ödeme uzlaşmaları "
-"korundu."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_order.py:0
-#, python-format
-msgid ""
-"Trendyol customer information is not available yet. Retry the import later."
-msgstr ""
-"Trendyol müşteri bilgileri henüz hazır değil. İçe aktarmayı daha sonra "
-"tekrar deneyin."
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"Commission payment %(payment)s for Trendyol orders %(orders)s was reconciled "
-"with this invoice."
-msgstr ""
-"Trendyol %(orders)s numaralı siparişlere ait %(payment)s komisyon ödemesi "
-"bu faturayla uzlaştırıldı."

--- a/trendyol_integration/i18n/trendyol_integration.pot
+++ b/trendyol_integration/i18n/trendyol_integration.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-27 07:17+0000\n"
-"PO-Revision-Date: 2026-04-27 07:17+0000\n"
+"POT-Creation-Date: 2026-09-08 07:30+0000\n"
+"PO-Revision-Date: 2026-09-08 07:30+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -307,6 +307,11 @@ msgid "Accessory Products"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model,name:trendyol_integration.model_account_auto_reconcile
+msgid "Account Auto Reconcile"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__account_tag_ids
 msgid "Account Tags"
 msgstr ""
@@ -461,13 +466,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_question.py:0
 #, python-format
-msgid "Answer Trendyol question: %s"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_question.py:0
-#, python-format
 msgid "Answer must be at least 10 characters long."
 msgstr ""
 
@@ -482,6 +480,11 @@ msgstr ""
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__answered
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_search
 msgid "Answered"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_application_ids
+msgid "Applications"
 msgstr ""
 
 #. module: trendyol_integration
@@ -528,6 +531,13 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__assembly_price
 msgid "Assembly Price"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__assembly_price
+msgid ""
+"Assembly share of the customization price in USD. This is a breakdown field;"
+" sales pricing uses Total Customization Price."
 msgstr ""
 
 #. module: trendyol_integration
@@ -909,6 +919,13 @@ msgid "Brand synchronization has been queued."
 msgstr ""
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Brand synchronization page limit reached."
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_export_wizard__trendyol_brand_id
 msgid "Brand to use for all selected products (optional)"
 msgstr ""
@@ -939,6 +956,13 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_cnc
 msgid "CNC Depo Tahmini"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__cnc_price
+msgid ""
+"CNC share of the customization price in USD. This is a breakdown field; "
+"sales pricing uses Total Customization Price."
 msgstr ""
 
 #. module: trendyol_integration
@@ -1083,7 +1107,8 @@ msgid "Category to use for all selected products (optional)"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__changeset_change_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__changeset_change_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__changeset_change_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__changeset_change_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__changeset_change_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__changeset_change_ids
@@ -1109,7 +1134,8 @@ msgid "Changeset Changes"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__changeset_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__changeset_ids
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__changeset_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__changeset_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__changeset_ids
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__changeset_ids
@@ -1234,6 +1260,13 @@ msgid "Claims import has been queued."
 msgstr ""
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Claims import page limit reached."
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__cnc_price
 msgid "Cnc Price"
 msgstr ""
@@ -1255,6 +1288,34 @@ msgid "Commission Amount"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+#, python-format
+msgid "Commission Matching"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_payment_id
 msgid "Commission Payment"
 msgstr ""
@@ -1262,6 +1323,30 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_rate
 msgid "Commission Rate"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matched to the referenced vendor document."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Commission matching is pending."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Commission payment %(payment)s for Trendyol orders %(orders)s was reconciled"
+" with this invoice."
 msgstr ""
 
 #. module: trendyol_integration
@@ -1327,7 +1412,8 @@ msgid "Costing Method"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__count_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__count_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__count_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__count_changesets
@@ -1353,7 +1439,8 @@ msgid "Count Changesets"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__count_pending_changeset_changes
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__count_pending_changeset_changes
@@ -1379,7 +1466,8 @@ msgid "Count Pending Changeset Changes"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__count_pending_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__count_pending_changesets
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__count_pending_changesets
@@ -1595,6 +1683,13 @@ msgid "Customer Name"
 msgstr ""
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Customer Payment Reconciled"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__access_url
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__access_url
 msgid "Customer Portal URL"
@@ -1633,13 +1728,43 @@ msgid ""
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_attribute_value_id
+msgid "Customization Attribute Value"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_base_product_id
+msgid "Customization Base Product"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_flow_report_available
+msgid "Customization Flow Report Available"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_line_ids
 msgid "Customization Lines"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_mrp_signature
+msgid "Customization Mrp Signature"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_prices_auto_update
 msgid "Customization Prices Auto Update"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_request_id
+msgid "Customization Request"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__total_customization_price
+msgid "Customization surcharge used by sales pricing, in USD."
 msgstr ""
 
 #. module: trendyol_integration
@@ -1845,6 +1970,11 @@ msgid "Description on Receptions"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_feature_ids
+msgid "Design Features"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__destination_port
 msgid "Destination port"
 msgstr ""
@@ -1912,6 +2042,11 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__v_min_iscilik_fiy
 msgid "En Az Toplam işçilik Fiyatı USD"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_type_ids
+msgid "Enclosure Types"
 msgstr ""
 
 #. module: trendyol_integration
@@ -2168,6 +2303,13 @@ msgid "Fill this field if you plan to invoice the shipping based on picking."
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_request_id
+msgid ""
+"Final customized product that owns this component. Only set on legacy staged"
+" component variants; new structures no longer generate component variants."
+msgstr ""
+
+#. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
 msgid "Financial"
 msgstr ""
@@ -2259,8 +2401,25 @@ msgid "Full Path"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_mrp_enabled
+msgid "Generate Customization Manufacturing"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__generate_type
 msgid "Generate Type"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_mrp_enabled
+msgid ""
+"Generate staged component variants and BoMs when a customized variant of "
+"this template is approved."
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__generated_customization_bom_ids
+msgid "Generated Customization BoMs"
 msgstr ""
 
 #. module: trendyol_integration
@@ -2480,6 +2639,7 @@ msgstr ""
 
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_1920
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_ids
 msgid "Image"
 msgstr ""
 
@@ -2507,11 +2667,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__image_url
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_url
 msgid "Image URL"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__image_ids
-msgid "Images"
 msgstr ""
 
 #. module: trendyol_integration
@@ -2587,6 +2742,11 @@ msgid "Imported"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__in_analysis
+msgid "In Analysis"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__standard_price
 msgid ""
 "In Standard Price & AVCO: value of the product (automatically computed in AVCO).\n"
@@ -2638,6 +2798,13 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__insert_installation_price
 msgid "Insert Installation Price"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__insert_installation_price
+msgid ""
+"Insert installation share of the customization price in USD. This is a "
+"breakdown field; sales pricing uses Total Customization Price."
 msgstr ""
 
 #. module: trendyol_integration
@@ -2791,6 +2958,11 @@ msgid "Is Published"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
+msgid "Is Trendyol Commission"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__has_configurable_attributes
 msgid "Is a configurable product"
 msgstr ""
@@ -2808,11 +2980,6 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_batch_request__result_data
 msgid "JSON data from batch request result"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model,name:trendyol_integration.model_account_move_line
-msgid "Journal Item"
 msgstr ""
 
 #. module: trendyol_integration
@@ -2857,6 +3024,20 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__laser_marking_price
 msgid "Laser Marking Price"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__lasercut_price
+msgid ""
+"Laser cut share of the customization price in USD. This is a breakdown "
+"field; sales pricing uses Total Customization Price."
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__laser_marking_price
+msgid ""
+"Laser marking share of the customization price in USD. This is a breakdown "
+"field; sales pricing uses Total Customization Price."
 msgstr ""
 
 #. module: trendyol_integration
@@ -2911,6 +3092,11 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_backend__last_question_sync
 msgid "Last Question Sync"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__last_sent_list_price
+msgid "Last Sent List Price"
 msgstr ""
 
 #. module: trendyol_integration
@@ -3039,6 +3225,11 @@ msgid "Main Vendor"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__maintenance_log_ids
+msgid "Maintenance Logs"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.module.category,description:trendyol_integration.module_category_trendyol
 msgid "Manage Trendyol marketplace integration"
 msgstr ""
@@ -3116,6 +3307,11 @@ msgid "Manufacturing Lead Time"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__customization_mrp_locked
+msgid "Manufacturing Structure Locked"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__mrp_production_ids
 msgid "Manufacturing orders associated with this sales order."
 msgstr ""
@@ -3153,6 +3349,21 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_available_maske
 msgid "Maske Depo Mevcut"
+msgstr ""
+
+#. module: trendyol_integration
+#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
+msgid "Match Commission Invoice"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__matched
+msgid "Matched"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_material_ids
+msgid "Materials"
 msgstr ""
 
 #. module: trendyol_integration
@@ -3270,6 +3481,13 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qty_virtual_montaj
 msgid "Montaj Depo Tahmini"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Multiple vendor documents have this commission invoice reference."
 msgstr ""
 
 #. module: trendyol_integration
@@ -3744,6 +3962,13 @@ msgid "Order import has been queued."
 msgstr ""
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Order import page limit reached."
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__invoice_policy
 msgid ""
 "Ordered Quantity: Invoice quantities ordered by the customer.\n"
@@ -3812,6 +4037,13 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__paint_price
 msgid "Paint Price"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__paint_price
+msgid ""
+"Paint share of the customization price in USD. This is a breakdown field; "
+"sales pricing uses Total Customization Price."
 msgstr ""
 
 #. module: trendyol_integration
@@ -3888,6 +4120,7 @@ msgid "Payment Terms"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model,name:trendyol_integration.model_account_payment
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__payment_ids
 msgid "Payments"
 msgstr ""
@@ -4042,6 +4275,11 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__categ_id
 msgid "Product Category"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__facet_ids
+msgid "Product Classes"
 msgstr ""
 
 #. module: trendyol_integration
@@ -4271,8 +4509,8 @@ msgid "Qty Increment Step"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qc_triggers
-msgid "Quality control triggers"
+#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__qc_test_ids
+msgid "Quality Tests"
 msgstr ""
 
 #. module: trendyol_integration
@@ -4344,6 +4582,13 @@ msgstr ""
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Question import has been queued."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Question import page limit reached."
 msgstr ""
 
 #. module: trendyol_integration
@@ -4626,6 +4871,11 @@ msgstr ""
 #. module: trendyol_integration
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_search
 msgid "Returns"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__review
+msgid "Review Required"
 msgstr ""
 
 #. module: trendyol_integration
@@ -4922,8 +5172,8 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_settlement__manual_review_required
 msgid ""
-"Set when reconciliation needs a human decision. Such rows are skipped by "
-"the automatic reconciliation pass."
+"Set when reconciliation needs a human decision. Such rows are skipped by the"
+" automatic reconciliation pass."
 msgstr ""
 
 #. module: trendyol_integration
@@ -4941,6 +5191,13 @@ msgstr ""
 #: code:addons/trendyol_integration/models/trendyol_backend.py:0
 #, python-format
 msgid "Settlement import has been queued."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_backend.py:0
+#, python-format
+msgid "Settlement import page limit reached."
 msgstr ""
 
 #. module: trendyol_integration
@@ -5068,7 +5325,8 @@ msgid "Slicer"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__smart_search
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__smart_search
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__smart_search
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__smart_search
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__smart_search
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__smart_search
@@ -5121,6 +5379,11 @@ msgid ""
 "        Average Cost (AVCO): The products are valued at weighted average cost.\n"
 "        First In First Out (FIFO): The products are valued supposing those that enter the company first will also leave it first.\n"
 "        "
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_base_product_id
+msgid "Standard variant from which this customized product was created."
 msgstr ""
 
 #. module: trendyol_integration
@@ -5529,6 +5792,13 @@ msgid ""
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_mrp_locked
+msgid ""
+"Technical lock that prevents an already-generated customization "
+"specification from being changed in place."
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_order__terms_type
 msgid "Terms & Conditions format"
 msgstr ""
@@ -5544,10 +5814,67 @@ msgid "Test Connection"
 msgstr ""
 
 #. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The API commission invoice reference was updated. Existing payment "
+"reconciliations were preserved."
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_order__country_code
 msgid ""
 "The ISO country code in two chars. \n"
 "You can use this field for quick search."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment amount differs from its settlement rows."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment and vendor document currencies differ."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment exceeds the referenced vendor document's remaining "
+"balance."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment is already reconciled with another document. Existing"
+" reconciliations were preserved."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The commission payment is closed without a matching vendor document."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment partner or company does not match the Trendyol "
+"backend."
 msgstr ""
 
 #. module: trendyol_integration
@@ -5556,7 +5883,8 @@ msgid "The internal user in charge of this contact."
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_move_line__count_pending_changeset_changes
+#: model:ir.model.fields,help:trendyol_integration.field_account_auto_reconcile__count_pending_changeset_changes
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__count_pending_changeset_changes
 #: model:ir.model.fields,help:trendyol_integration.field_product_product__count_pending_changeset_changes
 #: model:ir.model.fields,help:trendyol_integration.field_product_template__count_pending_changeset_changes
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__count_pending_changeset_changes
@@ -5582,7 +5910,8 @@ msgid "The number of pending changes of this record"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_move_line__count_pending_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_auto_reconcile__count_pending_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__count_pending_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_product__count_pending_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_template__count_pending_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__count_pending_changesets
@@ -5608,7 +5937,8 @@ msgid "The number of pending changesets of this record"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_account_move_line__count_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_auto_reconcile__count_changesets
+#: model:ir.model.fields,help:trendyol_integration.field_account_payment__count_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_product__count_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_product_template__count_changesets
 #: model:ir.model.fields,help:trendyol_integration.field_res_partner__count_changesets
@@ -5653,6 +5983,13 @@ msgstr ""
 msgid ""
 "The sale price is managed from the product template. Click on the 'Configure"
 " Variants' button to set the extra attribute prices."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "The vendor document has no compatible open payable lines."
 msgstr ""
 
 #. module: trendyol_integration
@@ -5716,6 +6053,25 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__price_extra
 msgid "This is the sum of the extra price of all attributes"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"This payment covers multiple commission invoice references. Review is "
+"required."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"This payout row arrived after the payout was reconciled. Its commission is "
+"not covered by the commission payment already recorded and needs manual "
+"review."
 msgstr ""
 
 #. module: trendyol_integration
@@ -5851,11 +6207,6 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__total_margin_rate
 msgid "Total margin * 100 / Turnover"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__total_customization_price
-msgid "Total price for all customizations in USD."
 msgstr ""
 
 #. module: trendyol_integration
@@ -6078,6 +6429,11 @@ msgid "Trendyol Commission - Order %s"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_settlement_ids
+msgid "Trendyol Commission Settlement"
+msgstr ""
+
+#. module: trendyol_integration
 #. odoo-python
 #: code:addons/trendyol_integration/models/trendyol_order.py:0
 #, python-format
@@ -6265,6 +6621,14 @@ msgstr ""
 
 #. module: trendyol_integration
 #. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_order.py:0
+#, python-format
+msgid ""
+"Trendyol customer information is not available yet. Retry the import later."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
 #: code:addons/trendyol_integration/models/stock_picking.py:0
 #, python-format
 msgid ""
@@ -6377,8 +6741,27 @@ msgid "UTM source to set on Trendyol orders"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__print_price
+msgid ""
+"UV print share of the customization price in USD. This is a breakdown field;"
+" sales pricing uses Total Customization Price."
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__unanswered
+msgid "Unanswered"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_order__trendyol_status__undelivered
 msgid "Undelivered"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__customization_attribute_value_id
+msgid ""
+"Unique customization identifier shared by the final product and all of its "
+"generated components."
 msgstr ""
 
 #. module: trendyol_integration
@@ -6389,41 +6772,6 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__uom_name
 msgid "Unit of Measure Name"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__cnc_price
-msgid "Unit price for CNC customization in USD."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__print_price
-msgid "Unit price for UV print customization in USD."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__assembly_price
-msgid "Unit price for assembly customization in USD."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__insert_installation_price
-msgid "Unit price for insert installation customization in USD."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__lasercut_price
-msgid "Unit price for laser cut customization in USD."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__laser_marking_price
-msgid "Unit price for laser marking customization in USD."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,help:trendyol_integration.field_trendyol_product_binding__paint_price
-msgid "Unit price for paint customization in USD."
 msgstr ""
 
 #. module: trendyol_integration
@@ -6507,7 +6855,8 @@ msgid "User"
 msgstr ""
 
 #. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_move_line__user_can_see_changeset
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_auto_reconcile__user_can_see_changeset
+#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__user_can_see_changeset
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_product__user_can_see_changeset
 #: model:ir.model.fields,field_description:trendyol_integration.field_product_template__user_can_see_changeset
 #: model:ir.model.fields,field_description:trendyol_integration.field_res_partner__user_can_see_changeset
@@ -6677,6 +7026,16 @@ msgid "Volume unit of measure label"
 msgstr ""
 
 #. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__waiting
+msgid "Waiting"
+msgstr ""
+
+#. module: trendyol_integration
+#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
+msgid "Waiting Fraud Check"
+msgstr ""
+
+#. module: trendyol_integration
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_in_action
 msgid "Waiting In Action"
 msgstr ""
@@ -6691,6 +7050,28 @@ msgstr ""
 #: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__waiting_for_approve
 #: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_question_search
 msgid "Waiting for Approve"
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission invoice number from Trendyol."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid "Waiting for the commission payment to be posted."
+msgstr ""
+
+#. module: trendyol_integration
+#. odoo-python
+#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
+#, python-format
+msgid ""
+"Waiting for the referenced DSM vendor bill or credit note to be posted."
 msgstr ""
 
 #. module: trendyol_integration
@@ -6908,265 +7289,4 @@ msgstr ""
 #. module: trendyol_integration
 #: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__v_fiyat_onceki_iscilik
 msgid "Önceki İşçilik Fiyatı"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Brand synchronization page limit reached."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Claims import page limit reached."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__in_analysis
-msgid "In Analysis"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_product_binding__last_sent_list_price
-msgid "Last Sent List Price"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Order import page limit reached."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Question import page limit reached."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_backend.py:0
-#, python-format
-msgid "Settlement import page limit reached."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "This payout row arrived after the payout was reconciled. Its commission is not covered by the commission payment already recorded and needs manual review."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_question__status__unanswered
-msgid "Unanswered"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_claim__claim_status__waiting_fraud_check
-msgid "Waiting Fraud Check"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_id
-msgid "Commission Invoice"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_invoice_number
-msgid "Commission Invoice Number"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_note
-msgid "Commission Match Note"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_trendyol_settlement__commission_match_state
-msgid "Commission Match State"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
-#, python-format
-msgid "Commission Matching"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Commission matched to the referenced vendor document."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Commission matching is pending."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Customer Payment Reconciled"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__is_trendyol_commission
-msgid "Is Trendyol Commission"
-msgstr ""
-
-#. module: trendyol_integration
-#: model_terms:ir.ui.view,arch_db:trendyol_integration.view_trendyol_settlement_form
-msgid "Match Commission Invoice"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__matched
-msgid "Matched"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Multiple vendor documents have this commission invoice reference."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__review
-msgid "Review Required"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The commission payment amount differs from its settlement rows."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The commission payment and vendor document currencies differ."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The commission payment exceeds the referenced vendor document's remaining "
-"balance."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The commission payment is already reconciled with another document. Existing"
-" reconciliations were preserved."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The commission payment is closed without a matching vendor document."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The commission payment partner or company does not match the Trendyol "
-"backend."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "The vendor document has no compatible open payable lines."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"This payment covers multiple commission invoice references. Review is "
-"required."
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields,field_description:trendyol_integration.field_account_payment__trendyol_commission_settlement_ids
-msgid "Trendyol Commission Settlement"
-msgstr ""
-
-#. module: trendyol_integration
-#: model:ir.model.fields.selection,name:trendyol_integration.selection__trendyol_settlement__commission_match_state__waiting
-msgid "Waiting"
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Waiting for the commission invoice number from Trendyol."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid "Waiting for the commission payment to be posted."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"Waiting for the referenced DSM vendor bill or credit note to be posted."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"The API commission invoice reference was updated. Existing payment "
-"reconciliations were preserved."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_order.py:0
-#, python-format
-msgid ""
-"Trendyol customer information is not available yet. Retry the import later."
-msgstr ""
-
-#. module: trendyol_integration
-#. odoo-python
-#: code:addons/trendyol_integration/models/trendyol_settlement.py:0
-#, python-format
-msgid ""
-"Commission payment %(payment)s for Trendyol orders %(orders)s was reconciled "
-"with this invoice."
 msgstr ""


### PR DESCRIPTION
Complete the regenerated Turkish catalogs for `marketplace_integration_base` and `trendyol_integration`. Fill 87 missing Trendyol translations and replace long or misleading wording with consistent UI terms across both modules.

Examples include Backend → Entegrasyon, Sync → Eşitleme, Payment Journal → Ödeme Yevmiyesi, and settlement Receipt → Dekont. Correct Trendyol-specific meanings such as Picking → Hazırlanıyor, UnPacked → Paket Bölündü, and Slicer → Ayrı Ürün Kartı Oluşturur. Keep list and sale prices distinct, and retain accounting conditions, units and technical placeholders in shortened help text.

Includes the regenerated POT files. Both catalogs are complete: 103 base entries and 1,210 Trendyol entries, with no missing or fuzzy translations.

Validation:

- `msgfmt --check --check-format` for both Turkish catalogs.
- PO/POT key parity, duplicate detection, placeholder consistency, HTML structure and report-expression syntax checks.
- `pre-commit run -a` and `git diff --check`.
