### PR TITLE
[IMP] Complete Hepsiburada commission reconciliation

### DIFF
--- a/hepsiburada_integration/__manifest__.py
+++ b/hepsiburada_integration/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Hepsiburada Marketplace Integration",
-    "version": "16.0.1.1.2",
+    "version": "16.0.1.2.0",
     "category": "Sales/Sales",
     "summary": "Integrate Odoo with Hepsiburada marketplace (orders, invoices, status)",
     "author": "Ahmet Yigit Budak, Altinkaya Enclosures",
@@ -15,6 +15,7 @@
         "sale_management",
         "stock",
         "account",
+        "altinkaya_account",
         "queue_job",
         "delivery",
         "delivery_integration_base",

--- a/hepsiburada_integration/i18n/hepsiburada_integration.pot
+++ b/hepsiburada_integration/i18n/hepsiburada_integration.pot
@@ -3920,3 +3920,175 @@ msgstr ""
 #: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_order__hb_status__cancelled
 msgid "İptal Edildi"
 msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid "A payment was posted before Hepsiburada marked the transaction Paid."
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model,name:hepsiburada_integration.model_account_auto_reconcile
+msgid "Account Auto Reconcile"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Check the commission amount, currency, partner and journal."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Claim import exceeded 100,000 records"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Commission Matching"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Pending"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__commission_refund
+msgid "Commission Refund"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Review"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Commission data changed; the existing payment was preserved."
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__hepsiburada_commission_settlement_ids
+msgid "Hepsiburada Commission Settlement"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__invoice_date
+msgid "Invoice Date"
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__is_hepsiburada_commission
+msgid "Is Hepsiburada Commission"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid ""
+"Legacy commission payment has no matched supplier invoice and must be "
+"reviewed."
+msgstr ""
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Match Commission Invoice"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Multiple posted customer documents require review."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Question import exceeded %s pages"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Reconciliation Failed"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Settlement import exceeded 100,000 records for %(window)s"
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The Hepsiburada payment status is unknown."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The commission direction, amount or currency is invalid."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The payment covers incompatible commission types."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The settlement amount has an invalid sign."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "This transaction type is not supported for automatic reconciliation."
+msgstr ""
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Transaction %s has no key for historical refresh."
+msgstr ""

--- a/hepsiburada_integration/i18n/tr.po
+++ b/hepsiburada_integration/i18n/tr.po
@@ -3954,3 +3954,180 @@ msgstr "İptal Edildi"
 
 #~ msgid "Waiting Customer"
 #~ msgstr "Müşteri Bekleniyor"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid "A payment was posted before Hepsiburada marked the transaction Paid."
+msgstr ""
+"Hepsiburada işlemi ödendi olarak işaretlemeden önce ödeme kaydı "
+"oluşturulmuş."
+
+#. module: hepsiburada_integration
+#: model:ir.model,name:hepsiburada_integration.model_account_auto_reconcile
+msgid "Account Auto Reconcile"
+msgstr "Otomatik Hesap Uzlaştırma"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Check the commission amount, currency, partner and journal."
+msgstr ""
+"Komisyon tutarını, para birimini, iş ortağını ve yevmiyeyi kontrol edin."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Claim import exceeded 100,000 records"
+msgstr "Talep aktarımı 100.000 kaydı aştı"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_id
+msgid "Commission Invoice"
+msgstr "Komisyon Faturası"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_invoice_number
+msgid "Commission Invoice Number"
+msgstr "Komisyon Fatura No."
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_note
+msgid "Commission Match Note"
+msgstr "Komisyon Uzlaştırma Notu"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__commission_match_state
+msgid "Commission Match State"
+msgstr "Komisyon Uzlaştırma Durumu"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Commission Matching"
+msgstr "Komisyon Uzlaştırma"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Pending"
+msgstr "Komisyon Bekliyor"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields.selection,name:hepsiburada_integration.selection__hepsiburada_settlement__transaction_type__commission_refund
+msgid "Commission Refund"
+msgstr "Komisyon İadesi"
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_search
+msgid "Commission Review"
+msgstr "Komisyon İncelemesi"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Commission data changed; the existing payment was preserved."
+msgstr "Komisyon bilgileri değişti; mevcut ödeme korundu."
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__hepsiburada_commission_settlement_ids
+msgid "Hepsiburada Commission Settlement"
+msgstr "Hepsiburada Komisyon Hesaplaşması"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_hepsiburada_settlement__invoice_date
+msgid "Invoice Date"
+msgstr "Fatura Tarihi"
+
+#. module: hepsiburada_integration
+#: model:ir.model.fields,field_description:hepsiburada_integration.field_account_payment__is_hepsiburada_commission
+msgid "Is Hepsiburada Commission"
+msgstr "Hepsiburada Komisyonu"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/migrations/16.0.1.1.0/post-migration.py:0
+#, python-format
+msgid ""
+"Legacy commission payment has no matched supplier invoice and must be "
+"reviewed."
+msgstr ""
+"Eski komisyon ödemesinin eşleşen tedarikçi faturası yok; incelenmesi "
+"gerekiyor."
+
+#. module: hepsiburada_integration
+#: model_terms:ir.ui.view,arch_db:hepsiburada_integration.view_hepsiburada_settlement_form
+msgid "Match Commission Invoice"
+msgstr "Komisyonu Uzlaştır"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Multiple posted customer documents require review."
+msgstr "Birden fazla onaylanmış müşteri belgesi var; incelenmesi gerekiyor."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Question import exceeded %s pages"
+msgstr "Soru aktarımı %s sayfayı aştı"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "Reconciliation Failed"
+msgstr "Uzlaştırma Başarısız"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Settlement import exceeded 100,000 records for %(window)s"
+msgstr "%(window)s aralığındaki hesaplaşma aktarımı 100.000 kaydı aştı"
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The Hepsiburada payment status is unknown."
+msgstr "Hepsiburada ödeme durumu bilinmiyor."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The commission direction, amount or currency is invalid."
+msgstr "Komisyonun yönü, tutarı veya para birimi geçersiz."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The payment covers incompatible commission types."
+msgstr "Ödeme, birbiriyle uyumsuz komisyon türleri içeriyor."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "The settlement amount has an invalid sign."
+msgstr "Hesaplaşma tutarının işareti işlem yönüyle uyuşmuyor."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_settlement.py:0
+#, python-format
+msgid "This transaction type is not supported for automatic reconciliation."
+msgstr "Bu işlem türü otomatik uzlaştırma için desteklenmiyor."
+
+#. module: hepsiburada_integration
+#. odoo-python
+#: code:addons/hepsiburada_integration/models/hepsiburada_backend.py:0
+#, python-format
+msgid "Transaction %s has no key for historical refresh."
+msgstr "%s işlemini geçmişten yenilemek için gerekli bilgiler bulunamadı."

--- a/hepsiburada_integration/migrations/16.0.1.2.0/post-migration.py
+++ b/hepsiburada_integration/migrations/16.0.1.2.0/post-migration.py
@@ -1,0 +1,12 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import SUPERUSER_ID, api
+
+
+def migrate(cr, version):
+    """Classify stored refund rows without changing their accounting links."""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env["hepsiburada.settlement"].search(
+        [("hb_transaction_type", "in", ("CommissionRefund", "CommissionInvoiceRefund"))]
+    ).write({"transaction_type": "commission_refund"})

--- a/hepsiburada_integration/models/__init__.py
+++ b/hepsiburada_integration/models/__init__.py
@@ -13,3 +13,5 @@ from . import stock_picking
 from . import hepsiburada_settlement
 from . import hepsiburada_question
 from . import hepsiburada_claim
+from . import account_payment
+from . import account_auto_reconcile

--- a/hepsiburada_integration/models/account_auto_reconcile.py
+++ b/hepsiburada_integration/models/account_auto_reconcile.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import models
+
+
+class AccountAutoReconcile(models.AbstractModel):
+    _inherit = "account.auto.reconcile"
+
+    def _get_payment_lines_domain(self, move, pay_term_account_ids):
+        """Reserve Hepsiburada commissions for their API-referenced vendor bills."""
+        return super()._get_payment_lines_domain(move, pay_term_account_ids) + [
+            ("payment_id.is_hepsiburada_commission", "=", False),
+        ]

--- a/hepsiburada_integration/models/account_payment.py
+++ b/hepsiburada_integration/models/account_payment.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from odoo import api, fields, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    hepsiburada_commission_settlement_ids = fields.One2many(
+        "hepsiburada.settlement", "commission_payment_id"
+    )
+    is_hepsiburada_commission = fields.Boolean(
+        compute="_compute_is_hepsiburada_commission", store=True, index=True
+    )
+
+    @api.depends("hepsiburada_commission_settlement_ids")
+    def _compute_is_hepsiburada_commission(self):
+        """Reserve current and historical commission payments by actual links."""
+        for payment in self:
+            payment.is_hepsiburada_commission = bool(
+                payment.hepsiburada_commission_settlement_ids
+            )

--- a/hepsiburada_integration/models/hepsiburada_backend.py
+++ b/hepsiburada_integration/models/hepsiburada_backend.py
@@ -615,7 +615,7 @@ class HepsiburadaBackend(models.Model):
             _("Settlement import has been queued."),
         )
 
-    def _import_settlement_window(self, client, window_start, window_end):
+    def _import_settlement_window(self, client, window_start, window_end, **filters):
         """Import one settlement window.
 
         Returns:
@@ -623,8 +623,8 @@ class HepsiburadaBackend(models.Model):
             Only fetch errors mean the window was not fully read.
         """
         Settlement = self.env["hepsiburada.settlement"]
