### PR TITLE
[FIX] Theme overflow and menu accessibility

### DIFF
--- a/altinkaya_theme/static/src/js/navigation.esm.js
+++ b/altinkaya_theme/static/src/js/navigation.esm.js
@@ -73,6 +73,13 @@ export class AltinkayaMenu extends Component {
     return searchMenuEntries(entries, query, app && app.id);
   }
 
+  /** Close the active launcher when its backdrop is clicked. */
+  handleBackdropClick(event) {
+    if (this.env.dialogData.isActive && event.target.classList.contains("modal")) {
+      this.props.close();
+    }
+  }
+
   /** Reset keyboard selection whenever the search text changes. */
   handleSearchInput(event) {
     this.state.query = event.target.value;

--- a/altinkaya_theme/static/src/scss/backend.scss
+++ b/altinkaya_theme/static/src/scss/backend.scss
@@ -240,6 +240,13 @@ body.o_web_client {
       }
     }
 
+    @include media-breakpoint-up(md) {
+      .o_field_statusbar > .o_statusbar_status {
+        // A wrapped row may end with an arrow-bearing button, not first-child.
+        padding-inline-end: $o-statusbar-arrow-width;
+      }
+    }
+
     .o_field_statusbar > .o_statusbar_status > .o_arrow_button,
     .o_form_statusbar > .o_statusbar_status > .o_arrow_button {
       --altinkaya-status-bg: #{$o-view-background-color};
@@ -288,13 +295,13 @@ body.o_web_client {
 
     .o_statusbar_buttons .btn-secondary {
       background-color: transparent;
-      border-color: transparent;
+      border-color: $o-altinkaya-field-border;
       font-weight: 500;
       text-transform: none;
 
       &:hover {
         background-color: $o-gray-200;
-        border-color: $o-gray-300;
+        border-color: $o-altinkaya-input-border;
       }
     }
   }

--- a/altinkaya_theme/static/src/scss/mobile.scss
+++ b/altinkaya_theme/static/src/scss/mobile.scss
@@ -309,6 +309,12 @@
     }
 
     .o_form_view {
+      .o_x2m_control_panel .o-kanban-button-new {
+        // Core gives this button full width on mobile; margins would add overflow.
+        margin-left: 0;
+        margin-right: 0;
+      }
+
       .o_form_renderer,
       .o_form_sheet_bg {
         min-width: 0;
@@ -320,7 +326,8 @@
         min-width: 0;
         max-width: 100%;
         margin: 0;
-        padding: 12px;
+        // Notebook headers use matching negative margins from Odoo's gutter.
+        padding: $o-horizontal-padding;
         border-radius: 0;
       }
 

--- a/altinkaya_theme/static/src/scss/navigation.scss
+++ b/altinkaya_theme/static/src/scss/navigation.scss
@@ -188,4 +188,49 @@ body.o_web_client {
   .o_altinkaya_sections_list {
     grid-template-columns: 1fr;
   }
+
+  @include media-breakpoint-up(md) {
+    .o_dialog .modal-dialog:has(.o_altinkaya_menu) {
+      width: calc(100vw - 48px);
+      max-width: 800px;
+    }
+
+    .o_altinkaya_menu {
+      max-height: calc(100vh - 64px);
+      max-height: calc(100dvh - 64px);
+    }
+
+    .o_altinkaya_menu_body {
+      min-height: 0;
+      overflow-y: auto;
+    }
+
+    .o_altinkaya_app_grid:not(.o_altinkaya_sections_list) {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 12px;
+
+      .o_altinkaya_app {
+        flex-direction: column;
+        justify-content: flex-start;
+        gap: 10px;
+        min-height: 152px;
+        padding: 12px 8px;
+        font-size: 14px;
+        text-align: center;
+      }
+
+      .o_altinkaya_app_icon {
+        flex-basis: 88px;
+        width: 88px;
+        height: 88px;
+        border-radius: 12px;
+        font-size: 44px;
+
+        img {
+          width: 80px;
+          height: 80px;
+        }
+      }
+    }
+  }
 }

--- a/altinkaya_theme/static/src/xml/navigation.xml
+++ b/altinkaya_theme/static/src/xml/navigation.xml
@@ -81,6 +81,7 @@
             footer="false"
             contentClass="'o_altinkaya_menu'"
             bodyClass="'o_altinkaya_menu_body'"
+            t-on-click="handleBackdropClick"
         >
             <div class="o_altinkaya_menu_search">
                 <i class="fa fa-search" aria-hidden="true" />


### PR DESCRIPTION
Fix horizontal form overflow caused by wrapped statusbar arrows and mismatched mobile notebook gutters, while keeping all controls visible.

- Add borders to secondary form-header buttons.
- Use five large, accessible application icons per desktop row in a wider, scrollable launcher.
- Include the active menu's outside-click close behavior.

Validation: full pre-commit and separate JavaScript checks passed. On the affected stock-picking form, measured scroll width now matches available width at both 1920px desktop and 675px mobile viewports.
