### PR TITLE
[FIX] web_translate_ai: apply prettier formatting to the llm data file

### DIFF
--- a/web_translate_ai/data/llm_model_data.xml
+++ b/web_translate_ai/data/llm_model_data.xml
@@ -8,7 +8,9 @@
         <field name="temperature">0.1</field>
         <field name="max_tokens">8192</field>
         <field name="timeout">60</field>
-        <field name="system_prompt"><![CDATA[You are the professional localization editor for Altınkaya Elektronik Cihaz Kutuları A.Ş. and its international Solidshell storefront.
+        <field
+            name="system_prompt"
+        ><![CDATA[You are the professional localization editor for Altınkaya Elektronik Cihaz Kutuları A.Ş. and its international Solidshell storefront.
 
 Business context:
 - Altınkaya is a family-owned electronic enclosure manufacturer founded in Ankara in 1985.


### PR DESCRIPTION
`pre-commit run --all-files` fails on `16.0` right now, on a file my own PR #325 brought in.

## What happened

#325 merged `web_translate_ai/data/llm_model_data.xml` in the single-line form. The OCA prettier config in this repo sets `printWidth: 88`, and the `<field name="system_prompt">` line exceeds that, so prettier splits the attribute onto its own line:

```xml
-        <field name="system_prompt"><![CDATA[You are the professional ...
+        <field
+            name="system_prompt"
+        ><![CDATA[You are the professional ...
```

CI runs `pre-commit run --all-files`, so this now fails the next PR to this repo regardless of what that PR touches. Same defect as odoo#754, which fixed two data files in the other repo.

I checked #325 with `pre-commit run --files <changed files>`. Per-file, prettier passed. It only reformats under `--all-files`, which is what CI uses.

## The prompt is untouched

Prettier keeps `>` immediately before `<![CDATA[`, so no whitespace enters the content. Verified both ways:

| check | result |
|---|---|
| CDATA blocks before / after | 1 / 1 |
| prompt length before / after | 5607 / 5607 bytes |
| prompt bytes equal | yes |
| all 8 parsed `<field>` values equal | yes |
| `pre-commit run --all-files` | every hook passes |

The seeded `llm.model` record loads the same prompt it did before.

## Scope

One line, one file, formatting only. I ran the same check against `website-next`: its `.prettierrc` is `{}`, so plugin-xml never loads there and XML is skipped, and `website_api/data/llm_model_data.xml` passes as shipped. This repo and `odoo` are the two that enforce printWidth on XML, and `odoo` is already fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017v5D6URyGjKniyPfghTuvy