-        start_str = window_start.strftime("%Y-%m-%d")
-        end_str = window_end.strftime("%Y-%m-%d")
+        start_str = window_start.strftime("%Y-%m-%d") if window_start else None
+        end_str = window_end.strftime("%Y-%m-%d") if window_end else None
         imported = Settlement.browse()
         fetch_errors = []
         record_errors = []
@@ -636,6 +636,7 @@ class HepsiburadaBackend(models.Model):
                     record_date_end=end_str,
                     offset=offset,
                     limit=100,
+                    **filters,
                 )
             except HepsiburadaAPIError as error:
                 fetch_errors.append(f"{start_str} - {end_str}: {error}")
@@ -678,21 +679,26 @@ class HepsiburadaBackend(models.Model):
 
     @staticmethod
     def _is_reconcilable_settlement(settlement):
-        """Only paid sale/return rows may be handed to _reconcile()."""
+        """Clear known financial transactions; bank payout status is independent."""
         return (
-            settlement.transaction_type in ("sale", "return")
-            and str(settlement.payment_status or "").lower() == "paid"
+            settlement.transaction_type
+            in ("sale", "return", "commission", "commission_refund")
+            and str(settlement.payment_status or "").lower() in ("paid", "willbepaid")
             and settlement.state in ("imported", "error")
             and not settlement.requires_manual_review
         )
 
-    def _reconcile_paid_settlements(self, imported_settlements):
+    def _reconcile_settlements(self, imported_settlements):
         Settlement = self.env["hepsiburada.settlement"]
         retryable = Settlement.search(
             [
                 ("backend_id", "=", self.id),
-                ("transaction_type", "in", ("sale", "return")),
-                ("payment_status", "=ilike", "Paid"),
+                (
+                    "transaction_type",
+                    "in",
+                    ("sale", "return", "commission", "commission_refund"),
+                ),
+                ("payment_status", "in", ("Paid", "WillBePaid")),
                 ("state", "in", ("imported", "error")),
                 ("requires_manual_review", "=", False),
             ]
@@ -719,10 +725,83 @@ class HepsiburadaBackend(models.Model):
                     group_key,
                 )
 
+    def _refresh_pending_settlements(self, client):
+        """Re-read old references and payout statuses without moving the cursor."""
+        self.ensure_one()
+        Settlement = self.env["hepsiburada.settlement"]
+        pending = Settlement.search(
+            [
+                ("backend_id", "=", self.id),
+                "|",
+                ("payment_status", "=ilike", "WillBePaid"),
+                "&",
+                ("transaction_type", "in", ("commission", "commission_refund")),
+                ("commission_invoice_number", "=", False),
+            ]
+        )
+        refreshed = Settlement.browse()
+        errors = []
+        seen = set()
+        for row in pending:
+            reference = (row.invoice_number or "").strip()
+            filters = {}
+            start = end = None
+            if row.order_number and row.order_number != "None":
+                key = ("order_number", row.order_number)
+                filters = {"order_number": row.order_number}
+            elif reference and reference != ".":
+                key = ("reference_document", reference)
+                filters = {"reference_document": reference}
+            elif row.transaction_date:
+                start = fields.Datetime.to_datetime(row.transaction_date.date())
+                end = start + timedelta(days=1)
+                key = ("record_date", start)
+            else:
+                errors.append(
+                    _("Transaction %s has no key for historical refresh.")
+                    % row.hb_transaction_id
+                )
+                continue
+            if key in seen:
+                continue
+            seen.add(key)
+            rows, fetch_errors, record_errors = self._import_settlement_window(
+                client, start, end, **filters
+            )
+            refreshed |= rows
+            errors.extend(fetch_errors + record_errors)
+        return refreshed, errors
+
+    def _reconcile_pending_commissions(self):
+        """Retry open commission payments, including historical linked payments."""
+        self.ensure_one()
+        payments = (
+            self.env["hepsiburada.settlement"]
+            .search(
+                [
+                    ("backend_id", "=", self.id),
+                    ("commission_payment_id.state", "=", "posted"),
+                    ("commission_payment_id.is_reconciled", "=", False),
+                ]
+            )
+            .commission_payment_id
+        )
+        for payment in payments:
+            rows = payment.hepsiburada_commission_settlement_ids
+            try:
+                with self.env.cr.savepoint():
+                    rows[:1]._reconcile_commission_invoice()
+            except Exception as error:
+                rows._set_commission_match("review", str(error))
+                _logger.exception(
+                    "Failed to match HB commission payment %s", payment.id
+                )
+
     def _import_settlements(self):
         """Import settlements from Hepsiburada finance API.
 
-        Import complete financial records first, then reconcile paid order groups.
+        Refresh pending metadata and clear customer/vendor balances separately
+        from the marketplace's bank payout status.
         """
         self.ensure_one()
         client = self._get_api_client()
@@ -736,7 +815,8 @@ class HepsiburadaBackend(models.Model):
         completed_until = start_date
         total_imported = 0
         errors = []
-        imported_settlements = self.env["hepsiburada.settlement"].browse()
+        imported_settlements, refresh_errors = self._refresh_pending_settlements(client)
+        errors.extend(refresh_errors)
 
         while window_start < end_date:
             window_end = min(window_start + timedelta(days=14), end_date)
@@ -757,7 +837,8 @@ class HepsiburadaBackend(models.Model):
             window_start = window_end
 
         if self.auto_reconcile_settlements:
-            self._reconcile_paid_settlements(imported_settlements)
+            self._reconcile_settlements(imported_settlements)
+            self._reconcile_pending_commissions()
 
         vals = {"last_settlement_sync": completed_until}
         if errors:

--- a/hepsiburada_integration/models/hepsiburada_request.py
+++ b/hepsiburada_integration/models/hepsiburada_request.py
@@ -462,6 +462,8 @@ class HepsiburadaRequest(MarketplaceRequest):
         transaction_types=None,
         offset=0,
         limit=100,
+        order_number=None,
+        reference_document=None,
     ):
         """Get financial transactions from the accounting API.
 
@@ -469,6 +471,8 @@ class HepsiburadaRequest(MarketplaceRequest):
             record_date_start: Start date string (YYYY-MM-DD)
             record_date_end: End date string (YYYY-MM-DD)
             transaction_types: Comma-separated types (e.g. "Payment,Commission")
+            order_number: Refresh all transactions of this order without date limits.
+            reference_document: Refresh transactions for this invoice reference.
             offset: Pagination offset
             limit: Page size (max 100)
 
@@ -486,6 +490,10 @@ class HepsiburadaRequest(MarketplaceRequest):
             params["recordDateEnd"] = record_date_end
         if transaction_types:
             params["transactionTypes"] = transaction_types
+        if order_number:
+            params["orderNumber"] = order_number
+        if reference_document:
+            params["ReferenceDocument"] = reference_document
 
         return self._make_request("GET", "finance", endpoint, params=params)
 

--- a/hepsiburada_integration/models/hepsiburada_settlement.py
+++ b/hepsiburada_integration/models/hepsiburada_settlement.py
@@ -5,7 +5,6 @@ import json
 import logging
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
 
 from .hepsiburada_backend import _parse_hb_datetime
 
@@ -17,6 +16,8 @@ TRANSACTION_TYPE_MAP = {
     "Return": "return",
     "BnplRefund": "return",
     "Commission": "commission",
+    "CommissionRefund": "commission_refund",
+    "CommissionInvoiceRefund": "commission_refund",
 }
 
 
@@ -39,12 +40,14 @@ class HepsiburadaSettlement(models.Model):
     transaction_type = fields.Selection(
         selection_add=[
             ("commission", "Commission"),
+            ("commission_refund", "Commission Refund"),
             ("expense", "Expense"),
             ("income", "Income"),
             ("other", "Other"),
         ],
         ondelete={
             "commission": "cascade",
+            "commission_refund": "cascade",
             "expense": "cascade",
             "income": "cascade",
             "other": "cascade",
@@ -69,9 +72,13 @@ class HepsiburadaSettlement(models.Model):
     currency_code = fields.Char(help="949=TRY, 840=USD")
 
     # Payment info
+    invoice_date = fields.Datetime()
     payment_date = fields.Datetime()
     payment_status = fields.Char(help="Paid / WillBePaid")
-    invoice_number = fields.Char()
+    invoice_number = fields.Char(index=True)
+    commission_invoice_number = fields.Char(
+        compute="_compute_commission_invoice_number", store=True, index=True
+    )
 
     # Odoo links
     hb_order_id = fields.Many2one(
@@ -115,6 +122,18 @@ class HepsiburadaSettlement(models.Model):
         ),
     ]
 
+    @api.depends("invoice_number", "transaction_type")
+    def _compute_commission_invoice_number(self):
+        """Treat the API's dot placeholder as a missing invoice reference."""
+        for row in self:
+            number = (row.invoice_number or "").strip()
+            row.commission_invoice_number = (
+                number
+                if row.transaction_type in ("commission", "commission_refund")
+                and number not in ("", ".")
+                else False
+            )
+
     @staticmethod
     def _numeric_value(value):
         """Extract a scalar from Hepsiburada's nested money objects."""
@@ -149,7 +168,7 @@ class HepsiburadaSettlement(models.Model):
             )
 
         # Find linked hepsiburada.order
