### PR TITLE
[FIX] altinkaya_crm: let crm.phonecall activity type take its NOT NULL

### DIFF
--- a/altinkaya_crm/__manifest__.py
+++ b/altinkaya_crm/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Altinkaya CRM Extension",
     "summary": "Adds tracking and conversion rates to orders.",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "category": "General",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "author": "Yousef Sheta, Altinkaya Enclosures",

--- a/altinkaya_crm/migrations/16.0.1.2.0/pre-migrate.py
+++ b/altinkaya_crm/migrations/16.0.1.2.0/pre-migrate.py
@@ -1,0 +1,28 @@
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Fill in activity_type_id so PostgreSQL will accept the NOT NULL.
+
+    The field is required, but rows older than that change, plus every row
+    crm_phonecall's "Schedule a call" wizard has written since, hold NULL. So
+    odoo.schema logs "unable to set NOT NULL on column 'activity_type_id'" and
+    the constraint never lands. These are phone calls, so "Phone call" is the
+    honest value for all of them.
+    """
+    if not version:
+        return
+    cr.execute(
+        """
+        UPDATE crm_phonecall
+        SET activity_type_id = d.res_id
+        FROM ir_model_data d
+        WHERE d.module = 'mail'
+          AND d.name = 'mail_activity_data_call'
+          AND crm_phonecall.activity_type_id IS NULL
+        """
+    )
+    _logger.info("crm.phonecall: filled in activity type on %s rows", cr.rowcount)

--- a/altinkaya_crm/models/crm_phonecall.py
+++ b/altinkaya_crm/models/crm_phonecall.py
@@ -6,9 +6,16 @@ from odoo import fields, models
 class CRMPhonecall(models.Model):
     _inherit = "crm.phonecall"
 
+    # crm_phonecall's "Schedule a call" wizard builds its vals in
+    # get_values_schedule_another_phonecall without this field, so without a
+    # default the NOT NULL that required=True asks for would raise at the user
+    # instead of at the developer.
     activity_type_id = fields.Many2one(
         "mail.activity.type",
         required=True,
+        default=lambda self: self.env.ref(
+            "mail.mail_activity_data_call", raise_if_not_found=False
+        ),
     )
     state = fields.Selection(
         selection_add=[("success", "Success"), ("failed", "Failed")]

--- a/altinkaya_crm/tests/__init__.py
+++ b/altinkaya_crm/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_crm_lead
+from . import test_crm_phonecall
 from . import test_sale_order

--- a/altinkaya_crm/tests/test_crm_phonecall.py
+++ b/altinkaya_crm/tests/test_crm_phonecall.py
@@ -1,0 +1,24 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestCRMPhonecall(TransactionCase):
+    def test_scheduling_a_call_fills_in_the_activity_type(self):
+        """Guard against a NOT NULL violation when scheduling another call."""
+        activity_type = self.env.ref("mail.mail_activity_data_call")
+        source = self.env["crm.phonecall"].create(
+            {
+                "name": "Source call",
+                "activity_type_id": activity_type.id,
+            }
+        )
+
+        vals = source.get_values_schedule_another_phonecall({"name": "Follow-up call"})
+        self.assertNotIn(
+            "activity_type_id",
+            vals,
+            "crm_phonecall's wizard omits activity_type_id, so the default keeps "
+            "the NOT NULL constraint from raising an error at the user.",
+        )
+
+        phonecall = self.env["crm.phonecall"].create(vals)
+        self.assertEqual(phonecall.activity_type_id, activity_type)


### PR DESCRIPTION
`crm.phonecall.activity_type_id` has been `required=True` since the 16.0 migration of this module, and its NOT NULL constraint has never existed on any database.

## What was happening

`odoo/fields.py:1062` queues `apply_required` through `pool.post_constraint`, which runs `ALTER TABLE crm_phonecall ALTER COLUMN activity_type_id SET NOT NULL`. PostgreSQL refuses, because rows already hold NULL. `odoo/modules/registry.py:484` catches that and logs it:

```
ERROR ALTINKAYA2025 odoo.schema: Table 'crm_phonecall': unable to set NOT NULL on column 'activity_type_id'
```

The loader then carries on, so the module has looked correct for a year while the column stayed unconstrained. On 16test2 before this change, `pg_attribute.attnotnull` read `false` for `activity_type_id` and `true` for `name`, which the OCA module marked required back when the table was young.

## Why backfilling alone is the wrong fix

575 of 30212 rows were NULL. 562 predate 2024, but 13 arrived between 2024 and 2026, all in state `open`, all from real users.

`crm_phonecall/models/crm_phonecall.py:117`, `get_values_schedule_another_phonecall`, builds the vals for the "Schedule a call" wizard without `activity_type_id`. Those inserts succeed because the constraint is missing. Backfill on its own would trade a log line for an IntegrityError thrown at whoever next schedules a follow-up call.

This PR does both.

## Changes

`models/crm_phonecall.py` gives the field `default=env.ref("mail.mail_activity_data_call")`, so the ORM fills it whenever a caller omits the key. `env.ref` suits every user here: `ir.model.data._xmlid_lookup` runs raw SQL with no ACL check, which matters because the Retell webhook in `altinkaya_hr` creates phonecalls as the public user.

`migrations/16.0.1.2.0/pre-migrate.py` backfills the existing NULLs to the same value. Direct SQL, not the ORM: it has to run before the schema step, and a `write()` would fire mail tracking on all 575 records.

"Phone call" is the honest value. These are phone calls, and it was already 23863 of the 30212 rows.

One test in `tests/test_crm_phonecall.py` pins the wizard path instead of restating the default. It asserts that `get_values_schedule_another_phonecall` returns no `activity_type_id` key, then creates from those vals and checks the type landed. Now that the constraint applies, deleting the default makes that create raise, so the test breaks instead of production. The `assertNotIn` doubles as a canary: if OCA adds the field upstream, that assertion fails and tells you the default is no longer load-bearing.

## Verified on 16test2

| check | result |
|---|---|
| dry run in a rolled-back transaction | 575 rows filled, `SET NOT NULL` succeeded |
| `-u altinkaya_crm` | `latest_version` = `16.0.1.2.0` |
| NULL rows after | 0 |
| `pg_attribute.attnotnull` | `f` to `t` |
| wizard vals carry the field? | no, so the default is load-bearing |
| create from those vals | activity type 2, rolled back |
| `--test-tags /altinkaya_crm` | 0 failed, 0 errors of 3 tests |

## Deploying this

Run `-u altinkaya_crm`. A restart is not enough: the pre-migration fires on this module's own version bump, so installing anything else that touches `crm.phonecall` (`altinkaya_hr` does, through Retell) keeps logging the same error until then.

ALTINKAYA2025 does not run on the dev machine, so production's NULL count is unknown. Neither half of the fix depends on it.

## One judgement call

All 13 recent NULL rows become "Phone call", including one a user named "Email Sent". Nobody had chosen a type for them, so there was no answer to preserve, but reclassifying them is a manual pass over 13 records if sales wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
