### PR TITLE
[FIX] Restore contrast in the language submenu and ks dashboards

### DIFF
--- a/altinkaya_theme/__manifest__.py
+++ b/altinkaya_theme/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Altinkaya Theme",
     "summary": "Modern light and dark themes for the Odoo backend",
-    "version": "16.0.1.4.0",
+    "version": "16.0.1.4.3",
     "category": "Themes/Backend",
     "author": "Altinkaya Enclosures, initOS GmbH, Odoo Community Association (OCA)",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
@@ -29,6 +29,7 @@
             "altinkaya_theme/static/src/xml/navigation.xml",
             "altinkaya_theme/static/src/scss/navigation.scss",
             "altinkaya_theme/static/src/scss/mobile.scss",
+            "altinkaya_theme/static/src/scss/ks_dashboard.scss",
         ],
         "web.dark_mode_assets_common": [
             ("prepend", "altinkaya_theme/static/src/scss/dark_variables.scss"),

--- a/altinkaya_theme/static/src/scss/backend.scss
+++ b/altinkaya_theme/static/src/scss/backend.scss
@@ -19,9 +19,14 @@ body.o_web_client {
     background: $o-navbar-background !important;
     color: $o-navbar-entry-color !important;
 
+    // Core marks a submenu toggler .dropdown-item, so excluding it keeps this
+    // rule on real navbar entries. Without that, the important colour also
+    // painted the language submenu toggler inside the open user menu panel,
+    // white on a white panel, and altinkaya_base cannot win it back: it sets
+    // the colour without !important, and !important beats specificity.
     .o_menu_brand,
     .o_nav_entry,
-    .dropdown-toggle,
+    .dropdown-toggle:not(.dropdown-item),
     > .o_menu_brand,
     > ul > li > a,
     > ul > li > label,
@@ -36,7 +41,7 @@ body.o_web_client {
       }
     }
 
-    .show .dropdown-toggle {
+    .show .dropdown-toggle:not(.dropdown-item) {
       background-color: $o-navbar-entry-bg--hover !important;
     }
   }

--- a/altinkaya_theme/static/src/scss/ks_dashboard.scss
+++ b/altinkaya_theme/static/src/scss/ks_dashboard.scss
@@ -1,0 +1,49 @@
+// ks_dashboard_ninja carries its own design tokens (--ks-dn-*), its own dark
+// mode keyed on a data-color-mode attribute that Odoo never sets, and inline
+// styles hardcoded in its QWeb templates. None of that follows the color_scheme
+// cookie, so the dark palette only reaches it through generic Bootstrap and Odoo
+// rules on classes it happens to share. These rules repair the places where that
+// half-application leaves text or surfaces unreadable. Delete them if ks ever
+// registers its own ks_dashboard_ninja_dark.scss, which today sits in the
+// module unreferenced by any asset bundle.
+body.o_web_client .ks_dashboard_ninja {
+  // Core gives every .card-body a translucent card background
+  // (web/static/src/scss/bootstrap_review.scss). ks paints the surrounding
+  // .card a literal white, so in dark mode the body resolved to
+  // rgba(38, 42, 48, 0.9) and drew a dark frame around each white chart. The
+  // chart surface has to stay light because Chart.js renders its axis labels
+  // into a canvas that CSS cannot restyle, so drop the frame rather than
+  // darken the card.
+  .ks_chart_card_body {
+    background-color: transparent !important;
+  }
+
+  // ks paints this panel white in the template itself
+  // (ks_dashboard_ninja_templates.xml:15), in both colour schemes, and an inline
+  // style outranks any ordinary rule. So the text on it has to be dark in both.
+  // Not $o-main-text-color, which flips to near-white in dark and left these
+  // items at about 1.15:1 against the panel.
+  .config_dropdown .dropdown-menu .dropdown-item {
+    color: #212529;
+  }
+
+  // The same template hardcodes style="color: black" on the settings button
+  // (line 11), which reads fine on the light button and lands at about 1.4:1 on
+  // the dark one. !important is what it takes to outrank an inline style. The
+  // value has to follow the scheme, so it is the same $o-gray-800 that
+  // backend.scss already gives .btn-secondary, not a literal.
+  .config_dropdown .dropdown-toggle {
+    color: $o-gray-800 !important;
+  }
+
+  // The header action icons are <img src="ks_dashboard_ninja/.../icons/*.svg">
+  // with a dark fill baked into the file, so they came out navy on the blue
+  // button and neither color nor fill can reach them. A filter is the only way
+  // to repaint an img. $o-brand-primary is a mid-dark blue in both schemes, so
+  // white is right for both and this needs no per-scheme value. Scoped to the
+  // buttons: the welcome hand_wave.png sits in this header too and keeps its
+  // own colours.
+  .ks_dashboard_header .btn-primary > img {
+    filter: brightness(0) invert(1);
+  }
+}


### PR DESCRIPTION
Four contrast defects in the new backend theme, all measured in the browser on 16test2 in both colour schemes.

## Language submenu, light mode

`backend.scss` emitted `.o_main_navbar .dropdown-toggle { color: #f3f6fc !important }`. The bare `.dropdown-toggle` matched every toggle in the navbar subtree, including the language submenu toggler that renders inside the open user menu panel. `altinkaya_base/static/src/scss/user_menu_language.scss` styles that toggler at specificity (0,5,1) but without `!important`, and `!important` beats specificity, so "Dil" came out near-white on a near-white panel.

It is now `.dropdown-toggle:not(.dropdown-item)`, in the colour rule and the `.show` hover rule. Real navbar entries are unchanged.

## ks_dashboard_ninja, dark mode

The module runs a theming system the `color_scheme` cookie never reaches: its own `--ks-dn-*` tokens applied with `!important`, its own dark mode keyed on a `data-color-mode` attribute nothing sets, inline styles hardcoded in its QWeb templates, and nineteen of twenty stylesheets in plain `.css` that never recompile with the dark palette. It also ships `ks_dashboard_ninja_dark.scss`, registered in no bundle.

Odoo's palette still reaches it through shared Bootstrap classes, and two of those collide:

- Core gives every `.card-body` a translucent card background (`web/static/src/scss/bootstrap_review.scss:26-31`), compiling to `rgba(38, 42, 48, 0.9) !important` in dark. ks paints the surrounding `.card` a literal white (`ks_dashboard_ninja_pro.css:60`), so every chart sat inside a dark frame.
- `ks_dashboard_ninja_templates.xml` hardcodes `background-color: rgba(255,255,255)` on the settings panel (line 15) and `color: black` on its button (line 11). The panel then carried our near-white `.dropdown-item` text, and the button carried black on a `#262a30` surface.

Separately, the header action buttons (play, print, mail, import, edit) render their glyphs as `<img src="ks_dashboard_ninja/static/images/icons/*.svg">` with a dark fill baked into each file. Neither `color` nor `fill` reaches an `img`, so they read as navy on the blue button in both schemes. A filter is the only way to repaint one.

The new `ks_dashboard.scss` repairs all four.

## Why not just darken them

Both obvious fixes were tried in a live page and both made things worse.

Darkening `.ks_dashboard_header` leaves ks's template-hardcoded dark text unreadable, including `<h3 style="color:black">` on the welcome line.

Darkening the chart card so `.card` and `.card-body` agree also removes the frame, but Chart.js renders axis labels into a canvas that CSS cannot restyle, and the numbers would go with it.

So the rule for this module is to repair the foreground on whatever surface ks insists on. Where ks pins that surface in both schemes, use a literal (`#212529` for the panel text). Where the surface follows the palette, use the variable (`$o-gray-800` for the button), or light mode breaks instead.

## Measured

| | before | after |
|---|---|---|
| "Dil" row, light | `rgb(243,246,252)` on `rgb(247,247,245)`, 1.05:1 | `rgb(32,36,42)`, matches its siblings |
| chart card body, dark | `rgba(38,42,48,0.9)` frame | transparent |
| settings menu items, dark | `rgb(226,229,233)` on white, 1.15:1 | `rgb(33,37,41)` on white |
| settings button, dark | black on `rgb(38,42,48)`, 1.4:1 | `rgb(226,229,233)`, about 11:1 |
| settings button, light | black on `rgb(247,247,245)` | `rgb(45,51,59)`, about 11:1 |
| header action icons, both | dark SVG fill on `#4168b0` / `#2455a1` | white, via `brightness(0) invert(1)` |

`debug=0` and `debug=assets` were ruled out along the way: the same dashboard in one dark session gives byte-identical computed values with no debug param, `?debug=0` and `?debug=assets`.

## Notes

- The new stylesheet is registered in `web.assets_backend` only. The dark bundle includes that bundle, so one entry serves both schemes.
- `ir_asset` holds no rows for this module, so manifest assets are read live. Deploying needs a server restart to pick up the new file. `-u altinkaya_theme` is not required.
- `ks_dashboard.scss` was compiled offline against both `primary_variables.scss` and `dark_variables.scss` before shipping.
- The icon filter is scoped to `.btn-primary > img`, so the welcome `hand_wave.png` in the same header keeps its own colours.
- Version 16.0.1.4.0 to 16.0.1.4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