-        order_number = str(data.get("orderNumber", ""))
+        order_number = str(data.get("orderNumber") or "")
         hb_order = False
         if order_number:
             hb_order = self.env["hepsiburada.order"].search(
@@ -198,6 +217,7 @@ class HepsiburadaSettlement(models.Model):
                 "tax_amount": self._numeric_value(data.get("taxAmount", 0.0)),
                 "quantity": self._numeric_value(data.get("quantity", 0.0)),
                 "currency_code": str(currency_code or "949"),
+                "invoice_date": _parse_hb_datetime(data.get("invoiceDate")),
                 "payment_date": _parse_hb_datetime(data.get("paymentDate"))
                 or fields.Datetime.to_datetime(data.get("paymentDate")),
                 "payment_status": data.get("status", ""),
@@ -206,7 +226,26 @@ class HepsiburadaSettlement(models.Model):
                 "raw_data": json.dumps(data, indent=2, ensure_ascii=False),
             }
             if existing:
+                commission_changed = any(
+                    existing[field] != vals[field]
+                    for field in (
+                        "invoice_number",
+                        "amount",
+                        "currency_code",
+                        "hb_transaction_type",
+                    )
+                )
                 existing.write(vals)
+                if existing.commission_payment_id and commission_changed:
+                    existing._set_commission_match(
+                        "review"
+                        if existing.commission_payment_id.is_reconciled
+                        else "waiting",
+                        _(
+                            "Commission data changed; "
+                            "the existing payment was preserved."
+                        ),
+                    )
                 settlement = existing
             else:
                 settlement = self.create(vals)
@@ -248,30 +287,135 @@ class HepsiburadaSettlement(models.Model):
             commission_amt = abs(self.amount)
         return commission_amt
 
+    def _commission_payment_rows(self, payment):
+        """Return current and historical links, not a reference-text heuristic."""
+        return payment.hepsiburada_commission_settlement_ids
+
+    def _commission_row_amount(self):
+        """HB amount already includes tax; netAmount excludes it."""
+        self.ensure_one()
+        return abs(self.amount)
+
+    def _commission_document_type(self, payment):
+        """Distinguish HB credit notes from our commission refund invoices."""
+        self.ensure_one()
+        return {
+            "Commission": "in_invoice",
+            "CommissionRefund": "in_refund",
+            "CommissionInvoiceRefund": "out_invoice",
+        }.get(self.hb_transaction_type, "in_invoice")
+
+    def _reconcile_commission_invoice(self):
+        """Validate HB row direction and currency before shared exact matching."""
+        self.ensure_one()
+        payment = self.commission_payment_id
+        if not payment:
+            return False
+        rows = self._commission_payment_rows(payment)
+        expected_types = {
+            "Commission": ("outbound", False),
+            "CommissionRefund": ("inbound", True),
+            "CommissionInvoiceRefund": ("inbound", True),
+        }
+        if len(set(rows.mapped("hb_transaction_type"))) != 1:
+            return rows._set_commission_match(
+                "review", _("The payment covers incompatible commission types.")
+            )
+        expected = expected_types.get(self.hb_transaction_type)
+        if (
+            not expected
+            or rows.filtered(
+                lambda row: (
+                    not row.is_invoice
+                    or row.is_income != expected[1]
+                    or row.amount == 0
+                    or (row.amount > 0) != expected[1]
+                    or {"949": "TRY", "840": "USD"}.get(row.currency_code)
+                    != payment.currency_id.name
+                )
+            )
+            or payment.payment_type != expected[0]
+        ):
+            return rows._set_commission_match(
+                "review", _("The commission direction, amount or currency is invalid.")
+            )
+        return super()._reconcile_commission_invoice()
+
+    def _reconcile_commission(self):
+        """Create one clearing payment per HB transaction, then match its invoice."""
+        self.ensure_one()
+        if self.commission_payment_id:
+            return self._reconcile_commission_invoice()
+        backend = self.backend_id
+        journal = backend.settlement_journal_id
+        currency = journal.currency_id or backend.company_id.currency_id
+        refund = self.hb_transaction_type in (
+            "CommissionRefund",
+            "CommissionInvoiceRefund",
+        )
+        if (
+            not journal
+            or not backend.hb_partner_id
+            or journal.company_id != backend.company_id
+            or {"949": "TRY", "840": "USD"}.get(self.currency_code) != currency.name
+            or not self.is_invoice
+            or self.is_income != refund
+            or not self.amount
+            or (self.amount > 0) != refund
+        ):
+            self._set_commission_match(
+                "review",
+                _("Check the commission amount, currency, partner and journal."),
+            )
+            return False
+        payment = self.env["account.payment"].create(
+            {
+                "payment_type": "inbound" if refund else "outbound",
+                "partner_type": "customer"
+                if self.hb_transaction_type == "CommissionInvoiceRefund"
+                else "supplier",
+                "partner_id": backend.hb_partner_id.id,
+                "amount": abs(self.amount),
+                "currency_id": currency.id,
+                "journal_id": journal.id,
+                "date": fields.Date.to_date(self.transaction_date or self.invoice_date)
+                or fields.Date.context_today(self),
+                "ref": self._marketplace_commission_ref(),
+            }
+        )
+        # Link before posting so generic auto-reconciliation cannot consume it.
+        self.commission_payment_id = payment
+        payment.action_post()
+        self.write({"state": "reconciled", "error_message": False})
+        return self._reconcile_commission_invoice()
+
     def _reconciliation_group_key(self):
         """Dedup key matching the domain fields of _reconciliation_group()."""
         self.ensure_one()
+        if self.transaction_type in ("commission", "commission_refund"):
+            return (self._name, self.id)
         return (
             self.backend_id.id,
             self.order_number,
             self.package_number,
             self.transaction_type,
-            self.payment_status,
-            self.payment_date,
             self.currency_code,
             self.invoice_number,
         )
 
     def _reconciliation_group(self):
         self.ensure_one()
