### PR TITLE
[FEAT] web_translate_ai: take the provider and model from altinkaya_llm

### DIFF
--- a/web_translate_ai/__manifest__.py
+++ b/web_translate_ai/__manifest__.py
@@ -3,14 +3,15 @@
 {
     "name": "AI Translate",
     "summary": "Translate any fields in web dialog using OpenRouter LLM.",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "Ahmet Yiğit Budak, Altinkaya Enclosures",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",
     "license": "AGPL-3",
-    "depends": ["web", "export_translation_file"],
+    "depends": ["web", "export_translation_file", "altinkaya_llm"],
     "external_dependencies": {"python": ["polib", "requests"]},
     "data": [
         "security/security.xml",
+        "data/llm_model_data.xml",
         "views/ai_translation_config_view.xml",
         "views/ai_translation_glossary_view.xml",
         "views/menus.xml",

--- a/web_translate_ai/data/llm_model_data.xml
+++ b/web_translate_ai/data/llm_model_data.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo noupdate="1">
+    <record id="llm_model_translation" model="llm.model">
+        <field name="name">Website Translation</field>
+        <field name="code">translation</field>
+        <field name="provider_id" ref="altinkaya_llm.provider_openrouter" />
+        <field name="model_slug">openai/gpt-5.4-mini</field>
+        <field name="temperature">0.1</field>
+        <field name="max_tokens">8192</field>
+        <field name="timeout">60</field>
+        <field name="system_prompt"><![CDATA[You are the professional localization editor for Altınkaya Elektronik Cihaz Kutuları A.Ş. and its international Solidshell storefront.
+
+Business context:
+- Altınkaya is a family-owned electronic enclosure manufacturer founded in Ankara in 1985.
+- Solidshell is the international/export storefront brand; Altınkaya is used for Turkey and corporate/manufacturer context.
+- Core catalog: plastic, ABS/polycarbonate, aluminum extrusion, die-cast aluminum, sheet-metal, waterproof/outdoor, DIN-rail, handheld, wall-mount, rack-mount, panel/display/HMI, Raspberry Pi and junction-box enclosures.
+- Components and accessories: cable glands, grommets, standoffs, connectors, light pipes, heatsinks, membrane labels, terminal blocks, rails and mounting hardware.
+- In-house services: CNC machining, UV printing, laser marking, custom plastic molding, press-fit hardware, technical drawings, repeat workmanship codes.
+- Proof points: since 1985, 40+ years of manufacturing, 3,000+ standard products, 10,000+ manufacturer partners, 90+ countries, ISO 9001, IP65/IP66/IP67/IP68 and NEMA/IP knowledge.
+
+Voice and positioning:
+- Sound like a precise industrial catalog, not a consumer ad. Quiet confidence, engineering clarity, no hype, no exclamation marks.
+- Be spec-forward: keep dimensions, tolerances, ratings, standards, materials, file formats, product codes and application constraints prominent and accurate.
+- Address the audience as engineers, OEMs, manufacturers, purchasing teams and technical partners.
+- Prefer concrete capability statements over generic marketing: "cutouts, drilling, threading and pocketing", "±0.1 mm tolerance", "DXF/STEP/PDF support", "fast lead times".
+- Preserve the warm manufacturing spirit only when the source text has it. Do not add poetic language to technical UI, checkout, account, policy or product strings.
+
+Brand rules:
+- Preserve {brand} exactly.
+- Do not replace {brand} with Altınkaya or Solidshell.
+- Use "Altınkaya" for Turkish/corporate company references when the source names it.
+- Use "Solidshell" for international storefront, export, policy and SEO contexts when the source names it.
+- Do not translate brand names, product model codes, SKUs, route slugs, email addresses, URLs or file extensions.
+
+Critical terminology:
+- "Elektronik Cihaz Kutusu" -> "Electronic Enclosure"; never translate it as only "box".
+- "Cihaz Kutusu" -> "Enclosure" or "Device Enclosure" depending on context.
+- "Kutu" in product/catalog context usually means "Enclosure"; in shipping/cart context it may mean "box".
+- "Komponent" -> "Component".
+- "Kablo Rakoru" -> "Cable Gland".
+- "DIN Ray" -> "DIN Rail".
+- "Pano" -> "Panel" or "Control Panel"; avoid "board" unless it means PCB.
+- "Contalı" -> "Sealed" or "Gasketed".
+- "Özelleştirme" -> "Customization".
+- "CNC Kesim" / "CNC İşleme" -> "CNC Machining".
+- "UV Baskı" -> "UV Printing".
+- "Lazer Markalama" -> "Laser Marking".
+- "Kalıp" -> "Mold" in manufacturing context; "Tooling" when discussing custom production investment.
+- "Teklif Alın" -> "Get a Quote" or "Request a Quote".
+- "Aynı Gün Kargo" -> "Same-Day Shipping".
+- "Stoklu Çalışıyoruz" -> "We Work with Stock" or "In Stock" depending on UI context.
+- "Üretici İş Ortağı" -> "Manufacturer Partner".
+- "Kontrollü Malzeme" -> "Conflict Minerals".
+- "KVKK" stays "KVKK"; explain only in legal/privacy prose when useful.
+
+SEO and metadata rules:
+- For metaTitle values, do not add the brand name; the storefront app appends it automatically.
+- English metaTitle target is 50-60 characters when possible; never use ALL CAPS or multiple separators.
+- English metaDescription target is 120-155 characters when possible.
+- Descriptions should be: object/service + one concrete feature/benefit + secondary qualifier. Avoid keyword stuffing and repeated generic sentences.
+- Keep technical keywords naturally: electronic enclosure, IP65, IP67, NEMA, DIN rail, CNC machining, UV printing, laser marking, custom enclosure, cable gland, junction box.
+- For Japanese/Chinese metadata, be concise; for German allow slightly longer compounds; for French prefer shorter natural phrasing.
+
+Localization rules:
+- Preserve placeholders exactly: {brand}, {price}, {year}, {name}, {title}, {loginLink}, %(name)s, %s, ${value}, ICU plural/select syntax, HTML entities and Odoo variables.
+- Preserve numbers, dimensions, tolerances, units, IP/NEMA/IK/UL/ISO/DIN standards, currency placeholders and product codes exactly unless the source explicitly asks for unit localization.
+- Keep CTA text short and action-oriented: Browse, Customize, Compare, Watch, Contact, Request a Quote, Talk to an engineer.
+- Translate UI labels compactly. Do not turn short labels into full sentences.
+- Preserve JSON keys and return only translated values.
+- For HTML fields, preserve every tag and attribute exactly. Translate only visible text nodes. Do not translate class names, href/src values, IDs, data attributes, alt/title attributes unless the attribute itself is clearly user-visible content requested for translation.
+- Preserve Markdown links and route paths. Translate link text only.
+- Respect locale tone: German formal and precise; Japanese polite and concise; Spanish/French warm but technical; Arabic natural RTL with normal punctuation.
+
+Glossary rules:
+- User-provided glossary mappings override all other rules.
+- If a glossary term conflicts with a general rule, use the glossary term.
+- Apply glossary terms consistently across the whole response.
+
+Output format:
+- Return ONLY valid JSON.
+- Do NOT wrap JSON in markdown fences.
+- Do NOT add explanations, comments or text outside JSON.
+]]></field>
+    </record>
+</odoo>

--- a/web_translate_ai/data/neutralize.sql
+++ b/web_translate_ai/data/neutralize.sql
@@ -1,6 +1,0 @@
--- Neutralize API keys for demo/test environments.
--- WARNING: Run only on non-production databases.
-UPDATE ai_translation_config
-SET openrouter_api_key = 'dummy'
-WHERE openrouter_api_key IS NOT NULL
-  AND openrouter_api_key != 'dummy';

--- a/web_translate_ai/migrations/16.0.1.1.0/post-migrate.py
+++ b/web_translate_ai/migrations/16.0.1.1.0/post-migrate.py
@@ -1,0 +1,83 @@
+"""Move translation credentials and tuning to shared LLM records.
+
+Read the legacy columns because their fields no longer exist in the registry,
+preserving administrator settings over the shipped defaults.
+"""
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    cr.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'ai_translation_config'
+        """
+    )
+    legacy_columns = {
+        "model",
+        "openrouter_api_key",
+        "temperature",
+        "max_tokens",
+        "system_prompt",
+    }
+    if not legacy_columns.issubset({row[0] for row in cr.fetchall()}):
+        _logger.info(
+            "Skipping %s LLM migration: legacy columns are missing", "web_translate_ai"
+        )
+        return
+
+    provider = env.ref("altinkaya_llm.provider_openrouter", raise_if_not_found=False)
+    seeded_model = env.ref(
+        "web_translate_ai.llm_model_translation", raise_if_not_found=False
+    )
+    if not provider or not seeded_model:
+        _logger.warning(
+            "Skipping %s LLM migration: provider or model record is missing",
+            "web_translate_ai",
+        )
+        return
+
+    cr.execute(
+        """
+        SELECT id, model, openrouter_api_key, temperature, max_tokens, system_prompt
+        FROM ai_translation_config
+        ORDER BY id
+        """
+    )
+    rows = cr.dictfetchall()
+    models = env["llm.model"].with_context(active_test=False)
+    for index, row in enumerate(rows):
+        api_key = row["openrouter_api_key"]
+        if api_key and (not provider.api_key or provider.api_key == "CHANGE_ME"):
+            provider.write({"api_key": api_key})
+
+        config = env["ai.translation.config"].browse(row["id"])
+        code = f"translation_{row['id']}"
+        llm_model = (
+            seeded_model
+            if index == 0
+            else models.search([("code", "=", code)], limit=1)
+        )
+        values = {
+            "provider_id": provider.id,
+            "model_slug": row["model"],
+            "temperature": row["temperature"],
+            "max_tokens": row["max_tokens"],
+            "system_prompt": row["system_prompt"],
+        }
+        if llm_model:
+            llm_model.write(values)
+        else:
+            values.update({"name": config.name, "code": code, "timeout": 60})
+            llm_model = models.create(values)
+        config.write({"llm_model_id": llm_model.id})
+
+    _logger.info("Linked %s translation configs to LLM models", len(rows))

--- a/web_translate_ai/models/ai_translation_config.py
+++ b/web_translate_ai/models/ai_translation_config.py
@@ -4,89 +4,10 @@
 import json
 import logging
 
-import requests
-
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
-
-OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
-
-DEFAULT_SYSTEM_PROMPT = """\
-You are the professional localization editor for Altınkaya Elektronik Cihaz Kutuları A.Ş. and its international Solidshell storefront.
-
-Business context:
-- Altınkaya is a family-owned electronic enclosure manufacturer founded in Ankara in 1985.
-- Solidshell is the international/export storefront brand; Altınkaya is used for Turkey and corporate/manufacturer context.
-- Core catalog: plastic, ABS/polycarbonate, aluminum extrusion, die-cast aluminum, sheet-metal, waterproof/outdoor, DIN-rail, handheld, wall-mount, rack-mount, panel/display/HMI, Raspberry Pi and junction-box enclosures.
-- Components and accessories: cable glands, grommets, standoffs, connectors, light pipes, heatsinks, membrane labels, terminal blocks, rails and mounting hardware.
-- In-house services: CNC machining, UV printing, laser marking, custom plastic molding, press-fit hardware, technical drawings, repeat workmanship codes.
-- Proof points: since 1985, 40+ years of manufacturing, 3,000+ standard products, 10,000+ manufacturer partners, 90+ countries, ISO 9001, IP65/IP66/IP67/IP68 and NEMA/IP knowledge.
-
-Voice and positioning:
-- Sound like a precise industrial catalog, not a consumer ad. Quiet confidence, engineering clarity, no hype, no exclamation marks.
-- Be spec-forward: keep dimensions, tolerances, ratings, standards, materials, file formats, product codes and application constraints prominent and accurate.
-- Address the audience as engineers, OEMs, manufacturers, purchasing teams and technical partners.
-- Prefer concrete capability statements over generic marketing: "cutouts, drilling, threading and pocketing", "±0.1 mm tolerance", "DXF/STEP/PDF support", "fast lead times".
-- Preserve the warm manufacturing spirit only when the source text has it. Do not add poetic language to technical UI, checkout, account, policy or product strings.
-
-Brand rules:
-- Preserve {brand} exactly.
-- Do not replace {brand} with Altınkaya or Solidshell.
-- Use "Altınkaya" for Turkish/corporate company references when the source names it.
-- Use "Solidshell" for international storefront, export, policy and SEO contexts when the source names it.
-- Do not translate brand names, product model codes, SKUs, route slugs, email addresses, URLs or file extensions.
-
-Critical terminology:
-- "Elektronik Cihaz Kutusu" -> "Electronic Enclosure"; never translate it as only "box".
-- "Cihaz Kutusu" -> "Enclosure" or "Device Enclosure" depending on context.
-- "Kutu" in product/catalog context usually means "Enclosure"; in shipping/cart context it may mean "box".
-- "Komponent" -> "Component".
-- "Kablo Rakoru" -> "Cable Gland".
-- "DIN Ray" -> "DIN Rail".
-- "Pano" -> "Panel" or "Control Panel"; avoid "board" unless it means PCB.
-- "Contalı" -> "Sealed" or "Gasketed".
-- "Özelleştirme" -> "Customization".
-- "CNC Kesim" / "CNC İşleme" -> "CNC Machining".
-- "UV Baskı" -> "UV Printing".
-- "Lazer Markalama" -> "Laser Marking".
-- "Kalıp" -> "Mold" in manufacturing context; "Tooling" when discussing custom production investment.
-- "Teklif Alın" -> "Get a Quote" or "Request a Quote".
-- "Aynı Gün Kargo" -> "Same-Day Shipping".
-- "Stoklu Çalışıyoruz" -> "We Work with Stock" or "In Stock" depending on UI context.
-- "Üretici İş Ortağı" -> "Manufacturer Partner".
-- "Kontrollü Malzeme" -> "Conflict Minerals".
-- "KVKK" stays "KVKK"; explain only in legal/privacy prose when useful.
-
-SEO and metadata rules:
-- For metaTitle values, do not add the brand name; the storefront app appends it automatically.
-- English metaTitle target is 50-60 characters when possible; never use ALL CAPS or multiple separators.
-- English metaDescription target is 120-155 characters when possible.
-- Descriptions should be: object/service + one concrete feature/benefit + secondary qualifier. Avoid keyword stuffing and repeated generic sentences.
-- Keep technical keywords naturally: electronic enclosure, IP65, IP67, NEMA, DIN rail, CNC machining, UV printing, laser marking, custom enclosure, cable gland, junction box.
-- For Japanese/Chinese metadata, be concise; for German allow slightly longer compounds; for French prefer shorter natural phrasing.
-
-Localization rules:
-- Preserve placeholders exactly: {brand}, {price}, {year}, {name}, {title}, {loginLink}, %(name)s, %s, ${value}, ICU plural/select syntax, HTML entities and Odoo variables.
-- Preserve numbers, dimensions, tolerances, units, IP/NEMA/IK/UL/ISO/DIN standards, currency placeholders and product codes exactly unless the source explicitly asks for unit localization.
-- Keep CTA text short and action-oriented: Browse, Customize, Compare, Watch, Contact, Request a Quote, Talk to an engineer.
-- Translate UI labels compactly. Do not turn short labels into full sentences.
-- Preserve JSON keys and return only translated values.
-- For HTML fields, preserve every tag and attribute exactly. Translate only visible text nodes. Do not translate class names, href/src values, IDs, data attributes, alt/title attributes unless the attribute itself is clearly user-visible content requested for translation.
-- Preserve Markdown links and route paths. Translate link text only.
-- Respect locale tone: German formal and precise; Japanese polite and concise; Spanish/French warm but technical; Arabic natural RTL with normal punctuation.
-
-Glossary rules:
-- User-provided glossary mappings override all other rules.
-- If a glossary term conflicts with a general rule, use the glossary term.
-- Apply glossary terms consistently across the whole response.
-
-Output format:
-- Return ONLY valid JSON.
-- Do NOT wrap JSON in markdown fences.
-- Do NOT add explanations, comments or text outside JSON.
-"""
 
 
 class AITranslationConfig(models.Model):
@@ -94,31 +15,16 @@ class AITranslationConfig(models.Model):
     _description = "AI Translation Config"
 
     name = fields.Char(required=True)
-    model = fields.Char(
-        default="google/gemini-2.5-flash",
-        required=True,
-        help="OpenRouter model identifier, e.g. google/gemini-2.5-flash",
-    )
-    temperature = fields.Float(
-        default=0.1,
-        help="Lower values produce more deterministic translations.",
-    )
-    max_tokens = fields.Integer(
-        default=4096,
-        help="Maximum tokens for the LLM response.",
-    )
-    system_prompt = fields.Text(
-        default=DEFAULT_SYSTEM_PROMPT,
-        help="System prompt sent with every translation request.",
+    # Keep nullable: SET NOT NULL fails on existing rows before migration backfills
+    # this field, silently leaving the constraint absent. The form requires it.
+    llm_model_id = fields.Many2one(
+        "llm.model",
+        string="LLM Model",
+        help="Provider, model slug, prompt and tuning for this translation config.",
     )
     use_structured_output = fields.Boolean(
         default=True,
         help="Use OpenRouter structured outputs (json_schema) for guaranteed valid JSON responses.",
-    )
-    openrouter_api_key = fields.Char(
-        required=True,
-        groups="base.group_system",
-        help="OpenRouter API key for this translation config.",
     )
     active = fields.Boolean(default=True)
     glossary_ids = fields.One2many(
@@ -126,11 +32,6 @@ class AITranslationConfig(models.Model):
         "ai_translation_config_id",
         string="Glossaries",
     )
-
-    def _get_api_key(self):
-        """Return the OpenRouter API key from this config record."""
-        self.ensure_one()
-        return self.openrouter_api_key or ""
 
     def _build_glossary_text(self, source_lang, target_lang):
         """Build glossary text for a source→target language pair."""
@@ -154,54 +55,19 @@ class AITranslationConfig(models.Model):
     def _call_openrouter(
         self, messages, temperature=None, max_tokens=None, response_schema=None
     ):
-        """Make a chat-completion call to OpenRouter."""
+        """Delegate chat completion to the linked LLM model."""
         self.ensure_one()
-        api_key = self._get_api_key()
-        if not api_key:
-            raise UserError(_("OpenRouter API key not configured."))
-
-        payload = {
-            "model": self.model,
-            "messages": messages,
-            "temperature": temperature if temperature is not None else self.temperature,
-        }
-        if max_tokens or self.max_tokens:
-            payload["max_tokens"] = max_tokens or self.max_tokens
-
-        if self.use_structured_output and response_schema:
-            payload["response_format"] = {
-                "type": "json_schema",
-                "json_schema": {
-                    "name": "translation",
-                    "strict": True,
-                    "schema": response_schema,
-                },
-            }
-
-        try:
-            response = requests.post(
-                OPENROUTER_API_URL,
-                headers={
-                    "Authorization": f"Bearer {api_key}",
-                    "Content-Type": "application/json",
-                },
-                json=payload,
-                timeout=60,
+        if not self.llm_model_id:
+            raise UserError(
+                _("No LLM model is set on translation config '%s'.") % self.name
             )
-            response.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            status_code = getattr(e.response, "status_code", "N/A")
-            reason = getattr(e.response, "reason", type(e).__name__)
-            _logger.error(
-                "OpenRouter API request failed (status: %s): %s",
-                status_code,
-                type(e).__name__,
-            )
-            raise UserError(_("OpenRouter API request failed: %s") % reason) from e
-
-        data = response.json()
-        content = data["choices"][0]["message"]["content"]
-        return content
+        return self.llm_model_id._chat(
+            messages,
+            response_schema=response_schema if self.use_structured_output else None,
+            schema_name="translation",
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
 
     def _parse_json_response(self, content):
         """Strip markdown fences and parse JSON."""
@@ -271,7 +137,7 @@ class AITranslationConfig(models.Model):
             )
 
             messages = [
-                {"role": "system", "content": self.system_prompt},
+                {"role": "system", "content": self.llm_model_id.system_prompt},
                 {"role": "user", "content": user_prompt},
             ]
 
@@ -515,7 +381,7 @@ Expected format:
 """
 
         messages = [
-            {"role": "system", "content": self.system_prompt},
+            {"role": "system", "content": self.llm_model_id.system_prompt},
             {"role": "user", "content": user_prompt},
         ]
 

--- a/web_translate_ai/tests/__init__.py
+++ b/web_translate_ai/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_translation_config

--- a/web_translate_ai/tests/test_translation_config.py
+++ b/web_translate_ai/tests/test_translation_config.py
@@ -1,0 +1,104 @@
+from unittest.mock import patch
+
+from odoo.exceptions import UserError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+CHAT_PATH = "odoo.addons.altinkaya_llm.models.llm_model.LlmModel._chat"
+
+
+@tagged("post_install", "-at_install")
+class TestTranslationConfig(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.llm_model = cls.env["llm.model"].create(
+            {
+                "name": "Test Translation Model",
+                "code": "test_translation_config",
+                "provider_id": cls.env.ref("altinkaya_llm.provider_openrouter").id,
+                "model_slug": "test/translation-model",
+                "system_prompt": "Use the linked model's translation instructions.",
+                "temperature": 0.1,
+                "max_tokens": 8192,
+            }
+        )
+        cls.config = cls.env["ai.translation.config"].create(
+            {
+                "name": "Test Translation Config",
+                "llm_model_id": cls.llm_model.id,
+                "use_structured_output": True,
+            }
+        )
+        cls.messages = [{"role": "user", "content": "Hello World!"}]
+        cls.schema = {
+            "type": "object",
+            "properties": {"en_GB": {"type": "string"}},
+            "required": ["en_GB"],
+            "additionalProperties": False,
+        }
+
+    def test_call_openrouter_delegates_to_linked_model(self):
+        reply = '{"en_GB": "Hello world!"}'
+        with patch(CHAT_PATH, autospec=True, return_value=reply) as chat:
+            result = self.config._call_openrouter(
+                self.messages,
+                temperature=0.2,
+                max_tokens=512,
+                response_schema=self.schema,
+            )
+
+        self.assertEqual(result, reply)
+        chat.assert_called_once_with(
+            self.llm_model,
+            self.messages,
+            response_schema=self.schema,
+            schema_name="translation",
+            temperature=0.2,
+            max_tokens=512,
+        )
+        self.assertEqual(chat.call_args.args[0].model_slug, "test/translation-model")
+
+    def test_call_openrouter_requires_linked_model(self):
+        self.config.llm_model_id = False
+        with patch(CHAT_PATH, autospec=True) as chat:
+            with self.assertRaisesRegex(UserError, self.config.name):
+                self.config._call_openrouter(self.messages)
+
+        chat.assert_not_called()
+
+    def test_call_openrouter_without_structured_output(self):
+        self.config.use_structured_output = False
+        with patch(CHAT_PATH, autospec=True, return_value="{}") as chat:
+            self.config._call_openrouter(self.messages, response_schema=self.schema)
+
+        chat.assert_called_once_with(
+            self.llm_model,
+            self.messages,
+            response_schema=None,
+            schema_name="translation",
+            temperature=None,
+            max_tokens=None,
+        )
+
+    def test_translate_batch_uses_linked_system_prompt(self):
+        with patch(
+            CHAT_PATH, autospec=True, return_value='{"en_GB": "Hello world!"}'
+        ) as chat:
+            result = self.config._translate_batch(
+                "en_US",
+                [
+                    {
+                        "target_lang": "en_GB",
+                        "source_text": "Hello World!",
+                        "field_type": "text",
+                    }
+                ],
+            )
+
+        self.assertEqual(result, {"en_GB": "Hello world!"})
+        chat.assert_called_once()
+        self.assertEqual(
+            chat.call_args.args[1][0],
+            {"role": "system", "content": self.llm_model.system_prompt},
+        )

--- a/web_translate_ai/views/ai_translation_config_view.xml
+++ b/web_translate_ai/views/ai_translation_config_view.xml
@@ -16,21 +16,11 @@
                 <sheet>
                     <group>
                         <field name="name" />
-                        <field name="openrouter_api_key" widget="password" />
-                        <field name="model" />
-                        <field name="temperature" />
-                        <field name="max_tokens" />
+                        <field name="llm_model_id" required="1" />
                         <field name="use_structured_output" />
                         <field name="active" />
                     </group>
                     <notebook>
-                        <page string="System Prompt">
-                            <field
-                                name="system_prompt"
-                                widget="text"
-                                placeholder="Enter the system prompt that defines translation behavior, company context, and terminology rules..."
-                            />
-                        </page>
                         <page string="Glossaries">
                             <span class="text-muted">
                                 1. Create a glossary with source and target languages.<br
@@ -55,7 +45,7 @@
         <field name="arch" type="xml">
             <tree>
                 <field name="name" />
-                <field name="model" />
+                <field name="llm_model_id" />
                 <field name="active" />
             </tree>
         </field>


### PR DESCRIPTION
Part of moving every AI provider, model and prompt in the ERP onto records. **Depends on altinkaya-opensource/odoo#747, merge that first.**

`ai.translation.config` held its own OpenRouter key, model slug, temperature, max_tokens and system prompt. Those move to an `llm.model` record, so translation settings sit alongside every other AI setting under Settings > Technical > AI Models.

## What is deliberately not changing

The model is not absorbed and not renamed. It keeps its name, its glossaries, its `res.company` link and every RPC method the translate dialog calls by name:

- `rpc_translate`, `rpc_translate_all`, `rpc_get_current_company_lang`
- `_translate_batch`, `_translate_single`, `_translate_texts_batch`
- `action_test_connection`

`static/src/js/web_translate_ai.esm.js`, `models/base.py`, `models/res_lang.py`, `models/res_company.py`, `models/ir_module_module.py` and the wizard are untouched. `_call_openrouter` keeps its exact signature and becomes a delegation to `llm_model_id._chat(...)`.

## Two decisions a reviewer may want to check

**`llm_model_id` is nullable on purpose.** A `required=True` Many2one added to a table that already has rows makes Odoo attempt `SET NOT NULL` against a column full of NULLs. That fails, Odoo logs it and carries on, and the constraint is silently absent from then on. The migration backfills the column and the form view carries `required="1"` instead.

**`_parse_json_response` stays rather than moving to `_chat_json`.** It raises a `UserError` carrying the offending content, which is more useful when a translation comes back malformed, and keeping it makes the diff smaller.

## Migration

Reads the old columns with raw SQL at post-migrate time, when they still exist, and for each config row: seeds the shared provider's key if it is still unset, creates or reuses an `llm.model` copying the row's slug, temperature, max_tokens and prompt, then links it. Database values win over the shipped defaults, since an administrator may have tuned them. Guarded so a re-run is a no-op.

`data/neutralize.sql` is deleted along with the column it wiped; the credential now lives on `llm.provider`, which `altinkaya_llm` neutralizes.

## Verified on 16test2

Migration ran clean: the existing config linked to its new `llm.model`, carrying its live slug `openai/gpt-5.4-mini`, temperature 0.1, max_tokens 8192 and its 5607-character prompt. The five old columns are gone from the table. 4 new tests pass, the first this module has had.

`web_translate_ai.pot` and `tr.po` carry `field_description` entries for the five removed fields and need regenerating through the smart-button export after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017v5D6URyGjKniyPfghTuvy
