### PR TITLE
[IMP] Refine Altinkaya theme UI and appearance handling

### DIFF
--- a/altinkaya_theme/README.rst
+++ b/altinkaya_theme/README.rst
@@ -33,8 +33,10 @@ Touch controls, full-width forms and scrollable notebook tabs follow the
 mobile layout conventions of ``web_responsive``.
 
 Use **Dark Mode** in the user menu to switch appearances. Under profile
-preferences, **Use System Theme** follows the device's appearance. An explicit
-switch disables system following. Preferences are stored per user.
+preferences, **Use System Theme** follows the device's appearance and is enabled
+by default for new users. An explicit switch disables system following.
+Preferences are stored per user. The appearance cookie is refreshed only on
+signed-in requests; requests without a signed-in session never receive it.
 
 In menu search, **Up/Down** highlights results and **Enter** opens the selected
 menu. Typing resets the selection; keyboard navigation keeps the search input

--- a/altinkaya_theme/__manifest__.py
+++ b/altinkaya_theme/__manifest__.py
@@ -3,12 +3,12 @@
 {
     "name": "Altinkaya Theme",
     "summary": "Modern light and dark themes for the Odoo backend",
-    "version": "16.0.1.4.0",
+    "version": "16.0.1.4.1",
     "category": "Themes/Backend",
     "author": "Altinkaya Enclosures, initOS GmbH, Odoo Community Association (OCA)",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "license": "AGPL-3",
-    "depends": ["web"],
+    "depends": ["web", "mail"],
     "excludes": [
         "web_enterprise",
         "web_responsive",

--- a/altinkaya_theme/i18n/altinkaya_theme.pot
+++ b/altinkaya_theme/i18n/altinkaya_theme.pot
@@ -117,3 +117,45 @@ msgstr ""
 #, python-format
 msgid "Close tools"
 msgstr ""
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "New"
+msgstr ""
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Send message"
+msgstr ""
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Log note"
+msgstr ""
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Activities"
+msgstr ""
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Follow"
+msgstr ""
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Unfollow"
+msgstr ""

--- a/altinkaya_theme/i18n/tr.po
+++ b/altinkaya_theme/i18n/tr.po
@@ -119,3 +119,45 @@ msgstr "Araçlar"
 #, python-format
 msgid "Close tools"
 msgstr "Araçları kapat"
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "New"
+msgstr "Yeni"
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Send message"
+msgstr "Mesaj Gönder"
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Log note"
+msgstr "Not Ekle"
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Activities"
+msgstr "Aktiviteler"
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Follow"
+msgstr "Takip Et"
+
+#. module: altinkaya_theme
+#. odoo-javascript
+#: code:addons/altinkaya_theme/static/src/xml/navigation.xml:0
+#, python-format
+msgid "Unfollow"
+msgstr "Takibi Bırak"

--- a/altinkaya_theme/models/ir_http.py
+++ b/altinkaya_theme/models/ir_http.py
@@ -19,8 +19,15 @@ class IrHttp(models.AbstractModel):
 
     @classmethod
     def _set_color_scheme(cls, response):
-        """Keep the next page's asset bundle aligned with the user's choice."""
-        user = request.env.user
+        """Keep the next page's asset bundle aligned with the user's choice.
+
+        Requests without a signed-in session are left untouched. The session
+        user is read directly because ``auth="none"`` routes run with no env user.
+        """
+        uid = request.session.uid
+        if not uid:
+            return
+        user = request.env["res.users"].sudo().browse(uid)
         if user.dark_mode_device_dependent:
             return
         scheme = "dark" if user.dark_mode else "light"

--- a/altinkaya_theme/models/res_users.py
+++ b/altinkaya_theme/models/res_users.py
@@ -10,6 +10,7 @@ class ResUsers(models.Model):
     dark_mode = fields.Boolean()
     dark_mode_device_dependent = fields.Boolean(
         string="Use System Theme",
+        default=True,
         help="Follow this device's light or dark appearance setting.",
     )
 

--- a/altinkaya_theme/static/src/js/menu_search.esm.js
+++ b/altinkaya_theme/static/src/js/menu_search.esm.js
@@ -15,6 +15,24 @@ function getWords(value) {
   return normalizeMenuName(value).match(/[\p{L}\p{N}]+/gu) || [];
 }
 
+/** Normalize a menu's words once so each keystroke only scores them. */
+export function makeMenuEntry(menu, parents = []) {
+  const path = parents.join(" / ");
+  const nameWords = getWords(menu.name);
+  return {menu, path, nameWords, pathWords: getWords(path), name: nameWords.join(" ")};
+}
+
+/** Flatten the accessible menu tree, keeping group names as context. */
+export function collectMenuEntries(nodes, parents = [], entries = []) {
+  for (const menu of nodes) {
+    if (menu.actionID) {
+      entries.push(makeMenuEntry(menu, parents));
+    }
+    collectMenuEntries(menu.childrenTree, [...parents, menu.name], entries);
+  }
+  return entries;
+}
+
 /** Bounded edit distance including adjacent swapped letters. */
 function getEditDistance(source, target, limit) {
   let previous = Array.from({length: target.length + 1}, (_, i) => i);
@@ -81,9 +99,7 @@ export function searchMenuEntries(entries, query, currentAppId) {
   const phrase = tokens.join(" ");
   const results = [];
   for (const entry of entries) {
-    const nameWords = getWords(entry.menu.name);
-    const pathWords = getWords(entry.path);
-    const name = nameWords.join(" ");
+    const {name, nameWords, pathWords} = entry;
     let score = 0;
     let nameMatches = 0;
     for (const token of tokens) {

--- a/altinkaya_theme/static/src/js/navigation.esm.js
+++ b/altinkaya_theme/static/src/js/navigation.esm.js
@@ -14,20 +14,20 @@ import {useAutofocus, useBus, useService} from "@web/core/utils/hooks";
 import {patch} from "@web/core/utils/patch";
 import {NavBar} from "@web/webclient/navbar/navbar";
 import {BurgerMenu} from "@web/webclient/burger_menu/burger_menu";
-import {searchMenuEntries} from "@altinkaya_theme/js/menu_search.esm";
+import {
+  collectMenuEntries,
+  makeMenuEntry,
+  searchMenuEntries,
+} from "@altinkaya_theme/js/menu_search.esm";
 
 let nextMenuId = 0;
 
-/** Flatten the accessible menu tree, keeping group names as context. */
-function collectMenuEntries(nodes, parents = []) {
-  const entries = [];
-  for (const menu of nodes) {
-    if (menu.actionID) {
-      entries.push({menu, path: parents.join(" / ")});
-    }
-    entries.push(...collectMenuEntries(menu.childrenTree, [...parents, menu.name]));
-  }
-  return entries;
+/** Accept the raw base64 icons the menu service serves, or ready data URLs. */
+function getIconUrl(webIconData) {
+  if (!webIconData) return false;
+  if (webIconData.startsWith("data:image")) return webIconData;
+  const type = webIconData.startsWith("P") ? "svg+xml" : "png";
+  return `data:image/${type};base64,${webIconData.replace(/\s/g, "")}`;
 }
 
 export class AltinkayaMenu extends Component {
@@ -38,6 +38,11 @@ export class AltinkayaMenu extends Component {
     this.searchInput = useAutofocus();
     this.results = useRef("results");
     this.resultsId = `o_altinkaya_results_${nextMenuId++}`;
+    // Menus cannot change while the launcher is open: index them once.
+    this.apps = this.menu.getApps().map((menu) => makeMenuEntry(menu));
+    this.allEntries = null;
+    this.lastSearch = {query: "", entries: this.apps};
+    this.iconUrls = new Map();
     // Odoo maps Alt to Control on macOS, matching the launcher's data-hotkey.
     useHotkey("alt+h", () => this.props.close(), {
       bypassEditableProtection: true,
@@ -60,17 +65,24 @@ export class AltinkayaMenu extends Component {
     return this.env._t("Search menus...");
   }
 
+  /** Reuse one ranking per query: the template and key handler read it repeatedly. */
   get entries() {
-    const app = this.menu.getCurrentApp();
     const query = this.state.query.trim();
-    const apps = this.menu.getApps();
-    let entries = apps.map((menu) => ({menu, path: ""}));
-    if (query) {
-      entries = collectMenuEntries(
-        apps.map((menu) => this.menu.getMenuAsTree(menu.id))
-      );
+    if (this.lastSearch.query !== query) {
+      this.lastSearch = {query, entries: this.searchEntries(query)};
     }
-    return searchMenuEntries(entries, query, app && app.id);
+    return this.lastSearch.entries;
+  }
+
+  /** Rank the flattened menu tree, which is built on the first search. */
+  searchEntries(query) {
+    if (!query) return this.apps;
+    if (!this.allEntries) {
+      const trees = this.menu.getApps().map((menu) => this.menu.getMenuAsTree(menu.id));
+      this.allEntries = collectMenuEntries(trees);
+    }
+    const app = this.menu.getCurrentApp();
+    return searchMenuEntries(this.allEntries, query, app && app.id);
   }
 
   /** Close the active launcher when its backdrop is clicked. */
@@ -126,13 +138,13 @@ export class AltinkayaMenu extends Component {
     return this.menu.getMenu(menu.appID) || menu;
   }
 
-  /** Return the root app icon, or use its letter fallback. */
+  /** Return the root app icon built once per app, or false for its letter fallback. */
   getIcon(menu) {
     const app = this.getApplication(menu);
-    if (!app.webIconData) return false;
-    if (app.webIconData.startsWith("data:image")) return app.webIconData;
-    const type = app.webIconData.startsWith("P") ? "svg+xml" : "png";
-    return `data:image/${type};base64,${app.webIconData.replace(/\s/g, "")}`;
+    if (!this.iconUrls.has(app.id)) {
+      this.iconUrls.set(app.id, getIconUrl(app.webIconData));
+    }
+    return this.iconUrls.get(app.id);
   }
 
   /** Keep ordinary links usable in a separate browser tab. */

--- a/altinkaya_theme/static/src/scss/backend.scss
+++ b/altinkaya_theme/static/src/scss/backend.scss
@@ -554,8 +554,25 @@ body.o_web_client {
     }
   }
 
+  .o_FormRenderer_chatterContainer {
+    // The outer bottom spacing belongs to the canvas, not the white form view.
+    background-color: $o-altinkaya-canvas;
+    border-top: 0;
+
+    &.o-aside {
+      padding: $o-sheet-vpadding * 0.5;
+      border-left: 0;
+    }
+
+    &:not(.o-aside) .o_ChatterContainer {
+      border-radius: $o-border-radius-lg;
+    }
+  }
+
   .o_ChatterContainer {
     background-color: $o-altinkaya-chatter-bg;
+    border: 1px solid $border-color;
+    box-shadow: 0 5px 20px -15px rgba(#000, 0.4);
 
     // Chatter children have bg-view utilities that otherwise hide it.
     .o_Chatter,
@@ -565,14 +582,59 @@ body.o_web_client {
   }
 
   .o_ChatterTopbar {
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    // Replace the legacy tab borders and margins with one padded toolbar.
+    --ChatterTopbar-border: 0;
+    --ChatterTopbar-padding-v: 0;
+    --ChatterTopbar-padding-left: 0;
+    --ChatterTopbar-padding-right: 0;
+
+    box-sizing: border-box;
+    padding: 8px 12px;
+    border-bottom: 1px solid $o-gray-300;
+    gap: 8px;
+
+    .o_ChatterTopbar_actions,
+    .o_ChatterTopbar_tools {
+      min-width: 0;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .o_ChatterTopbar_controllers,
+    .o_ChatterTopbar_tools {
+      padding: 0 !important;
+    }
+
+    .o_ChatterTopbar_controllers,
+    .o_ChatterTopbar_rightSection {
+      align-items: center;
+      gap: 6px;
+    }
+
+    .o_ChatterTopbar_tools > .o_ChatterTopbar_borderLeft {
+      display: none;
+    }
+
+    .o_ChatterTopbar_rightSection {
+      margin-inline-start: auto;
+    }
+
+    .o_ChatterTopbar_button {
+      min-height: 32px;
+      margin: 0 !important;
+    }
+
+    .o_ChatterTopbar_followButton .btn {
+      padding-inline: 8px !important;
+      white-space: nowrap;
+    }
 
     .btn-light:not(.btn-primary) {
-      border-color: transparent;
+      border-color: $o-gray-300;
 
       &:hover {
-        border-color: $o-gray-300;
+        border-color: $o-gray-400;
       }
     }
   }

--- a/altinkaya_theme/static/src/scss/mobile.scss
+++ b/altinkaya_theme/static/src/scss/mobile.scss
@@ -309,6 +309,52 @@
     }
 
     .o_form_view {
+      .o_control_panel {
+        .o_cp_bottom_right {
+          justify-content: flex-start !important;
+          gap: 6px;
+        }
+
+        // Odoo keeps this invisible group in the layout even for saved records.
+        .o_form_status_indicator:has(.o_form_status_indicator_buttons.invisible) {
+          display: none;
+        }
+
+        .o_cp_action_menus {
+          display: flex;
+          gap: 6px;
+        }
+
+        .o_cp_action_menus .dropdown-toggle,
+        .oe_pager_refresh,
+        .o_form_button_create {
+          min-width: 40px;
+          margin: 0;
+          padding: 6px;
+        }
+
+        .o_cp_pager {
+          padding-left: 0;
+
+          .o_pager {
+            gap: 4px !important;
+            white-space: nowrap;
+          }
+
+          .btn {
+            min-width: 36px;
+          }
+        }
+      }
+
+      .o_form_button_create {
+        font-size: 0;
+
+        .o_altinkaya_mobile_icon {
+          font-size: 16px;
+        }
+      }
+
       .o_x2m_control_panel .o-kanban-button-new {
         // Core gives this button full width on mobile; margins would add overflow.
         margin-left: 0;
@@ -350,8 +396,53 @@
 
       .o_form_statusbar {
         flex-wrap: wrap;
-        gap: 4px;
-        padding: 4px 8px;
+        align-items: center;
+        gap: 8px;
+        padding: 8px;
+
+        .o_statusbar_buttons > .btn,
+        .o_statusbar_buttons > .o-dropdown > .dropdown-toggle,
+        .o_field_statusbar .dropdown-toggle {
+          min-height: 40px;
+          margin: 0;
+          padding: 8px 12px;
+          font-weight: 600;
+          text-transform: none !important;
+        }
+
+        .o_field_statusbar .dropdown-toggle {
+          color: $o-main-text-color !important;
+          background-color: $o-altinkaya-field-bg !important;
+          border-color: $o-gray-300 !important;
+        }
+
+        .dropdown-menu {
+          max-width: calc(100vw - 16px);
+          max-height: 65vh;
+          overflow-y: auto;
+        }
+
+        .o_statusbar_button_dropdown_item {
+          padding: 0;
+
+          > .btn {
+            min-height: 40px;
+            margin: 0;
+            padding: 8px 12px;
+            border-radius: 0 !important;
+            text-align: left;
+            white-space: normal;
+          }
+
+          > .btn-secondary {
+            border: 0;
+            background-color: transparent;
+
+            &:hover {
+              background-color: $o-list-group-active-bg;
+            }
+          }
+        }
       }
 
       .o_statusbar_buttons {
@@ -363,6 +454,36 @@
         min-width: 0;
         max-width: 100%;
         margin-left: auto;
+      }
+
+      .o-form-buttonbox {
+        // Match the mobile sheet's 16px padding instead of the desktop 24px.
+        margin-top: -$o-horizontal-padding;
+        margin-bottom: $o-horizontal-padding;
+
+        .btn.oe_stat_button {
+          height: 56px;
+        }
+
+        > .btn.oe_stat_button:not(.dropdown) {
+          display: inline-flex;
+          align-items: center;
+
+          > .o_button_icon {
+            flex-shrink: 0;
+            line-height: 1;
+          }
+
+          > .o_stat_info,
+          > .o_field_statinfo {
+            min-width: 0;
+            white-space: normal;
+
+            .o_stat_text {
+              white-space: normal;
+            }
+          }
+        }
       }
 
       .o_notebook > .o_notebook_headers {
@@ -386,12 +507,51 @@
     }
 
     .o_ChatterTopbar {
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       gap: 4px;
       padding: 8px;
 
+      .o_ChatterTopbar_actions,
+      .o_ChatterTopbar_tools,
+      .o_ChatterTopbar_controllers,
+      .o_ChatterTopbar_rightSection {
+        flex-wrap: nowrap;
+        gap: 4px;
+      }
+
       .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 40px;
         min-height: 40px;
+        padding: 6px;
+      }
+
+      .o_ChatterTopbar_buttonSendMessage,
+      .o_ChatterTopbar_buttonLogNote,
+      .o_ChatterTopbar_followButton .btn {
+        font-size: 0;
+      }
+
+      .o_altinkaya_mobile_icon,
+      .o_ChatterTopbar_buttonScheduleActivity .fa {
+        font-size: 16px;
+        margin: 0 !important;
+      }
+
+      .o_FollowButton_unfollow > .position-relative {
+        display: none;
+      }
+
+      .o_FollowerListMenu_dropdown {
+        // Odoo anchors this fixed menu to the follower button's right edge.
+        left: 8px !important;
+        right: 8px;
+        width: auto;
+        max-width: none;
+        max-height: 60vh;
+        overflow-y: auto;
       }
     }
 

--- a/altinkaya_theme/static/src/xml/navigation.xml
+++ b/altinkaya_theme/static/src/xml/navigation.xml
@@ -150,4 +150,119 @@
             >No matching menu.</p>
         </Dialog>
     </t>
+    <!-- Mobile icon controls follow OCA/web_responsive (LGPL-3.0-or-later),
+         Copyright 2023 Onestein and 2025 Dixmit. -->
+    <t
+        t-name="altinkaya_theme.MobileForm"
+        t-inherit="web.FormView"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath expr="//button[hasclass('o_form_button_create')]" position="attributes">
+            <attribute name="aria-label">New</attribute>
+            <attribute name="title">New</attribute>
+        </xpath>
+        <xpath expr="//button[hasclass('o_form_button_create')]" position="inside">
+            <i
+                class="o_altinkaya_mobile_icon fa fa-plus d-md-none"
+                aria-hidden="true"
+            />
+        </xpath>
+    </t>
+    <t
+        t-name="altinkaya_theme.MobileFormButtons"
+        t-inherit="web.FormView.Buttons"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath expr="//button[hasclass('o_form_button_create')]" position="attributes">
+            <attribute name="aria-label">New</attribute>
+            <attribute name="title">New</attribute>
+        </xpath>
+        <xpath expr="//button[hasclass('o_form_button_create')]" position="inside">
+            <i
+                class="o_altinkaya_mobile_icon fa fa-plus d-md-none"
+                aria-hidden="true"
+            />
+        </xpath>
+    </t>
+    <t
+        t-name="altinkaya_theme.MobileChatter"
+        t-inherit="mail.ChatterTopbar"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonSendMessage')]"
+            position="attributes"
+        >
+            <attribute name="aria-label">Send message</attribute>
+            <attribute name="title">Send message</attribute>
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonSendMessage')]"
+            position="inside"
+        >
+            <i
+                class="o_altinkaya_mobile_icon fa fa-paper-plane d-md-none"
+                aria-hidden="true"
+            />
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonLogNote')]"
+            position="attributes"
+        >
+            <attribute name="aria-label">Log note</attribute>
+            <attribute name="title">Log note</attribute>
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonLogNote')]"
+            position="inside"
+        >
+            <i
+                class="o_altinkaya_mobile_icon fa fa-sticky-note-o d-md-none"
+                aria-hidden="true"
+            />
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonScheduleActivity')]"
+            position="attributes"
+        >
+            <attribute name="aria-label">Activities</attribute>
+            <attribute name="title">Activities</attribute>
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_ChatterTopbar_buttonScheduleActivity')]/span"
+            position="attributes"
+        >
+            <attribute name="class" add="d-none d-md-inline" separator=" " />
+        </xpath>
+    </t>
+    <t
+        t-name="altinkaya_theme.MobileFollowButton"
+        t-inherit="mail.FollowButton"
+        t-inherit-mode="extension"
+        owl="1"
+    >
+        <xpath expr="//button[hasclass('o_FollowButton_follow')]" position="attributes">
+            <attribute name="aria-label">Follow</attribute>
+            <attribute name="title">Follow</attribute>
+        </xpath>
+        <xpath expr="//button[hasclass('o_FollowButton_follow')]" position="inside">
+            <i class="o_altinkaya_mobile_icon fa fa-eye d-md-none" aria-hidden="true" />
+        </xpath>
+        <xpath
+            expr="//button[hasclass('o_FollowButton_unfollow')]"
+            position="attributes"
+        >
+            <attribute name="aria-label">Unfollow</attribute>
+            <attribute name="title">Unfollow</attribute>
+        </xpath>
+        <xpath expr="//button[hasclass('o_FollowButton_unfollow')]" position="inside">
+            <i
+                class="o_altinkaya_mobile_icon fa fa-eye-slash d-md-none"
+                aria-hidden="true"
+            />
+        </xpath>
+    </t>
 </templates>

--- a/altinkaya_theme/tests/test_theme.py
+++ b/altinkaya_theme/tests/test_theme.py
@@ -3,11 +3,51 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from odoo import api
 from odoo.exceptions import UserError
 from odoo.tests import common
 
 from ..hooks import pre_init_hook
 from ..models import ir_http
+
+LAUNCHER_CHECK = """
+(async () => {
+    const until = async (check, label) => {
+        for (let i = 0; i < 100; i++) {
+            const value = check();
+            if (value) return value;
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+        throw new Error("timeout: " + label);
+    };
+    document.querySelector(".o_altinkaya_launcher_button").click();
+    const input = await until(
+        () => document.querySelector(".o_altinkaya_menu_search input"),
+        "launcher search field"
+    );
+    if (!document.querySelector(".o_altinkaya_app_grid .o_altinkaya_app_icon")) {
+        throw new Error("no application tiles rendered");
+    }
+    input.value = "user";
+    input.dispatchEvent(new Event("input", {bubbles: true}));
+    await until(
+        () => document.querySelector(".o_altinkaya_sections_list"), "search results"
+    );
+    const names = [...document.querySelectorAll(".o_altinkaya_app strong")].map(
+        (el) => el.textContent
+    );
+    if (!names.some((name) => /user/i.test(name))) {
+        throw new Error("Users menu missing from: " + names.join(", "));
+    }
+    const arrowDown = new KeyboardEvent("keydown", {key: "ArrowDown", bubbles: true});
+    input.dispatchEvent(arrowDown);
+    await until(
+        () => document.querySelector(".o_altinkaya_app[aria-selected='true']"),
+        "keyboard selection"
+    );
+    console.log("test successful");
+})().catch((error) => console.error(error.message));
+"""
 
 
 class TestTheme(common.TransactionCase):
@@ -25,8 +65,10 @@ class TestTheme(common.TransactionCase):
         self.assertTrue(user.dark_mode_device_dependent)
 
     def test_cookie_follows_saved_appearance(self):
+        self.user.write({"dark_mode_device_dependent": False})
         request = SimpleNamespace(
             env=self.user.with_user(self.user).env,
+            session=SimpleNamespace(uid=self.user.id),
             httprequest=SimpleNamespace(cookies={}),
         )
         with patch.object(ir_http, "request", request):
@@ -43,15 +85,38 @@ class TestTheme(common.TransactionCase):
                 response.set_cookie.assert_not_called()
 
     def test_system_preference_does_not_overwrite_browser_choice(self):
-        self.user.write({"dark_mode_device_dependent": True})
         request = SimpleNamespace(
             env=self.user.with_user(self.user).env,
+            session=SimpleNamespace(uid=self.user.id),
             httprequest=SimpleNamespace(cookies={"color_scheme": "dark"}),
         )
         response = MagicMock()
         with patch.object(ir_http, "request", request):
             self.env["ir.http"]._set_color_scheme(response)
         response.set_cookie.assert_not_called()
+
+    def test_anonymous_requests_get_no_cookie(self):
+        request = SimpleNamespace(
+            env=self.env(user=self.env.ref("base.public_user")),
+            session=SimpleNamespace(uid=None),
+            httprequest=SimpleNamespace(cookies={}),
+        )
+        response = MagicMock()
+        with patch.object(ir_http, "request", request):
+            self.env["ir.http"]._set_color_scheme(response)
+        response.set_cookie.assert_not_called()
+
+    def test_auth_none_routes_read_the_session_user(self):
+        self.user.write({"dark_mode": True, "dark_mode_device_dependent": False})
+        request = SimpleNamespace(
+            env=api.Environment(self.env.cr, None, {}),
+            session=SimpleNamespace(uid=self.user.id),
+            httprequest=SimpleNamespace(cookies={"color_scheme": "light"}),
+        )
+        response = MagicMock()
+        with patch.object(ir_http, "request", request):
+            self.env["ir.http"]._set_color_scheme(response)
+        response.set_cookie.assert_called_once_with("color_scheme", "dark")
 
     def test_assets_are_scoped_to_backend_bundles(self):
         assets = self.env["ir.asset"]
@@ -139,3 +204,18 @@ class TestLegacyMigration(common.TransactionCase):
             pre_init_hook(self.env.cr)
         self.assertEqual(self.legacy.state, "installed")
         self.assertEqual(self.data.module, "web_dark_mode")
+
+
+@common.tagged("post_install", "-at_install")
+class TestLauncherUi(common.HttpCase):
+    def test_launcher_search_and_keyboard_selection(self):
+        self.env.ref("base.user_admin").write(
+            {"dark_mode": False, "dark_mode_device_dependent": False}
+        )
+        self.browser_js(
+            "/web",
+            LAUNCHER_CHECK,
+            "document.querySelector('.o_action_manager > *') !== null",
+            login="admin",
+            timeout=300,
+        )


### PR DESCRIPTION
Refine mobile form and chatter controls, dropdown placement, menu dismissal, and launcher search performance. Use system appearance for new users and synchronize appearance cookies only for signed-in sessions.

Includes responsive spacing, below-form chatter cards, accessible mobile icons, Turkish labels, and deterministic launcher regression coverage.

Validation:
- Full pre-commit checks and explicit JavaScript lint checks.
- 10 Odoo tests in a disposable database, including the launcher browser test.
- Browser checks at 320/360px and desktop widths, including menus, follow states, and new-form controls.