+        if (
+            self.transaction_type in ("commission", "commission_refund")
+            or not self.order_number
+        ):
+            return self
         return self.search(
             [
                 ("backend_id", "=", self.backend_id.id),
                 ("order_number", "=", self.order_number),
                 ("package_number", "=", self.package_number),
                 ("transaction_type", "=", self.transaction_type),
-                ("payment_status", "=", self.payment_status),
-                ("payment_date", "=", self.payment_date),
                 ("currency_code", "=", self.currency_code),
                 ("invoice_number", "=", self.invoice_number),
             ]
@@ -292,23 +436,47 @@ class HepsiburadaSettlement(models.Model):
         group.write(vals)
 
     def _reconcile(self):
-        """Reconcile one paid order group using the API transaction total."""
+        """Clear customer/vendor balances independently of the bank payout status."""
         self.ensure_one()
         group = self._reconciliation_group()
-        if self.transaction_type not in ("sale", "return"):
+        if self.transaction_type not in (
+            "sale",
+            "return",
+            "commission",
+            "commission_refund",
+        ):
             self._set_group_error(
                 group,
-                _("Only paid sale and return transactions can be reconciled."),
+                _(
+                    "This transaction type is not supported "
+                    "for automatic reconciliation."
+                ),
             )
             return False
-        if str(self.payment_status or "").lower() != "paid":
+        if group.filtered(
+            lambda row: (
+                str(row.payment_status or "").lower() not in ("paid", "willbepaid")
+            )
+        ):
             self._set_group_error(
                 group,
-                _("Hepsiburada has not paid this transaction yet."),
+                _("The Hepsiburada payment status is unknown."),
             )
             return False
+        if self.commission_payment_id and self.transaction_type in (
+            "commission",
+            "commission_refund",
+        ):
+            return self._reconcile_commission_invoice()
         if group.filtered("requires_manual_review"):
             return False
+        if self.transaction_type in ("commission", "commission_refund"):
+            return self._reconcile_commission()
+        return self._reconcile_customer_group(group)
+
+    def _reconcile_customer_group(self, group):
+        """Clear one complete customer invoice using its signed API row totals."""
+        self.ensure_one()
         if not self.backend_id.settlement_journal_id:
             self._set_group_error(
                 group,
@@ -327,11 +495,16 @@ class HepsiburadaSettlement(models.Model):
         invoice_type = (
             "out_invoice" if self.transaction_type == "sale" else "out_refund"
         )
-        invoice = fields.first(
-            order.odoo_id.invoice_ids.filtered(
-                lambda move: move.state == "posted" and move.move_type == invoice_type
-            )
+        invoice = order.odoo_id.invoice_ids.filtered(
+            lambda move: move.state == "posted" and move.move_type == invoice_type
         )
+        if len(invoice) > 1:
+            self._set_group_error(
+                group,
+                _("Multiple posted customer documents require review."),
+                manual_review=True,
+            )
+            return False
         if not invoice:
             self._set_group_error(
                 group,
@@ -342,7 +515,7 @@ class HepsiburadaSettlement(models.Model):
 
         currency = invoice.currency_id
         expected_currency = {"949": "TRY", "840": "USD"}.get(self.currency_code)
-        if expected_currency and currency.name != expected_currency:
+        if currency.name != expected_currency:
             self._set_group_error(
                 group,
                 _(
@@ -354,7 +527,10 @@ class HepsiburadaSettlement(models.Model):
             return False
         journal = self.backend_id.settlement_journal_id
         journal_currency = journal.currency_id or journal.company_id.currency_id
-        if journal_currency != currency:
+        if (
+            journal_currency != currency
+            or journal.company_id != self.backend_id.company_id
+        ):
             self._set_group_error(
                 group,
                 _(
@@ -365,11 +541,38 @@ class HepsiburadaSettlement(models.Model):
             )
             return False
 
+        if group.filtered(
+            lambda row: (
+                not row.amount or (row.amount > 0) != (row.transaction_type == "sale")
+            )
+        ):
+            self._set_group_error(
+                group, _("The settlement amount has an invalid sign.")
+            )
+            return False
         group_amount = sum(abs(amount) for amount in group.mapped("amount"))
         existing_payments = group.mapped("odoo_payment_id")
         if existing_payments:
+            payment_lines = existing_payments.move_id.line_ids.filtered(
+                lambda line: line.account_type == "asset_receivable"
+            )
+            partials = (
+                payment_lines.matched_debit_ids | payment_lines.matched_credit_ids
+            )
+            counterparts = (
+                partials.debit_move_id | partials.credit_move_id
+            ) - payment_lines
             valid_legacy_payment = (
                 len(existing_payments) == 1
+                and counterparts.move_id == invoice
+                and existing_payments.is_reconciled
+                and existing_payments.state == "posted"
+                and existing_payments.partner_id.commercial_partner_id
+                == invoice.commercial_partner_id
+                and existing_payments.company_id == invoice.company_id
+                and existing_payments.partner_type == "customer"
+                and existing_payments.payment_type
+                == ("inbound" if self.transaction_type == "sale" else "outbound")
                 and existing_payments.currency_id == currency
                 and currency.is_zero(existing_payments.amount - group_amount)
                 and invoice.payment_state in ("paid", "in_payment")
@@ -420,9 +623,8 @@ class HepsiburadaSettlement(models.Model):
                 "partner_type": "customer",
                 "partner_id": invoice.partner_id.id,
                 "amount": group_amount,
-                "date": fields.Date.to_date(self.payment_date)
-                if self.payment_date
-                else fields.Date.context_today(self),
+                "date": fields.Date.to_date(self.transaction_date or self.invoice_date)
+                or fields.Date.context_today(self),
                 "currency_id": currency.id,
                 "journal_id": journal.id,
                 "ref": self._marketplace_payment_ref(),
@@ -446,18 +648,21 @@ class HepsiburadaSettlement(models.Model):
         return True
 
     def action_reconcile(self):
+        """Show clearing and commission matching as distinct outcomes."""
         self.ensure_one()
-        if not self._reconcile():
-            raise UserError(
-                self.error_message or _("Settlement could not be reconciled.")
-            )
+        self._reconcile()
+        if self.transaction_type in ("commission", "commission_refund"):
+            return self.action_reconcile_commission()
+        success = self.state == "reconciled"
         return {
             "type": "ir.actions.client",
             "tag": "display_notification",
             "params": {
-                "title": _("Reconciled"),
-                "message": _("Settlement group has been reconciled successfully."),
-                "type": "success",
-                "sticky": False,
+                "title": _("Reconciled") if success else _("Reconciliation Failed"),
+                "message": _("Settlement group has been reconciled successfully.")
+                if success
+                else self.error_message or _("Settlement could not be reconciled."),
+                "type": "success" if success else "danger",
+                "sticky": not success,
             },
         }

--- a/hepsiburada_integration/tests/__init__.py
+++ b/hepsiburada_integration/tests/__init__.py
@@ -4,3 +4,4 @@ from . import test_hepsiburada_question
 from . import test_hepsiburada_request
 from . import test_hepsiburada_security
 from . import test_hepsiburada_settlement
+from . import test_hepsiburada_commission

--- a/hepsiburada_integration/tests/test_hepsiburada_commission.py
+++ b/hepsiburada_integration/tests/test_hepsiburada_commission.py
@@ -1,0 +1,344 @@
+# Copyright 2026 Ahmet Yigit Budak (https://github.com/yibudak)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from datetime import datetime
+from unittest.mock import Mock
+
+from .common import HepsiburadaCommon
+
+
+class TestHepsiburadaCommission(HepsiburadaCommon):
+    def setUp(self):
+        super().setUp()
+        if "short.url.yourls" in self.env:
+            self.patch(
+                type(self.env["short.url.yourls"]),
+                "shorten_url",
+                lambda service, url: url,
+            )
+        journal = self.env["account.journal"].search(
+            [
+                ("company_id", "=", self.env.company.id),
+                ("type", "=", "bank"),
+                ("currency_id", "in", [False, self.env.company.currency_id.id]),
+            ],
+            limit=1,
+        )
+        self.assertTrue(journal)
+        (
+            journal.inbound_payment_method_line_ids
+            | journal.outbound_payment_method_line_ids
+        ).payment_account_id = journal.default_account_id
+        supplier = self.env["res.partner"].create({"name": "HB Commission Supplier"})
+        self.backend.write(
+            {"settlement_journal_id": journal.id, "hb_partner_id": supplier.id}
+        )
+
+    def _payload(
+        self,
+        key="commission-1",
+        number="HB20269999900001",
+        amount=-120,
+        transaction="Commission",
+    ):
+        """Model actual nested HB money values, including tax and dot references."""
+        return {
+            "id": key,
+            "transactionType": transaction,
+            "invoiceNumber": number,
+            "isInvoice": True,
+            "isIncome": amount > 0,
+            "status": "WillBePaid",
+            "amount": {"value": amount, "currencyCode": "949"},
+            "netAmount": {"value": amount / 1.2, "currencyCode": "949"},
+            "taxAmount": {"value": amount - amount / 1.2, "currencyCode": "949"},
+            "orderNumber": "HB-ORDER",
+            "invoiceDate": "2026-09-01T00:00:00",
+        }
+
+    def _row(self, **values):
+        return self.env["hepsiburada.settlement"]._import_settlement(
+            self.backend, self._payload(**values)
+        )
+
+    def _invoice(
+        self,
+        number="HB20269999900001",
+        amount=240,
+        move_type="in_invoice",
+        partner=False,
+        currency=False,
+    ):
+        """Post a real accounting document without external e-invoice delivery."""
+        account = self.env["account.account"].search(
+            [
+                ("company_id", "=", self.env.company.id),
+                (
+                    "account_type",
+                    "=",
+                    "income" if move_type.startswith("out_") else "expense",
+                ),
+                ("deprecated", "=", False),
+            ],
+            limit=1,
+        )
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": move_type,
+                "partner_id": (partner or self.backend.hb_partner_id).id,
+                "invoice_date": "2026-09-01",
+                "ref": number,
+                "currency_id": (currency or self.env.company.currency_id).id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Commission",
+                            "account_id": account.id,
+                            "quantity": 1,
+                            "price_unit": amount,
+                            "tax_ids": [(5, 0, 0)],
+                        },
+                    )
+                ],
+            }
+        )
+        if "ignore_exception" in invoice._fields:
+            invoice.ignore_exception = True
+        if "prevent_einvoice_generation" in invoice.journal_id._fields:
+            invoice.journal_id.prevent_einvoice_generation = True
+        if hasattr(invoice, "_update_einvoice_fields"):
+            invoice._update_einvoice_fields()
+        invoice.action_post()
+        self.assertEqual(invoice.state, "posted")
+        invoice.ref = number
+        return invoice
+
+    def test_commission_gross_payment_matches_only_referenced_bill(self):
+        unrelated = self._invoice(number="OLDER-BILL", amount=120)
+        bill = self._invoice()
+        row = self._row()
+        self.assertTrue(row._reconcile())
+        payment = row.commission_payment_id
+        self.assertEqual(payment.amount, 120)
+        self.assertEqual(payment.date.isoformat(), "2026-09-01")
+        self.assertTrue(payment.is_hepsiburada_commission)
+        self.assertEqual(row.commission_invoice_id, bill)
+        self.assertEqual(bill.amount_residual, 120)
+        self.assertEqual(unrelated.amount_residual, 120)
+        self.assertEqual(row.payment_status, "WillBePaid")
+        self.assertFalse(row.odoo_payment_id)
+        self.assertTrue(row._reconcile())
+        self.assertEqual(row.commission_payment_id, payment)
+        notes = self.env["mail.message"].search(
+            [
+                ("model", "=", "account.move"),
+                ("res_id", "=", bill.id),
+                ("body", "ilike", "HB-ORDER"),
+            ]
+        )
+        self.assertEqual(len(notes), 1)
+        self.assertFalse(notes.notification_ids)
+
+    def test_dot_reference_then_late_invoice_reuses_payment(self):
+        row = self._row(number=".")
+        self.assertFalse(row._reconcile())
+        payment = row.commission_payment_id
+        self.assertTrue(payment)
+        self.assertEqual(row.commission_match_state, "waiting")
+        self.assertFalse(row.commission_invoice_number)
+        self._row()
+        self.backend._reconcile_pending_commissions()
+        self.assertEqual(row.commission_match_state, "waiting")
+        bill = self._invoice(amount=120)
+        self.backend._reconcile_pending_commissions()
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertEqual(row.commission_match_state, "matched")
+        self.assertEqual(bill.amount_residual, 0)
+
+    def test_independent_rows_with_same_invoice_are_all_cleared(self):
+        bill = self._invoice(amount=240)
+        rows = self._row(key="first") | self._row(key="second")
+        self.backend._reconcile_settlements(rows)
+        self.assertEqual(len(rows.commission_payment_id), 2)
+        self.assertEqual(set(rows.mapped("commission_match_state")), {"matched"})
+        self.assertEqual(bill.amount_residual, 0)
+        payments = rows.commission_payment_id
+        self.backend._reconcile_settlements(rows)
+        self.assertEqual(rows.commission_payment_id, payments)
+
+    def test_commission_refund_uses_supplier_credit_note(self):
+        bill = self._invoice(amount=120, move_type="in_refund")
+        row = self._row(amount=120, transaction="CommissionRefund")
+        self.assertTrue(row._reconcile())
+        self.assertEqual(row.commission_payment_id.partner_type, "supplier")
+        self.assertEqual(row.commission_payment_id.payment_type, "inbound")
+        self.assertEqual(row.commission_invoice_id, bill)
+        self.assertEqual(bill.amount_residual, 0)
+
+    def test_commission_invoice_refund_uses_our_customer_invoice(self):
+        invoice = self._invoice(amount=120, move_type="out_invoice")
+        row = self._row(amount=120, transaction="CommissionInvoiceRefund")
+        self.assertTrue(row._reconcile())
+        self.assertEqual(row.commission_payment_id.partner_type, "customer")
+        self.assertEqual(row.commission_payment_id.payment_type, "inbound")
+        self.assertEqual(row.commission_invoice_id, invoice)
+        self.assertEqual(invoice.amount_residual, 0)
+
+    def test_invalid_direction_and_unknown_currency_do_not_create_payments(self):
+        row = self._row(amount=120)
+        self.assertFalse(row._reconcile())
+        self.assertFalse(row.commission_payment_id)
+        self.assertEqual(row.commission_match_state, "review")
+        row = self._row(key="bad-currency")
+        row.currency_code = "999"
+        self.assertFalse(row._reconcile())
+        self.assertFalse(row.commission_payment_id)
+
+    def test_missing_supplier_does_not_mark_commission_reconciled(self):
+        row = self._row()
+        self.backend.hb_partner_id = False
+        self.assertFalse(row._reconcile())
+        self.assertFalse(row.commission_payment_id)
+        self.assertEqual(row.state, "imported")
+
+    def test_amount_exceeding_bill_is_left_for_review(self):
+        bill = self._invoice(amount=100)
+        row = self._row()
+        self.assertFalse(row._reconcile())
+        self.assertEqual(row.commission_match_state, "review")
+        self.assertEqual(bill.amount_residual, 100)
+        self.assertFalse(row.commission_payment_id.is_reconciled)
+
+    def test_existing_wrong_reconciliation_is_preserved(self):
+        wrong = self._invoice(number="WRONG", amount=120)
+        row = self._row()
+        row._reconcile()
+        payment = row.commission_payment_id
+        lines = (wrong.line_ids | payment.move_id.line_ids).filtered(
+            lambda line: (
+                line.account_type == "liability_payable" and not line.reconciled
+            )
+        )
+        lines.reconcile()
+        expected = self._invoice(amount=120)
+        self.assertFalse(row._reconcile_commission_invoice())
+        self.assertEqual(row.commission_match_state, "review")
+        self.assertEqual(wrong.amount_residual, 0)
+        self.assertEqual(expected.amount_residual, 120)
+
+    def test_duplicate_invoice_reference_is_not_guessed(self):
+        self._invoice()
+        self._invoice()
+        row = self._row()
+        self.assertFalse(row._reconcile())
+        self.assertEqual(row.commission_match_state, "review")
+        self.assertFalse(row.commission_payment_id.is_reconciled)
+
+    def test_supplier_and_currency_must_match(self):
+        other = self.env["res.partner"].create({"name": "Other Supplier"})
+        bill = self._invoice(partner=other)
+        row = self._row()
+        self.assertFalse(row._reconcile())
+        self.assertEqual(row.commission_match_state, "waiting")
+        self.assertEqual(bill.amount_residual, 240)
+        bill = self._invoice(currency=self.env.ref("base.USD"))
+        self.assertFalse(row._reconcile_commission_invoice())
+        self.assertEqual(row.commission_match_state, "review")
+        self.assertFalse(row.commission_payment_id.is_reconciled)
+
+    def test_generic_reconciliation_excludes_hb_commission_payments(self):
+        bill = self._invoice()
+        row = self._row(number=".")
+        row._reconcile()
+        account_ids = bill.line_ids.filtered(
+            lambda line: line.account_type == "liability_payable"
+        ).account_id.ids
+        domain = self.env["account.auto.reconcile"]._get_payment_lines_domain(
+            bill, account_ids
+        )
+        self.assertIn(("payment_id.is_hepsiburada_commission", "=", False), domain)
+        self.assertFalse(
+            self.env["account.move.line"].search(domain)
+            & row.commission_payment_id.move_id.line_ids
+        )
+
+    def test_historical_refresh_updates_status_and_reference_without_payments(self):
+        row = self._row(number=".")
+        self._row(key="second", number=".")
+        client = Mock()
+        payload = self._payload()
+        payload.update({"status": "Paid", "paymentDate": "2026-09-08T00:00:00"})
+        client.get_transactions.return_value = [payload]
+        self.backend.last_settlement_sync = datetime(2026, 9, 8)
+        refreshed, errors = self.backend._refresh_pending_settlements(client)
+        self.assertFalse(errors)
+        self.assertEqual(refreshed, row)
+        self.assertEqual(row.payment_status, "Paid")
+        self.assertEqual(row.commission_invoice_number, payload["invoiceNumber"])
+        self.assertFalse(row.commission_payment_id)
+        self.assertEqual(self.backend.last_settlement_sync, datetime(2026, 9, 8))
+        client.get_transactions.assert_called_once_with(
+            record_date_start=None,
+            record_date_end=None,
+            offset=0,
+            limit=100,
+            order_number="HB-ORDER",
+        )
+
+    def test_refresh_paginates_all_commission_rows(self):
+        row = self._row(number=".")
+        client = Mock()
+        client.get_transactions.side_effect = [
+            [self._payload(key=f"page-one-{i}") for i in range(100)],
+            [self._payload()],
+        ]
+        refreshed, errors = self.backend._refresh_pending_settlements(client)
+        self.assertFalse(errors)
+        self.assertEqual(len(refreshed), 101)
+        self.assertEqual(row.commission_invoice_number, "HB20269999900001")
+        self.assertEqual(client.get_transactions.call_args.kwargs["offset"], 100)
+
+    def test_refresh_preserves_closed_payment_when_reference_changes(self):
+        bill = self._invoice(amount=120)
+        row = self._row()
+        self.assertTrue(row._reconcile())
+        payment = row.commission_payment_id
+        self._row(number="CHANGED")
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertEqual(bill.amount_residual, 0)
+        self.assertEqual(row.commission_match_state, "review")
+
+    def test_legacy_manual_review_never_creates_another_payment(self):
+        row = self._row(number=".")
+        row._reconcile()
+        payment = row.commission_payment_id
+        row.write({"requires_manual_review": True, "state": "error"})
+        self._row()
+        bill = self._invoice(amount=120)
+        self.backend._reconcile_pending_commissions()
+        self.assertEqual(row.commission_payment_id, payment)
+        self.assertEqual(row.commission_match_state, "matched")
+        self.assertEqual(bill.amount_residual, 0)
+        self.assertTrue(row.requires_manual_review)
+
+    def test_orderless_invoice_refresh_uses_reference_document(self):
+        payload = self._payload()
+        payload["orderNumber"] = None
+        row = self.env["hepsiburada.settlement"]._import_settlement(
+            self.backend, payload
+        )
+        self.assertFalse(row.order_number)
+        client = Mock()
+        client.get_transactions.return_value = [payload]
+        refreshed, errors = self.backend._refresh_pending_settlements(client)
+        self.assertFalse(errors)
+        self.assertEqual(refreshed, row)
+        client.get_transactions.assert_called_once_with(
+            record_date_start=None,
+            record_date_end=None,
+            offset=0,
+            limit=100,
+            reference_document=payload["invoiceNumber"],
+        )

--- a/hepsiburada_integration/tests/test_hepsiburada_request.py
+++ b/hepsiburada_integration/tests/test_hepsiburada_request.py
@@ -41,3 +41,12 @@ class TestHepsiburadaRequest(TransactionCase):
 
         self.assertEqual(len(records), 13)
         self.assertEqual(fetch.call_args_list[1].kwargs["offset"], 10)
+
+    def test_finance_reference_filters_use_the_documented_names(self):
+        self.client.get_transactions(
+            order_number="HB-ORDER", reference_document="HB-INVOICE"
+        )
+        params = self.client._make_request.call_args.kwargs["params"]
+        self.assertEqual(params["orderNumber"], "HB-ORDER")
+        self.assertEqual(params["ReferenceDocument"], "HB-INVOICE")
+        self.assertNotIn("recordDateStart", params)

--- a/hepsiburada_integration/tests/test_hepsiburada_settlement.py
+++ b/hepsiburada_integration/tests/test_hepsiburada_settlement.py
@@ -75,7 +75,7 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
         self.assertFalse(settlement.transaction_date)
         self.assertFalse(settlement.payment_date)
 
-    def test_will_be_paid_transaction_is_not_reconciled(self):
+    def test_unknown_status_is_not_reconciled(self):
         settlement = self.env["hepsiburada.settlement"].create(
             {
                 "backend_id": self.backend.id,
@@ -83,7 +83,7 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
                 "transaction_type": "sale",
                 "amount": 100,
                 "currency_code": "949",
-                "payment_status": "WillBePaid",
+                "payment_status": "Unknown",
             }
         )
 
@@ -91,13 +91,13 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
         self.assertEqual(settlement.state, "error")
         self.assertFalse(settlement.odoo_payment_id)
 
-    def test_non_paid_rows_stay_imported_after_a_sync(self):
+    def test_unsupported_rows_stay_imported_after_a_sync(self):
         settlements = self.env["hepsiburada.settlement"].create(
             [
                 {
                     "backend_id": self.backend.id,
                     "hb_transaction_id": "commission-row",
-                    "transaction_type": "commission",
+                    "transaction_type": "expense",
                     "amount": -40,
                     "currency_code": "949",
                     "payment_status": "Paid",
@@ -109,13 +109,13 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
                     "transaction_type": "sale",
                     "amount": 100,
                     "currency_code": "949",
-                    "payment_status": "WillBePaid",
+                    "payment_status": "Unknown",
                     "order_number": "ORDER-UNRECONCILED",
                 },
             ]
         )
 
-        self.backend._reconcile_paid_settlements(settlements)
+        self.backend._reconcile_settlements(settlements)
 
         self.assertEqual(set(settlements.mapped("state")), {"imported"})
         self.assertFalse(any(settlements.mapped("error_message")))
@@ -208,7 +208,6 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
             "TRY": "949",
             "USD": "840",
         }.get(invoice.currency_id.name, "")
-        payment_date = fields.Datetime.now()
         settlements = self.env["hepsiburada.settlement"].create(
             [
                 {
@@ -217,8 +216,8 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
                     "transaction_type": "sale",
                     "amount": 40,
                     "currency_code": currency_code,
-                    "payment_status": "Paid",
-                    "payment_date": payment_date,
+                    "payment_status": "WillBePaid",
+                    "payment_date": False,
                     "order_number": "ORDER-PAID",
                     "package_number": "PACKAGE-PAID",
                 },
@@ -228,8 +227,8 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
                     "transaction_type": "sale",
                     "amount": 60,
                     "currency_code": currency_code,
-                    "payment_status": "Paid",
-                    "payment_date": payment_date,
+                    "payment_status": "WillBePaid",
+                    "payment_date": False,
                     "order_number": "ORDER-PAID",
                     "package_number": "PACKAGE-PAID",
                 },
@@ -244,3 +243,11 @@ class TestHepsiburadaSettlement(HepsiburadaCommon):
         self.assertEqual(len(settlements.mapped("odoo_payment_id")), 1)
         self.assertEqual(settlements[0].odoo_payment_id.amount, 100)
         self.assertEqual(invoice.payment_state, "paid")
+
+        payment = settlements.odoo_payment_id
+        settlements.write(
+            {"payment_status": "Paid", "payment_date": fields.Datetime.now()}
+        )
+        self.assertTrue(settlements[1]._reconcile())
+        self.assertEqual(settlements.odoo_payment_id, payment)
+        self.assertFalse(settlements.commission_payment_id)

--- a/hepsiburada_integration/views/hepsiburada_settlement_views.xml
+++ b/hepsiburada_integration/views/hepsiburada_settlement_views.xml
@@ -12,9 +12,15 @@
                         string="Reconcile"
                         type="object"
                         class="btn-primary"
-                        attrs="{'invisible': ['|', '|', '|', ('state', '=', 'reconciled'), ('transaction_type', 'not in', ['sale', 'return']), ('payment_status', '!=', 'Paid'), ('requires_manual_review', '=', True)]}"
+                        attrs="{'invisible': ['|', '|', '|', ('state', '=', 'reconciled'), ('transaction_type', 'not in', ['sale', 'return', 'commission', 'commission_refund']), ('payment_status', 'not in', ['Paid', 'WillBePaid']), ('requires_manual_review', '=', True)]}"
                     />
                     <field name="state" widget="statusbar" />
+                    <button
+                        name="action_reconcile_commission"
+                        string="Match Commission Invoice"
+                        type="object"
+                        attrs="{'invisible': [('commission_payment_id', '=', False)]}"
+                    />
                 </header>
                 <sheet>
                     <div
@@ -54,6 +60,7 @@
                     </group>
                     <group>
                         <group string="Payment Info">
+                            <field name="invoice_date" />
                             <field name="payment_date" />
                             <field name="payment_status" />
                             <field name="invoice_number" />
@@ -67,6 +74,14 @@
                         </group>
                     </group>
                     <notebook>
+                        <page string="Commission Matching" name="commission_matching">
+                            <group>
+                                <field name="commission_invoice_number" />
+                                <field name="commission_invoice_id" />
+                                <field name="commission_match_state" />
+                                <field name="commission_match_note" />
+                            </group>
+                        </page>
                         <page string="Raw Data" name="raw_data">
                             <field name="raw_data" />
                         </page>
@@ -98,6 +113,8 @@
                 <field name="state" />
                 <field name="requires_manual_review" optional="show" />
                 <field name="odoo_invoice_id" optional="show" />
+                <field name="commission_invoice_id" optional="show" />
+                <field name="commission_match_state" optional="show" />
             </tree>
         </field>
     </record>
@@ -111,7 +128,19 @@
                 <field name="order_number" />
                 <field name="sku" />
                 <field name="hb_transaction_id" />
+                <field name="invoice_number" />
+                <field name="commission_invoice_id" />
                 <separator />
+                <filter
+                    name="commission_waiting"
+                    string="Commission Pending"
+                    domain="[('commission_match_state', '=', 'waiting')]"
+                />
+                <filter
+                    name="commission_review"
+                    string="Commission Review"
+                    domain="[('commission_match_state', '=', 'review')]"
+                />
                 <filter
                     name="imported"
                     string="To Reconcile"
@@ -141,7 +170,7 @@
                 <filter
                     name="commission"
                     string="Commissions"
-                    domain="[('transaction_type', '=', 'commission')]"
+                    domain="[('transaction_type', 'in', ['commission', 'commission_refund'])]"
                 />
                 <group expand="0" string="Group By">
                     <filter

--- a/marketplace_integration_base/__manifest__.py
+++ b/marketplace_integration_base/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Marketplace Integration Base",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "category": "Sales/Sales",
     "summary": "Shared helpers for marketplace integration modules",
     "author": "Ahmet Yigit Budak, Altinkaya Enclosures",

--- a/marketplace_integration_base/i18n/marketplace_integration_base.pot
+++ b/marketplace_integration_base/i18n/marketplace_integration_base.pot
@@ -644,3 +644,161 @@ msgstr ""
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__warehouse_ids
 msgid "Warehouses"
 msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__commission_invoice_id
+msgid "Commission Invoice"
+msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__commission_match_note
+msgid "Commission Match Note"
+msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__commission_match_state
+msgid "Commission Match State"
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Commission Matching"
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Commission matched to the referenced vendor document."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Commission matching is pending."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"Commission payment %(payment)s for %(marketplace)s orders %(orders)s was "
+"reconciled with this invoice."
+msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__commission_match_state__matched
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__commission_match_state__matched
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__trendyol_settlement__commission_match_state__matched
+msgid "Matched"
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Multiple vendor documents have this commission invoice reference."
+msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__commission_match_state__review
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__commission_match_state__review
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__trendyol_settlement__commission_match_state__review
+msgid "Review Required"
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The commission payment amount differs from its settlement rows."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The commission payment and vendor document currencies differ."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment exceeds the referenced vendor document's remaining "
+"balance."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment is already reconciled with another document. Existing"
+" reconciliations were preserved."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The commission payment is closed without a matching vendor document."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment partner or company does not match the marketplace "
+"backend."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The vendor document has no compatible open payable lines."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"This payment covers multiple commission invoice references. Review is "
+"required."
+msgstr ""
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__commission_match_state__waiting
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__commission_match_state__waiting
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__trendyol_settlement__commission_match_state__waiting
+msgid "Waiting"
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Waiting for the commission invoice number from the marketplace."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Waiting for the commission payment to be posted."
+msgstr ""
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Waiting for the referenced vendor bill or credit note to be posted."
+msgstr ""

--- a/marketplace_integration_base/i18n/tr.po
+++ b/marketplace_integration_base/i18n/tr.po
@@ -649,3 +649,170 @@ msgstr "Değişiklikleri Görebilir"
 #: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_backend_mixin__warehouse_ids
 msgid "Warehouses"
 msgstr "Depolar"
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__commission_invoice_id
+msgid "Commission Invoice"
+msgstr "Komisyon Faturası"
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__commission_match_note
+msgid "Commission Match Note"
+msgstr "Komisyon Uzlaştırma Notu"
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields,field_description:marketplace_integration_base.field_marketplace_settlement_mixin__commission_match_state
+msgid "Commission Match State"
+msgstr "Komisyon Uzlaştırma Durumu"
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Commission Matching"
+msgstr "Komisyon Uzlaştırma"
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Commission matched to the referenced vendor document."
+msgstr "Komisyon, ilgili tedarikçi belgesiyle uzlaştırıldı."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Commission matching is pending."
+msgstr "Komisyon uzlaştırması bekliyor."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"Commission payment %(payment)s for %(marketplace)s orders %(orders)s was "
+"reconciled with this invoice."
+msgstr ""
+"%(marketplace)s siparişleri %(orders)s için %(payment)s komisyon ödemesi bu "
+"faturayla uzlaştırıldı."
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__commission_match_state__matched
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__commission_match_state__matched
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__trendyol_settlement__commission_match_state__matched
+msgid "Matched"
+msgstr "Uzlaştırıldı"
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Multiple vendor documents have this commission invoice reference."
+msgstr ""
+"Bu komisyon fatura numarasıyla birden fazla tedarikçi belgesi bulundu."
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__commission_match_state__review
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__commission_match_state__review
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__trendyol_settlement__commission_match_state__review
+msgid "Review Required"
+msgstr "İnceleme Gerekli"
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The commission payment amount differs from its settlement rows."
+msgstr ""
+"Komisyon ödemesi, hesaplaşma satırlarındaki komisyon toplamıyla uyuşmuyor."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The commission payment and vendor document currencies differ."
+msgstr "Komisyon ödemesi ile tedarikçi belgesinin para birimleri farklı."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment exceeds the referenced vendor document's remaining "
+"balance."
+msgstr "Komisyon ödemesi, ilgili tedarikçi belgesinin açık bakiyesini aşıyor."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment is already reconciled with another document. Existing"
+" reconciliations were preserved."
+msgstr ""
+"Komisyon ödemesi başka bir belgeyle eşleşmiş. Mevcut eşleşmeler korundu."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The commission payment is closed without a matching vendor document."
+msgstr "Komisyon ödemesi, tedarikçi belgesiyle eşleşmeden kapanmış."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"The commission payment partner or company does not match the marketplace "
+"backend."
+msgstr ""
+"Komisyon ödemesinin iş ortağı veya şirketi pazaryeri entegrasyonuyla "
+"eşleşmiyor."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "The vendor document has no compatible open payable lines."
+msgstr "Tedarikçi belgesinde uzlaştırılabilecek açık borç satırı yok."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid ""
+"This payment covers multiple commission invoice references. Review is "
+"required."
+msgstr "Bu ödeme birden fazla komisyon faturasını kapsıyor. İnceleme gerekli."
+
+#. module: marketplace_integration_base
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__hepsiburada_settlement__commission_match_state__waiting
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__marketplace_settlement_mixin__commission_match_state__waiting
+#: model:ir.model.fields.selection,name:marketplace_integration_base.selection__trendyol_settlement__commission_match_state__waiting
+msgid "Waiting"
+msgstr "Bekliyor"
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Waiting for the commission invoice number from the marketplace."
+msgstr "Pazaryerinden komisyon faturası numarası bekleniyor."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Waiting for the commission payment to be posted."
+msgstr "Komisyon ödemesinin onaylanması bekleniyor."
+
+#. module: marketplace_integration_base
+#. odoo-python
+#: code:addons/marketplace_integration_base/models/marketplace_settlement.py:0
+#, python-format
+msgid "Waiting for the referenced vendor bill or credit note to be posted."
+msgstr ""
+"Belirtilen tedarikçi faturasının veya iade belgesinin onaylanması "
+"bekleniyor."

--- a/marketplace_integration_base/models/marketplace_settlement.py
+++ b/marketplace_integration_base/models/marketplace_settlement.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from markupsafe import escape
+
 from odoo import _, fields, models
 from odoo.exceptions import UserError
 
@@ -31,6 +33,13 @@ class MarketplaceSettlementMixin(models.AbstractModel):
     odoo_invoice_id = fields.Many2one("account.move", string="Invoice")
     odoo_payment_id = fields.Many2one("account.payment", string="Payment")
     commission_payment_id = fields.Many2one("account.payment")
+
+    commission_invoice_id = fields.Many2one("account.move", readonly=True)
+    commission_match_state = fields.Selection(
+        [("waiting", "Waiting"), ("matched", "Matched"), ("review", "Review Required")],
+        readonly=True,
+    )
+    commission_match_note = fields.Text(readonly=True)
 
     state = fields.Selection(
         [
@@ -331,3 +340,219 @@ class MarketplaceSettlementMixin(models.AbstractModel):
         )
         payment.action_post()
         return payment
+
+    def _commission_payment_rows(self, payment):
+        """Return the concrete marketplace's rows for a payment."""
+        raise NotImplementedError
+
+    def _commission_document_type(self, payment):
+        """Return the invoice direction represented by the commission payment."""
+        return "in_invoice" if payment.payment_type == "outbound" else "in_refund"
+
+    def _commission_row_amount(self):
+        """Return the tax-inclusive commission amount for one API row."""
+        self.ensure_one()
+        return abs(self.commission_amount)
+
+    def _set_commission_match(self, state, note=False, invoice=False):
+        """Report commission matching separately from customer reconciliation."""
+        values = {
+            "commission_match_state": state,
+            "commission_match_note": note,
+            "commission_invoice_id": invoice.id if invoice else False,
+        }
+        self.write(values)
+        return state == "matched"
+
+    def _reconcile_commission_invoice(self):
+        """Match a commission payment only to the vendor document named by the API."""
+        self.ensure_one()
+        payment = self.commission_payment_id
+        if not payment:
+            return False
+        rows = self._commission_payment_rows(payment)
+        currency = payment.currency_id
+        charged_rows = rows.filtered(
+            lambda row: not currency.is_zero(row._commission_row_amount())
+        )
+        numbers = set(charged_rows.mapped("commission_invoice_number"))
+        if not numbers or False in numbers:
+            return rows._set_commission_match(
+                "waiting",
+                _("Waiting for the commission invoice number from the marketplace."),
+            )
+        if len(numbers) != 1:
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "This payment covers multiple commission invoice references. "
+                    "Review is required."
+                ),
+            )
+        backend = self.backend_id
+        supplier = backend[self._marketplace_partner_field()].commercial_partner_id
+        move_type = self._commission_document_type(payment)
+        partner_type = "customer" if move_type.startswith("out_") else "supplier"
+        account_type = (
+            "asset_receivable" if partner_type == "customer" else "liability_payable"
+        )
+        if (
+            len(rows.backend_id) != 1
+            or payment.partner_type != partner_type
+            or payment.partner_id.commercial_partner_id != supplier
+            or payment.company_id != backend.company_id
+        ):
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment partner or company does not match "
+                    "the marketplace backend."
+                ),
+            )
+        if payment.state != "posted":
+            return rows._set_commission_match(
+                "waiting", _("Waiting for the commission payment to be posted.")
+            )
+        if currency.compare_amounts(
+            sum(abs(row._commission_row_amount()) for row in rows), payment.amount
+        ):
+            return rows._set_commission_match(
+                "review",
+                _("The commission payment amount differs from its settlement rows."),
+            )
+        invoice_number = numbers.pop()
+        invoices = self.env["account.move"].search(
+            [
+                ("company_id", "=", backend.company_id.id),
+                ("commercial_partner_id", "=", supplier.id),
+                ("move_type", "=", move_type),
+                ("state", "=", "posted"),
+                "|",
+                ("ref", "=", invoice_number),
+                ("name", "=", invoice_number),
+            ],
+            limit=2,
+        )
+        if not invoices:
+            return rows._set_commission_match(
+                "waiting",
+                _(
+                    "Waiting for the referenced vendor bill or credit note "
+                    "to be posted."
+                ),
+            )
+        if len(invoices) != 1:
+            return rows._set_commission_match(
+                "review",
+                _("Multiple vendor documents have this commission invoice reference."),
+            )
+        invoice = invoices
+        if invoice.currency_id != currency:
+            return rows._set_commission_match(
+                "review",
+                _("The commission payment and vendor document currencies differ."),
+                invoice,
+            )
+        payment_lines = payment.move_id.line_ids.filtered(
+            lambda line: line.account_type == account_type
+        )
+        partials = payment_lines.matched_debit_ids | payment_lines.matched_credit_ids
+        counterpart_lines = (
+            partials.debit_move_id | partials.credit_move_id
+        ) - payment_lines
+        if counterpart_lines.filtered(lambda line: line.move_id != invoice):
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment is already reconciled with another "
+                    "document. "
+                    "Existing reconciliations were preserved."
+                ),
+                invoice,
+            )
+        if payment.is_reconciled:
+            if counterpart_lines:
+                return rows._set_commission_match("matched", invoice=invoice)
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment is closed without a matching "
+                    "vendor document."
+                ),
+                invoice,
+            )
+        payment_lines = payment_lines.filtered(lambda line: not line.reconciled)
+        invoice_lines = invoice.line_ids.filtered(
+            lambda line: line.account_type == account_type and not line.reconciled
+        )
+        if (
+            not payment_lines
+            or not invoice_lines
+            or len(payment_lines.account_id) != 1
+            or payment_lines.account_id != invoice_lines.account_id
+            or sum(payment_lines.mapped("balance"))
+            * sum(invoice_lines.mapped("balance"))
+            >= 0
+        ):
+            return rows._set_commission_match(
+                "review",
+                _("The vendor document has no compatible open payable lines."),
+                invoice,
+            )
+        residual_field = (
+            "amount_residual"
+            if currency == backend.company_id.currency_id
+            else "amount_residual_currency"
+        )
+        payment_remaining = abs(sum(payment_lines.mapped(residual_field)))
+        invoice_remaining = abs(sum(invoice_lines.mapped(residual_field)))
+        if currency.compare_amounts(payment_remaining, invoice_remaining) > 0:
+            return rows._set_commission_match(
+                "review",
+                _(
+                    "The commission payment exceeds the referenced vendor "
+                    "document's remaining balance."
+                ),
+                invoice,
+            )
+        (payment_lines + invoice_lines).reconcile()
+        charged_rows._log_commission_reconciliation(invoice, payment)
+        return rows._set_commission_match("matched", invoice=invoice)
+
+    def _log_commission_reconciliation(self, invoice, payment):
+        """Record the newly allocated orders without notifying invoice followers."""
+        order_numbers = sorted(set(self.mapped("order_number")) - {False, ""})
+        if not order_numbers:
+            return
+        invoice._message_log(
+            body=escape(
+                _(
+                    "Commission payment %(payment)s for %(marketplace)s "
+                    "orders %(orders)s "
+                    "was reconciled with this invoice.",
+                    payment=payment.name,
+                    marketplace=self._marketplace_name(),
+                    orders=", ".join(order_numbers),
+                )
+            )
+        )
+
+    def action_reconcile_commission(self):
+        """Retry invoice-specific matching without creating another payment."""
+        self.ensure_one()
+        matched = self._reconcile_commission_invoice()
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "title": _("Commission Matching"),
+                "message": self.commission_match_note
+                or (
+                    _("Commission matched to the referenced vendor document.")
+                    if matched
+                    else _("Commission matching is pending.")
+                ),
+                "type": "success" if matched else "warning",
+                "sticky": not matched,
+            },
+        }

