### PR TITLE
[FIX] Make required-field backgrounds more visible

### DIFF
--- a/altinkaya_theme/static/src/scss/primary_variables.scss
+++ b/altinkaya_theme/static/src/scss/primary_variables.scss
@@ -20,7 +20,7 @@ $o-altinkaya-field-border: #aeb6c1 !default;
 $o-altinkaya-chatter-bg: #eceeef !default;
 $o-altinkaya-accent: #174b87 !default;
 $o-altinkaya-accent-hover: #103762 !default;
-$o-altinkaya-required-bg: #f1edf5 !default;
+$o-altinkaya-required-bg: #e4d6ef !default;
 $o-altinkaya-required-border: #8766ac !default;
 $o-altinkaya-required-text: #47335e !default;
 $o-altinkaya-required-placeholder: #6b537f !default;


### PR DESCRIPTION
Make required fields easier to distinguish from the light form background by changing their fill from `#f1edf5` to `#e4d6ef`.

The existing text and border colors remain readable; required-field text contrast is above 7:1. This is a single CSS palette change for light mode.

Validation: contrast calculation and full repository pre-commit checks.
