### PR TITLE
Add Postmark recipient reactivation

### DIFF
--- a/postmark_connector/models/mail_mail.py
+++ b/postmark_connector/models/mail_mail.py
@@ -263,6 +263,32 @@ class MailMail(models.Model):
         return len(normalized_emails)
 
     @api.model
+    def _postmark_reactivate_email(self, email):
+        """Reactivate one recipient; callers remove the local blacklist on success."""
+        normalized_email = tools.email_normalize(email, strict=False)
+        api_key = config.get("postmark_api_key")
+        if not normalized_email or not api_key or not postmark_sync:
+            return "unavailable"
+
+        try:
+            with postmark_sync.ServerClient(
+                api_key, timeout=self._postmark_get_timeout()
+            ) as postmark:
+                results = postmark.suppressions.delete("outbound", [normalized_email])
+        except Exception:
+            _logger.warning("Postmark recipient reactivation failed", exc_info=True)
+            return "unavailable"
+
+        if len(results) != 1 or results[0].email_address.lower() != normalized_email:
+            return "unavailable"
+        if results[0].status == "Deleted":
+            return "unblocked"
+        # Spam complaints and administrator suppressions require Postmark support.
+        if results[0].status == "Failed":
+            return "support_required"
+        return "unavailable"
+
+    @api.model
     def _postmark_sync_suppressions(self, stream_id="outbound"):
         """Import Postmark suppressions into Odoo's mail blacklist."""
         api_key = config.get("postmark_api_key")

--- a/postmark_connector/tests/__init__.py
+++ b/postmark_connector/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_mail_mail
 from . import test_mail_notification
+from . import test_reactivate_email

--- a/postmark_connector/tests/test_reactivate_email.py
+++ b/postmark_connector/tests/test_reactivate_email.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.postmark_connector.models import mail_mail
+
+
+@tagged("post_install", "-at_install")
+class TestReactivateEmail(TransactionCase):
+    """Never report success unless Postmark confirms the requested recipient."""
+
+    def setUp(self):
+        super().setUp()
+        self.client_patch = patch.object(mail_mail.postmark_sync, "ServerClient")
+        self.client = self.client_patch.start()
+        self.addCleanup(self.client_patch.stop)
+        self.postmark = self.client.return_value.__enter__.return_value
+        self.config_patch = patch.object(mail_mail.config, "get")
+        self.config_get = self.config_patch.start()
+        self.addCleanup(self.config_patch.stop)
+        self.config_get.side_effect = lambda key, default=None: (
+            "test-key" if key == "postmark_api_key" else default
+        )
+
+    def test_confirmed_recipient_is_normalized(self):
+        self.postmark.suppressions.delete.return_value = [
+            SimpleNamespace(email_address="reactivate@example.com", status="Deleted")
+        ]
+        result = self.env["mail.mail"]._postmark_reactivate_email(
+            "Customer <REACTIVATE@example.com>"
+        )
+        self.assertEqual(result, "unblocked")
+        self.postmark.suppressions.delete.assert_called_once_with(
+            "outbound", ["reactivate@example.com"]
+        )
+
+    def test_provider_refusal_requires_support(self):
+        self.postmark.suppressions.delete.return_value = [
+            SimpleNamespace(email_address="reactivate@example.com", status="Failed")
+        ]
+        self.assertEqual(
+            self.env["mail.mail"]._postmark_reactivate_email("reactivate@example.com"),
+            "support_required",
+        )
+
+    def test_missing_or_unexpected_confirmation_fails_closed(self):
+        for results in (
+            [],
+            [SimpleNamespace(email_address="another@example.com", status="Deleted")],
+            [SimpleNamespace(email_address="reactivate@example.com", status="Unknown")],
+        ):
+            with self.subTest(results=results):
+                self.postmark.suppressions.delete.return_value = results
+                self.assertEqual(
+                    self.env["mail.mail"]._postmark_reactivate_email(
+                        "reactivate@example.com"
+                    ),
+                    "unavailable",
+                )
+
+    def test_provider_outage_preserves_block(self):
+        self.postmark.suppressions.delete.side_effect = TimeoutError()
+        self.assertEqual(
+            self.env["mail.mail"]._postmark_reactivate_email("reactivate@example.com"),
+            "unavailable",
+        )
+
+    def test_missing_key_does_not_call_provider(self):
+        self.config_get.side_effect = lambda key, default=None: default
+        self.assertEqual(
+            self.env["mail.mail"]._postmark_reactivate_email("reactivate@example.com"),
+            "unavailable",
+        )
+        self.client.assert_not_called()


### PR DESCRIPTION
Add a recipient reactivation helper for the storefront's customer-requested email unblock flow. It reports success only when Postmark confirms `Deleted` for the exact normalized address; provider refusals require support, while missing configuration and transport failures keep the local block intact.

Validation: 5 Odoo tests with Postmark mocked; full repository pre-commit checks. No live suppression was changed. Deploy this helper before the companion website-next change.

Companion storefront PR: https://github.com/altinkaya-opensource/website-next/pull/363.