--- a/trendyol_integration/__manifest__.py
+++ b/trendyol_integration/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Trendyol Marketplace Integration",
-    "version": "16.0.1.2.1",
+    "version": "16.0.1.2.2",
     "category": "Sales/Sales",
     "summary": "Integrate Odoo with Trendyol marketplace",
     "author": "Ahmet Yigit Budak, Altinkaya Enclosures",

--- a/trendyol_integration/models/trendyol_settlement.py
+++ b/trendyol_integration/models/trendyol_settlement.py
@@ -4,8 +4,6 @@
 import json
 import logging
 
-from markupsafe import escape
-
 from odoo import _, api, fields, models
 
 from .trendyol_backend import _trendyol_ts_to_utc
@@ -80,12 +78,6 @@ class TrendyolSettlement(models.Model):
     commission_invoice_number = fields.Char(
         compute="_compute_commission_invoice_number", store=True, index=True
     )
-    commission_invoice_id = fields.Many2one("account.move", readonly=True)
-    commission_match_state = fields.Selection(
-        [("waiting", "Waiting"), ("matched", "Matched"), ("review", "Review Required")],
-        readonly=True,
-    )
-    commission_match_note = fields.Text(readonly=True)
 
     # Status
     state = fields.Selection(
@@ -370,186 +362,9 @@ class TrendyolSettlement(models.Model):
             }
         )
 
