### PR TITLE
Fix credit risk bypass for captured Iyzico payments

### DIFF
--- a/payment_iyzico_altinkaya/__manifest__.py
+++ b/payment_iyzico_altinkaya/__manifest__.py
@@ -15,7 +15,7 @@
 
 {
     "name": "Payment Provider: iyzico",
-    "version": "16.0.0.1.0",
+    "version": "16.0.0.1.1",
     "category": "Accounting/Payment Providers",
     "license": "LGPL-3",
     "website": "https://github.com/altinkaya-opensource/odoo-addons",

--- a/payment_iyzico_altinkaya/models/payment_transaction.py
+++ b/payment_iyzico_altinkaya/models/payment_transaction.py
@@ -123,7 +123,9 @@ class PaymentTransaction(models.Model):
                 # When setting iyzico amounts, there could be mismatch in amounts
                 # due to installment fees. So, firstly confirm the order to lock the
                 # amount, then set the amounts from iyzico response.
-                self._check_amount_and_confirm_order()
+                # Captured card payments do not consume customer credit. This
+                # direct path needs the same risk context as _reconcile_after_done.
+                self.with_context(bypass_risk=True)._check_amount_and_confirm_order()
                 self._iyzico_set_amounts(response)
             else:
                 self._set_error(response)

--- a/payment_iyzico_altinkaya/tests/__init__.py
+++ b/payment_iyzico_altinkaya/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2026 Altinkaya Enclosures
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from . import test_payment_confirmation

--- a/payment_iyzico_altinkaya/tests/test_payment_confirmation.py
+++ b/payment_iyzico_altinkaya/tests/test_payment_confirmation.py
@@ -1,0 +1,95 @@
+# Copyright 2026 Altinkaya Enclosures
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestIyzicoPaymentConfirmation(TransactionCase):
+    """Exercise the confirmation path shared by direct and 3DS payments."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.provider = cls.env.ref("payment_iyzico_altinkaya.payment_provider_iyzico")
+        cls.partner = cls.env["res.partner"].create({"name": "Card Payment Customer"})
+        if "risk_sale_order_include" in cls.partner._fields:
+            cls.partner.write({"credit_limit": 0, "risk_sale_order_include": True})
+        if "exception.rule" in cls.env:
+            cls.env["exception.rule"].search(
+                [("model", "in", ["sale.order", "sale.order.line"])]
+            ).active = False
+        cls.product = cls.env["product.product"].create(
+            {"name": "Card Payment Service", "type": "service", "taxes_id": False}
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    Command.create(
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1,
+                            "price_unit": 100,
+                            "tax_id": [Command.clear()],
+                        }
+                    )
+                ],
+            }
+        )
+        self.tx = self.env["payment.transaction"].create(
+            {
+                "provider_id": self.provider.id,
+                "reference": f"IYZICO-CONFIRM-{self.order.id}",
+                "amount": self.order.amount_total,
+                "currency_id": self.order.currency_id.id,
+                "partner_id": self.partner.id,
+                "sale_order_ids": [Command.set(self.order.ids)],
+                "operation": "online_direct",
+            }
+        )
+
+    def _finalize_success(self):
+        self.tx._iyzico_finalize_payment(
+            "success",
+            {"currency": self.tx.currency_id.name, "paidPrice": self.tx.amount},
+        )
+        self.assertEqual(self.tx.state, "done")
+
+    def test_paid_order_confirms_without_customer_credit(self):
+        self._finalize_success()
+        self.assertIn(self.order.state, ("sale", "done"))
+
+    def test_failed_payment_does_not_confirm(self):
+        self.tx._iyzico_finalize_payment("error", "Payment declined")
+        self.assertEqual(self.tx.state, "error")
+        self.assertEqual(self.order.state, "draft")
+
+    def test_partial_payment_does_not_confirm(self):
+        self.tx.amount /= 2
+        self._finalize_success()
+        self.assertEqual(self.order.state, "draft")
+
+    def test_changed_order_total_does_not_confirm(self):
+        self.order.order_line.product_uom_qty = 2
+        self._finalize_success()
+        self.assertEqual(self.order.state, "draft")
+
+    def test_paid_order_still_checks_sale_exceptions(self):
+        if "exception.rule" not in self.env:
+            self.skipTest("sale_exception is not installed")
+        rule = self.env["exception.rule"].create(
+            {
+                "name": "Payment must not skip this exception",
+                "model": "sale.order",
+                "exception_type": "by_py_code",
+                "code": "failed = True",
+            }
+        )
+        self._finalize_success()
+        self.assertNotIn(self.order.state, ("sale", "done"))
+        self.assertIn(rule, self.order.exception_ids)
+        self.assertFalse(self.order.ignore_exception)

--- a/web_translate_ai/data/llm_model_data.xml
+++ b/web_translate_ai/data/llm_model_data.xml
@@ -8,7 +8,9 @@
         <field name="temperature">0.1</field>
         <field name="max_tokens">8192</field>
         <field name="timeout">60</field>
-        <field name="system_prompt"><![CDATA[You are the professional localization editor for Altınkaya Elektronik Cihaz Kutuları A.Ş. and its international Solidshell storefront.
+        <field
+            name="system_prompt"
+        ><![CDATA[You are the professional localization editor for Altınkaya Elektronik Cihaz Kutuları A.Ş. and its international Solidshell storefront.
 
 Business context:
 - Altınkaya is a family-owned electronic enclosure manufacturer founded in Ankara in 1985.


### PR DESCRIPTION
Successful Iyzico payments call order confirmation directly, missing the financial-risk bypass used by normal payment post-processing. Apply that context after successful capture so fully paid orders can confirm with zero customer credit. Existing payment-amount and sale-exception checks remain active.

Add regression coverage for successful payment, failed payment, partial payment, changed order totals, and sale exceptions. Include the existing XML formatting correction required by the repository-wide pre-commit check.

Validation: all 13 related Odoo TransactionCase tests passed using the PR sources; `pre-commit run -a` passed. The shared Iyzico confirmation path was exercised; storefront end-to-end testing was unavailable because local `website_api` dependencies could not load.

Related sale-exception ordering fix: https://github.com/altinkaya-opensource/odoo/pull/756.

Deployment: upgrade `payment_iyzico_altinkaya` and restart Odoo.