-    def _set_commission_match(self, state, note=False, invoice=False):
-        """Report commission matching separately from customer reconciliation."""
-        values = {
-            "commission_match_state": state,
-            "commission_match_note": note,
-            "commission_invoice_id": invoice.id if invoice else False,
-        }
-        self.write(values)
-        return state == "matched"
-
-    def _reconcile_commission_invoice(self):
-        """Match a commission payment only to the vendor document named by the API."""
-        self.ensure_one()
-        payment = self.commission_payment_id
-        if not payment:
-            return False
-        rows = payment.trendyol_commission_settlement_ids
-        currency = payment.currency_id
-        charged_rows = rows.filtered(
-            lambda row: not currency.is_zero(row.commission_amount)
-        )
-        numbers = set(charged_rows.mapped("commission_invoice_number"))
-        if not numbers or False in numbers:
-            return rows._set_commission_match(
-                "waiting", _("Waiting for the commission invoice number from Trendyol.")
-            )
-        if len(numbers) != 1:
-            return rows._set_commission_match(
-                "review",
-                _(
-                    "This payment covers multiple commission invoice references. "
-                    "Review is required."
-                ),
-            )
-        backend = self.backend_id
-        supplier = backend.trendyol_partner_id.commercial_partner_id
-        if (
-            len(rows.backend_id) != 1
-            or payment.partner_type != "supplier"
-            or payment.partner_id.commercial_partner_id != supplier
-            or payment.company_id != backend.company_id
-        ):
-            return rows._set_commission_match(
-                "review",
-                _(
-                    "The commission payment partner or company does not match "
-                    "the Trendyol backend."
-                ),
-            )
-        if payment.state != "posted":
-            return rows._set_commission_match(
-                "waiting", _("Waiting for the commission payment to be posted.")
-            )
-        if currency.compare_amounts(
-            sum(abs(row.commission_amount) for row in rows), payment.amount
-        ):
-            return rows._set_commission_match(
-                "review",
-                _("The commission payment amount differs from its settlement rows."),
-            )
-        invoice_number = numbers.pop()
-        invoices = self.env["account.move"].search(
-            [
-                ("company_id", "=", backend.company_id.id),
-                ("commercial_partner_id", "=", supplier.id),
-                (
-                    "move_type",
-                    "=",
-                    "in_invoice" if payment.payment_type == "outbound" else "in_refund",
-                ),
-                ("state", "=", "posted"),
-                "|",
-                ("ref", "=", invoice_number),
-                ("name", "=", invoice_number),
-            ],
-            limit=2,
-        )
-        if not invoices:
-            return rows._set_commission_match(
-                "waiting",
-                _(
-                    "Waiting for the referenced DSM vendor bill or credit note "
-                    "to be posted."
-                ),
-            )
-        if len(invoices) != 1:
-            return rows._set_commission_match(
-                "review",
-                _("Multiple vendor documents have this commission invoice reference."),
-            )
-        invoice = invoices
-        if invoice.currency_id != currency:
-            return rows._set_commission_match(
-                "review",
-                _("The commission payment and vendor document currencies differ."),
-                invoice,
-            )
-        payment_lines = payment.move_id.line_ids.filtered(
-            lambda line: line.account_type == "liability_payable"
-        )
-        partials = payment_lines.matched_debit_ids | payment_lines.matched_credit_ids
-        counterpart_lines = (
-            partials.debit_move_id | partials.credit_move_id
-        ) - payment_lines
-        if counterpart_lines.filtered(lambda line: line.move_id != invoice):
-            return rows._set_commission_match(
-                "review",
-                _(
-                    "The commission payment is already reconciled with another "
-                    "document. "
-                    "Existing reconciliations were preserved."
-                ),
-                invoice,
-            )
-        if payment.is_reconciled:
-            if counterpart_lines:
-                return rows._set_commission_match("matched", invoice=invoice)
-            return rows._set_commission_match(
-                "review",
-                _(
-                    "The commission payment is closed without a matching "
-                    "vendor document."
-                ),
-                invoice,
-            )
-        payment_lines = payment_lines.filtered(lambda line: not line.reconciled)
-        invoice_lines = invoice.line_ids.filtered(
-            lambda line: (
-                line.account_type == "liability_payable" and not line.reconciled
-            )
-        )
-        if (
-            not payment_lines
-            or not invoice_lines
-            or len(payment_lines.account_id) != 1
-            or payment_lines.account_id != invoice_lines.account_id
-            or sum(payment_lines.mapped("balance"))
-            * sum(invoice_lines.mapped("balance"))
-            >= 0
-        ):
-            return rows._set_commission_match(
-                "review",
-                _("The vendor document has no compatible open payable lines."),
-                invoice,
-            )
-        residual_field = (
-            "amount_residual"
-            if currency == backend.company_id.currency_id
-            else "amount_residual_currency"
-        )
-        payment_remaining = abs(sum(payment_lines.mapped(residual_field)))
-        invoice_remaining = abs(sum(invoice_lines.mapped(residual_field)))
-        if currency.compare_amounts(payment_remaining, invoice_remaining) > 0:
-            return rows._set_commission_match(
-                "review",
-                _(
-                    "The commission payment exceeds the referenced vendor "
-                    "document's remaining balance."
-                ),
-                invoice,
-            )
-        (payment_lines + invoice_lines).reconcile()
-        charged_rows._log_commission_reconciliation(invoice, payment)
-        return rows._set_commission_match("matched", invoice=invoice)
-
-    def _log_commission_reconciliation(self, invoice, payment):
-        """Record the newly allocated orders without notifying invoice followers."""
-        order_numbers = sorted(set(self.mapped("order_number")) - {False, ""})
-        if not order_numbers:
-            return
-        invoice._message_log(
-            body=escape(
-                _(
-                    "Commission payment %(payment)s for Trendyol orders %(orders)s "
-                    "was reconciled with this invoice.",
-                    payment=payment.name,
-                    orders=", ".join(order_numbers),
-                )
-            )
-        )
+    def _commission_payment_rows(self, payment):
+        """Return all settlement rows assigned to this commission payment."""
+        return payment.trendyol_commission_settlement_ids
 
     def action_reconcile(self):
         """Make a waiting commission explicit after successful customer collection."""
@@ -569,23 +384,3 @@ class TrendyolSettlement(models.Model):
                 }
             )
         return action
-
-    def action_reconcile_commission(self):
-        """Retry invoice-specific matching without creating another payment."""
-        self.ensure_one()
-        matched = self._reconcile_commission_invoice()
-        return {
-            "type": "ir.actions.client",
-            "tag": "display_notification",
-            "params": {
-                "title": _("Commission Matching"),
-                "message": self.commission_match_note
-                or (
-                    _("Commission matched to the referenced vendor document.")
-                    if matched
-                    else _("Commission matching is pending.")
-                ),
-                "type": "success" if matched else "warning",
-                "sticky": not matched,
-            },
-        }


### PR DESCRIPTION
Hepsiburada commissions were imported without creating and matching their payments. Add VAT-inclusive commission clearing, exact invoice-number matching, commission refunds, historical reference/status refresh and retries without duplicating existing payments. Share the invoice matcher with Trendyol and add Turkish UI messages.

Customer and commission entries use the intermediary journal for both `Paid` and `WillBePaid`; bank payout status remains separate. Existing allocations and manual-review flags are preserved.

Validation:
- Full `pre-commit run -a` and `git diff --check` pass.
- 67 Odoo tests: 66 pass, 0 errors, 0 skips. The existing `test_tracking_number_is_written_to_outgoing_picking` failure also reproduces with clean base-branch code on the same isolated database.
- All new accounting tests and all 18 Trendyol settlement tests pass. Upgrade preserves existing payments and reconciliations.
